### PR TITLE
docs: reduce AI instruction token load

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,105 +1,44 @@
-Canonical AI guidance entrypoint (scope: short repo orientation, enduring architectural invariants, and command pointers)
+This file is the canonical AI guidance entrypoint and short index. Preserve guardrails when shortening; move area rules to narrower files, do not drop them.
 
-Guidance stack
-- This file is the canonical AI guidance entrypoint and short index.
-- `.github/instructions/general.instructions.md` owns shared workflow, validation, and documentation-maintenance guardrails.
-- `.github/instructions/backend.instructions.md`, `.github/instructions/frontend.instructions.md`, `.github/instructions/firmware.instructions.md`, `.github/instructions/pi-image.instructions.md`, and `.github/instructions/tests.instructions.md` own area-specific deltas only.
-- `docs/ai/repo-map.md` is the repo map for layout, entry points, and stable ownership boundaries; it is not a second workflow or policy guide.
-- Do not create additional guidance files in `docs/ai/`.
-- Paths below are repo-relative unless a bullet is explicitly talking about a Python import namespace such as `vibesensor.domain` or `vibesensor.shared.*`.
-- Design docs under `docs/designs/` must declare `Status: Active`, `Status: Historical`, or `Status: Superseded`; follow Active docs as guidance, and treat Historical/Superseded docs as reference only.
+## Guidance stack
+- Start here for repo invariants and validation routing.
+- Shared workflow, docs, PR, CI, and safety rules live in `.github/instructions/general.instructions.md`.
+- Backend rules: `.github/instructions/backend.instructions.md`; updater rules: `.github/instructions/backend-updates.instructions.md`.
+- Frontend rules: `.github/instructions/frontend.instructions.md`; firmware rules: `.github/instructions/firmware.instructions.md`.
+- Pi image rules: `.github/instructions/pi-image.instructions.md`; backend test rules: `.github/instructions/tests.instructions.md`.
+- Use `docs/ai/repo-map.md` only when `rg`, file names, imports, and tests do not reveal ownership.
+- Do not add more files under `docs/ai/`. Design docs under `docs/designs/` must declare `Status: Active`, `Historical`, or `Superseded`; only Active docs are current guidance.
 
-Execution philosophy
-- Be decisive, direct, and completion-oriented. Default to completing the user's requested change end to end.
-- Expand scope only to fix the root cause, update direct callers, or handle clearly adjacent regressions found during validation. Do not broaden into unrelated cleanup.
-- Decompose large tasks into execution waves and keep going until the in-scope work is done, validated, or blocked by credentials, hardware, external services, or an explicit user pause.
-- Breaking internal-only interfaces is acceptable and preferred when the result is cleaner. The repo controls both producers and consumers; coordinated breaking refactors are the right default, not the exception.
-- Do not preserve deprecated aliases, old DTO shapes, fallback branches, or legacy config forms unless a real external consumer is confirmed. The cleaner architecture wins.
-- Full workflow and validation rules live in `.github/instructions/general.instructions.md`.
+## Repo invariants
+- VibeSensor contains a Python backend (`apps/server/`), TypeScript/Vite UI (`apps/ui/`), ESP32 firmware (`firmware/esp/`), and Raspberry Pi image build (`infra/pi-image/`).
+- Raw ingest/sample acceleration may use g; post-stop analysis outputs must expose vibration strength/intensity in dB only.
+- Canonical dB math: `apps/server/vibesensor/vibration_strength.py::vibration_strength_db_scalar()`.
+- Static config that does not change between deployments belongs in Python constants, not runtime file loaders.
+- Internal shared logic stays in the server package. Generated UI constants come from backend sources under `vibesensor.shared.*`.
+- `vibesensor.shared` is for stable contracts, ports, codecs, constants, and pure helpers. Runtime bootstrap/subprocess orchestration belongs in `apps/server/vibesensor/app/` or the owning `use_cases/**` module.
+- Pi hotspot provisioning is offline-first; required packages are baked into the image. Pi image outputs must be deterministic and self-validated.
 
-Repository overview
-- VibeSensor: Python backend (`apps/server/`), TypeScript/Vite dashboard (`apps/ui/`), ESP32 firmware (`firmware/esp/`), Pi image build (`infra/pi-image/`).
-- Key runtime artifacts: `docker-compose.yml` (local stack), `apps/server/pyproject.toml` (backend packaging and CLI entry points).
-- Units policy: raw ingest/sample acceleration values may use g, but post-stop analysis outputs (persisted summaries, findings, report-template artifacts) must expose vibration strength or intensity in dB only.
-- Canonical dB definition: `apps/server/vibesensor/vibration_strength.py::vibration_strength_db_scalar()` (`20*log10((peak+eps)/(floor+eps))`, `eps=max(1e-9, floor*0.05)`).
-
-Architectural constraints
-- Offline-first hotspot boot: hotspot provisioning must not depend on internet connectivity. Required packages are baked into the image build stage.
-- Deterministic image outputs: custom pi-gen stage must export uniquely suffixed artifacts and self-validate rootfs contents.
-- Internal shared logic belongs in the server package (`apps/server/vibesensor/vibration_strength.py`, `apps/server/vibesensor/strength_bands.py`), not in separate packages. Generated shared TS constants are emitted to `apps/ui/src/constants.ts` from backend sources under the `vibesensor.shared.*` Python import namespace.
-- `vibesensor.shared` is for stable cross-layer contracts, ports, codecs, constants, and pure helper language. App/runtime bootstrap or subprocess orchestration belongs in `apps/server/vibesensor/app/` or the owning `use_cases/**` module, not in `vibesensor.shared`.
-- Do not create runtime file-loading mechanisms for static configuration data. Use Python constants for values that don't change between deployments.
-
-Domain model (scope: behavioral rules only; see `docs/domain-model.md` for the full domain object catalog and relationship map)
-- Domain objects own behavior (classification, ranking, lifecycle, computation). Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
-- Consumers import from `vibesensor.domain`, not from individual module files.
+## Backend/domain boundaries
+- Domain objects own classification, ranking, lifecycle, and computation. Boundary adapters translate; they do not duplicate domain logic.
+- Import domain objects from `vibesensor.domain`, not individual domain module files.
 - Boundary decoders/serializers live under `apps/server/vibesensor/shared/boundaries/`; do not rebuild payload-driven business logic in report/history/runtime consumers.
-- Factories that build domain objects from already-typed internal metadata, snapshots, or computed state belong on domain objects (or the owning use-case), not in `apps/server/vibesensor/shared/boundaries/`.
-- Backend layer dependency DAG is enforced by `tools/dev/verify_backend_static_guards.py::_check_layer_boundaries()`:
-  - `domain` imports no inner project layers
-  - `shared` may import `domain`
-  - `use_cases` may import `domain` and `shared`
-  - `infra` may import `domain` and `shared`
-  - `adapters` may import `domain`, `shared`, `infra`, and `use_cases`
-  - `app` may import all backend layers
-- Treat `shared -> domain` and `infra -> domain` as intentional allowed edges, not violations. The disallowed direction is outer-layer leakage back inward, such as `use_cases -> adapters` or `domain -> shared/infra/adapters`.
+- Factories for already-typed internal metadata, snapshots, or computed state belong on domain objects or the owning use case, not boundary decoders.
+- Backend layer DAG, enforced by `apps/server/pyproject.toml` and `tools/dev/verify_backend_static_guards.py`: `domain` imports no project layers; `shared` may import `domain`; `use_cases` may import `domain, shared`; `infra` may import `domain, shared`; `adapters` may import `domain, shared, infra, use_cases`; `app` may import all. `shared -> domain` and `infra -> domain` are allowed; inward leakage such as `use_cases -> adapters` is not.
 
-Commands
-- Other AI guidance and docs should reference this list instead of repeating it.
-- `make setup`
-- `make format`
-- `python -m pip install -e "./apps/server[dev]"`
-- `make lint`
-- `make typecheck-backend`
-- `make sync-contracts`
-- `make ui-typecheck` (default frontend validation path: materialize generated UI contract artifacts, then run UI format drift, lint, and TypeScript checks)
-- `make docs-lint`
-- `make plan-validation` (primary AI/dev validation planner: changed-file CI plan, local command, ACT command, and JSON summary)
-- `./.venv/bin/python tools/tests/plan_validation.py --run` (run the planned non-Docker local CI jobs)
-- `make doctor` (reports local prerequisites, including host `shellcheck` for local `shell-lint` parity)
-- `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
-- `make test-ci-fast` (fast local CI gates: lint, docs, static guards, and type checks; no browser/release/firmware/e2e/backend test suites)
-- `make test-ci-lite` (non-Docker workflow jobs except e2e; includes backend shards, UI smoke, release smoke, and firmware native tests)
-- `make test-all` (CI-parity local suite using the repo Python)
-- `./tools/tests/run_ci_with_act.sh` (changed-scope ACT/GitHub workflow parity with generated pull-request event data; requires Docker)
-- `./tools/tests/run_ci_with_act.sh --full-stack` (force all CI jobs through `ci-scope`; requires Docker)
-- `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a selected CI job locally via `act`; requires Docker)
-- `./tools/tests/run_ci_with_act.sh -j backend-tests` (run the backend test matrix job via `act`; ACT uses raw GitHub job ids, not local logical shard ids like `backend-tests-1`)
-- `act -l -W .github/workflows/ci.yml` (list CI jobs)
-- `./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset; direct local CI runners reject the wrong Python major/minor)
-- `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
-- `./.venv/bin/python tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green` (compact state-change watcher; default `--interval 10`, `--heartbeat 120`, `--gh-timeout 30`, `--fetch-failure-limit 3`; omit `--merge-on-green` for watch-only mode)
-- `cd apps/ui && npm ci && npm run build` (bundle build after `make ui-typecheck`; raw `npm run typecheck` / `npm run build` only check contract freshness and fail if generated UI files are stale)
-- `cd apps/ui && npm run test:visual`
-- `cd firmware/esp && pio run`
-- `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh`
-- `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`
-- `./infra/pi-image/pi-gen/validate-image.sh`
-- `docker compose build --pull && docker compose up -d`
-
-Validation chooser
-- Start with `make plan-validation` for changed-file CI scope; use `./.venv/bin/python tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
-- Use `make test-ci-fast` for a broad but fast local gate before heavier browser/release/backend suites; use `make test-ci-lite` only when you want the larger non-Docker workflow surface except e2e.
-- `run_ci_parallel.py` respects GitHub `needs` order among selected jobs, warns when you select a downstream job without its prerequisites, and reports workflow-only needs it substitutes locally.
-- Local `shell-lint` parity requires host `shellcheck`; use ACT when you need CI to install ShellCheck inside the workflow job.
+## Validation router
+- Start with `make plan-validation`; run planned non-Docker jobs with `./.venv/bin/python tools/tests/plan_validation.py --run`, or use `--act` / `./tools/tests/run_ci_with_act.sh` only when GitHub workflow or Docker parity is needed.
+- Use `./tools/tests/run_ci_with_act.sh --full-stack` only when you must force all gated CI jobs.
+- Docs or instruction-only changes: run `make docs-lint` plus `make plan-validation`.
 - Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
-- Backend contracts/API payloads: add `make sync-contracts` and `make ui-typecheck`.
-- Frontend logic, contracts, or composition: `make ui-typecheck`; for bundle behavior also run `cd apps/ui && npm ci && npm run build`.
-- Rendered UI or snapshots: add `cd apps/ui && npm run test:visual`.
-- Firmware code: `cd firmware/esp && pio run`; for protocol/native CI parity, add `python tools/firmware/generate_protocol_contract_fixtures.py --check` and `cd firmware/esp && pio test -e native`.
-- Pi app artifact changes: `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh`.
-- Pi image-stage logic: `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`, then `./infra/pi-image/pi-gen/validate-image.sh [artifact]` when an artifact is available.
-- Do not use ACT for `.github/workflows/manual-pi-image-arm.yml` or `.github/workflows/weekly-pi-image.yml`; those workflows require GitHub's `ubuntu-24.04-arm` runner label, which is intentionally not mapped in `.actrc`. Use the Pi-image local build/validate commands above.
-- Docs or AI-instruction-only changes: `make docs-lint`.
+- Backend API/contracts/shared UI constants: add `make sync-contracts` and `make ui-typecheck`.
+- Frontend logic/contracts/composition: `make ui-typecheck`; add `cd apps/ui && npm run build`, `npm run test:unit`, or `npm run test:visual` when the changed seam requires it.
+- Firmware: `cd firmware/esp && pio run`; for protocol/native parity add `python tools/firmware/generate_protocol_contract_fixtures.py --check` and `cd firmware/esp && pio test -e native`.
+- Pi image: use the narrow path, `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh` or `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`; use `./infra/pi-image/pi-gen/validate-image.sh [artifact]` to validate an existing artifact.
+- Do not use ACT for `.github/workflows/manual-pi-image-arm.yml` or `.github/workflows/weekly-pi-image.yml`; they require GitHub's `ubuntu-24.04-arm` runner label, which is intentionally not mapped in `.actrc`.
+- Full command details, ACT limits, test placement, and CI job notes live in `docs/testing.md`.
 
-Command gotchas
-- `make ui-typecheck` is the default frontend gate because it materializes generated UI contract artifacts before checking Biome formatting, linting, and TypeScript.
-- Raw `cd apps/ui && npm run typecheck` or `npm run build` can fail when generated UI contract files are stale; run `make sync-contracts` or `make ui-typecheck` first when backend contracts changed.
-- `act` requires Docker; prefer `tools/tests/run_ci_with_act.sh` for PR changed-file CI scope because it generates base/head SHAs for the pull-request event. Use `./tools/tests/run_ci_with_act.sh --full-stack` only when you need to force every gated CI job.
-- PlatformIO must be installed before `cd firmware/esp && pio run` or `cd firmware/esp && pio test -e native`.
-- Pi image builds are expensive; use the narrow `BUILD_MODE=app` or `BUILD_MODE=image` path unless both layers changed.
-- The local Docker stack is for runtime integration behavior, not docs-only, instruction-only, or pure unit-test changes.
-
-Pi access defaults (prebuilt image)
-- Narrow owner: `infra/pi-image/pi-gen/README.md` and `docs/operational-runbooks.md`
-- Use those docs for hotspot/UI defaults, SSH defaults, and remote-simulator examples; image-build overrides still live under `VS_FIRST_USER_NAME` and `VS_FIRST_USER_PASS` in `infra/pi-image/pi-gen/README.md`.
+## PR/CI flow
+- Branch from latest `main`, open a PR to `main`, and use `./.venv/bin/python tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green` unless the user explicitly wants watch-only.
+- Inspect failing annotations, failing test names, and concise log tails; do not paste full CI logs into context.
+- Fix failures caused by the branch, push, and rerun the watcher until required CI is green and the PR is merged. Do not merge on red required checks; document unrelated/flaky blockers.
+- Prefer squash merge unless repo convention or user instruction says otherwise.

--- a/.github/instructions/backend-updates.instructions.md
+++ b/.github/instructions/backend-updates.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "apps/server/vibesensor/use_cases/updates/**,apps/server/tests/use_cases/updates/**"
+---
+Updater rules for the wheel-based app, firmware, Wi-Fi, release, install/rollback, and status update paths.
+
+- `apps/server/vibesensor/use_cases/updates/manager.py` is the public facade for workflow orchestration and validation. Update callers directly when methods move; do not add static passthroughs, module aliases, shims, or compatibility layers.
+- Keep release JSON boundaries typed. Prefer `read_typed_json_response` and `GitHubApiClient.get_typed_json` over loose `json.loads(...)` plus manual `.get(...)` coercion. Minimal-dependency CLI validation paths may use stdlib `json` when they intentionally run without optional runtime dependencies.
+- `apps/server/vibesensor/use_cases/updates/releases/release_validation.py` may import `tenacity` lazily for `smoke-server` readiness only. `validate-wheel-metadata` and `validate-firmware-manifest` must remain importable without optional deps such as `tenacity`, `msgspec`, or `pydantic`.
+- Preserve update integrity checks and safe network/device defaults. Do not weaken validation, release decoding, firmware/app update sequencing, or rollback paths.
+- Validation: start with `make plan-validation`; run targeted `pytest -q apps/server/tests/use_cases/updates/` plus backend lint/typecheck gates when update code changes.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,27 +1,18 @@
 ---
 applyTo: "apps/server/**"
 ---
-Backend (scope: backend-specific behavioral rules and deltas; see `docs/ai/repo-map.md` for full package layout and entry points)
-- Backend ownership boundaries: see `docs/ai/repo-map.md` § "Backend package layout" for the full module map and `docs/domain-model.md` for the domain object graph.
-- Shared domain-model authority lives in `.github/copilot-instructions.md` § "Domain model"; the bullets below are backend-specific deltas on top of that baseline.
-- Domain-first modeling rules:
-	- Analysis pipeline adapters delegate classification and ranking to domain `Finding`.
-	- Keep pure math, DSP, FFT, and signal-processing transforms functional; do not wrap them in classes unless a domain reason exists.
-	- Do not introduce forward-looking infrastructure types until their persistence and delivery requirements exist. Domain types that produce outputs consumed by no production code path are phantom infrastructure.
-	- Do not create domain types that are only consumed by a single class within the same package. Merge single-consumer satellites into their host file.
-	- See `docs/domain-model.md` for the full domain object graph and modeling rules.
-- Report generation rules:
-	- Preserve persistence-aware diagnostics and ranking behavior; do not regress report ranking to max-only peak selection.
-	- Keep transient/impact events visible in report output, but not promoted above likely persistent faults by default.
-	- Validate report-facing output (rendered/report API/PDF text and ordering), not just internal helper outputs.
-	- When user-facing report text changes, update `apps/server/vibesensor/data/report_i18n.json`.
-	- `apps/server/vibesensor/use_cases/updates/`: wheel-based updater package; `apps/server/vibesensor/use_cases/updates/manager.py` is the public facade with workflow orchestration and validation; other modules handle Wi-Fi, releases, ESP flash, firmware cache, release validation, install and rollback, and status. Do not add backward-compatibility shims, static method passthroughs, or module-level aliases in `apps/server/vibesensor/use_cases/updates/`; when methods move to sub-modules, update callers directly.
-	- Updater-owned GitHub release JSON boundaries should prefer msgspec-backed typed decode (`read_typed_json_response`, `GitHubApiClient.get_typed_json`) instead of loose `json.loads(...)` + manual `.get(...)` coercion. Minimal dependency CLI validation paths may stay on stdlib `json` when they intentionally run without optional runtime deps.
-	- `apps/server/vibesensor/use_cases/updates/releases/release_validation.py` may use `tenacity` lazily inside the `smoke-server` readiness path, but `validate-wheel-metadata` and `validate-firmware-manifest` must remain importable without optional deps such as `tenacity`, `msgspec`, or `pydantic`.
-- Backend-owned persistence/history/export JSON text serialization should prefer shared `orjson` helpers (`json_text_dumps`, `safe_json_dumps`) over ad hoc stdlib `json.dumps(...)`. CLI/debug/log sinks may stay on stdlib `json` when human formatting, ASCII escaping, or script portability is the real requirement.
-- Use the backend command list (defined in the copilot instructions "Commands" section); its backend type gate runs mypy across the `vibesensor` package by default without an internal module denylist, and `docs/testing.md` covers backend test placement and command details.
-- Keep route-facing modules on shared ports or adapter-local protocols rather than direct `infra` imports, and keep sensor metadata writes behind the client location-assignment handoff in `apps/server/vibesensor/adapters/http/clients.py`.
-- Prefer explicit payload contracts (`TypedDict`, dataclass, protocol, `JsonValue`/`JsonObject` aliases) over broad `Any` when shaping analysis, report, and persistence data.
-- Treat `Any` as a design smell by default: prefer `object` for untrusted inputs, shared JSON aliases for persisted payloads, `ParamSpec` for callable wrappers, and focused `TypedDict`/protocol contracts for nested state.
-- For live processing / WebSocket payloads, prefer shared contracts in `apps/server/vibesensor/shared/types/payload_types.py` and `vibesensor.vibration_strength` over ad-hoc `dict[str, Any]` bags.
-- Common backend documentation touchpoints include `apps/server/README.md`, `docs/testing.md`, and the relevant `docs/ai/*.md` or `.github/*.instructions.md` files.
+Backend rules. Use `docs/ai/repo-map.md` only for ownership lookup and `docs/domain-model.md` for the full domain graph.
+
+- Preserve the backend layer DAG from `.github/copilot-instructions.md`. Domain/shared/use_cases/infra/adapters/app boundaries are enforced by `apps/server/pyproject.toml` and `tools/dev/verify_backend_static_guards.py`.
+- Domain behavior belongs in domain objects or the owning use case. Adapters translate at persistence, transport, PDF, simulator, and HTTP boundaries; they do not duplicate classification, ranking, lifecycle, or computation.
+- Route-facing modules should depend on shared ports or adapter-local protocols, not direct `infra` imports. Keep sensor metadata writes behind the client location-assignment handoff in `apps/server/vibesensor/adapters/http/clients.py`.
+- Analysis adapters delegate classification/ranking to domain `Finding`.
+- Keep pure math, DSP, FFT, and signal transforms functional; do not wrap them in classes without a domain reason.
+- Do not create phantom domain/infrastructure types consumed by no production path, or single-consumer domain satellites that should live with their host.
+- Preserve report ranking and persistence-aware diagnostics. Do not regress report ranking to max-only peak selection.
+- Keep transient/impact events visible in reports without promoting them above likely persistent faults by default.
+- Validate report-facing output: rendered/API/PDF text and ordering, not only helper internals. User-facing report text changes require `apps/server/vibesensor/data/report_i18n.json`.
+- Prefer shared `orjson` helpers (`json_text_dumps`, `safe_json_dumps`) for backend-owned persistence/history/export JSON text. CLI/debug/log sinks may use stdlib `json` for formatting, ASCII escaping, or script portability.
+- Prefer explicit payload contracts (`TypedDict`, dataclass, protocol, `JsonValue`/`JsonObject`) over `Any`. Use `object` for untrusted inputs, `ParamSpec` for callable wrappers, and focused contracts for nested state.
+- For live processing/WebSocket payloads, reuse `apps/server/vibesensor/shared/types/payload_types.py` and `vibesensor.vibration_strength` instead of ad-hoc `dict[str, Any]` bags.
+- Backend validation: start with `make plan-validation`; for backend source run `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`. Add `make sync-contracts` and `make ui-typecheck` when API payloads, generated contracts, or shared backend/frontend constants change.

--- a/.github/instructions/firmware.instructions.md
+++ b/.github/instructions/firmware.instructions.md
@@ -1,8 +1,9 @@
 ---
 applyTo: "firmware/esp/**"
 ---
-Firmware (`firmware/esp`)
-- `src/main.cpp` stays a thin orchestrator. Keep queue, sampling, transport, Wi-Fi, LED, config, and status logic in the matching `runtime_*.{h,cpp}` owner instead of growing `main.cpp` or creating overlapping runtime state.
-- Keep the firmware aligned with the fixed hotspot/protocol contract in `docs/protocol.md` and `infra/pi-image/pi-gen/README.md`; do not add runtime provisioning flows or internet-dependent boot assumptions.
-- Prefer targeted edits in the existing runtime module that owns the subsystem (`runtime_sampling.*`, `runtime_transport.*`, `runtime_wifi.*`, and peers) over adding duplicate helpers or parallel recovery paths.
-- Validation: for firmware code changes, run `cd firmware/esp && pio run` for compile coverage. For firmware protocol/native CI parity, also run `python tools/firmware/generate_protocol_contract_fixtures.py --check` and `cd firmware/esp && pio test -e native`. Use `pio run -t upload` and `pio device monitor` only when hardware-backed behavior needs confirmation. For docs/instruction-only changes under `firmware/esp/`, use proportionate docs validation instead of flashing hardware.
+Firmware rules for `firmware/esp`.
+
+- `src/main.cpp` stays a thin orchestrator. Put queue, sampling, transport, Wi-Fi, LED, config, and status logic in the matching `runtime_*.{h,cpp}` owner.
+- Keep firmware aligned with `docs/protocol.md` and `infra/pi-image/pi-gen/README.md`. Do not add runtime provisioning flows or internet-dependent hotspot boot assumptions.
+- Prefer targeted edits in the existing subsystem owner (`runtime_sampling.*`, `runtime_transport.*`, `runtime_wifi.*`, etc.) over duplicate helpers or parallel recovery paths.
+- Validation: start with `make plan-validation`; run `cd firmware/esp && pio run` for code changes. For protocol/native CI parity add `python tools/firmware/generate_protocol_contract_fixtures.py --check` and `cd firmware/esp && pio test -e native`. Use `pio run -t upload` and `pio device monitor` only for hardware-backed confirmation.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,17 +1,15 @@
 ---
 applyTo: "apps/ui/**"
 ---
-Frontend (`apps/ui`)
-- Shared contract-sync authority lives in `apps/ui/README.md` § "Contract sync"; follow that flow and do not introduce a second sync path.
-- Keep frontend changes focused when practical; larger cross-cutting and breaking UI changes are allowed.
-- `apps/ui/src/app/runtime/` owns app-wide composition, startup, shell chrome, live transport, spectrum lifecycle, and other long-lived controllers. Keep cross-feature orchestration there instead of re-creating it inside feature modules.
-- `apps/ui/src/app/features/` owns feature workflows, API calls, polling lifecycles, and app-state mutations for settings, realtime, history, updates, cars, and ESP flash. Extend the existing feature owner before adding a parallel controller/service for the same surface.
-- `apps/ui/src/app/views/` owns DOM rendering, HTML helpers, and event-target decoding. Keep views data-in / DOM-out; do not move request orchestration, polling, or business branching into view modules.
-- Keep computed/derived ownership out of view components when possible. Prefer runtime, feature, presenter, or shared adapter modules to own `computed()` state, and let views mostly read already-derived signal values.
-- Keep DOM rendering and event decoding in views, while runtime/feature modules translate those events into workflow actions.
-- Keep polling, timers, WebSocket/session state, and other shared runtime state centralized. Reuse the feature workflow polling seams, `apps/ui/src/app/runtime/ui_live_transport_controller.ts`, and `apps/ui/src/app/ui_app_state.ts` instead of introducing duplicate per-feature loops or freshness owners.
-- Avoid parallel fetch, poll, or contract-sync paths when one canonical path already exists. Reuse `apps/ui/src/api/http.ts`, `apps/ui/src/ws.ts`, generated contracts, `apps/ui/src/ws_payload_validator.ts`, and `apps/ui/src/server_payload.ts` instead of adding alternate transport wrappers or ad-hoc payload adapters for the same server state.
-- For owned server-controlled runtime boundaries, validate `unknown` payloads once at the API/transport seam with Valibot (or a documented hot-path custom validator) before feature/runtime code consumes typed data.
-- Keep `apps/ui/src/` free of `any`/`as any`; prefer explicit interfaces, unions, and narrowing helpers when wiring server payloads and DOM state.
-- For server/WebSocket inputs, keep raw data as `unknown` until a decoder proves the shape; prefer generated contracts, schema-backed validation, and narrow adapters over loose record-bag handling.
-- Validation: for frontend logic, contract, or composition changes, run `make ui-typecheck`; it materializes generated UI contract artifacts before Biome and TypeScript checks. For bundle behavior, add `cd apps/ui && npm run build` after `make ui-typecheck` or `make sync-contracts`. For feature workflow/runtime logic, add `cd apps/ui && npm run test:unit`; for rendered UI states or snapshots, add `cd apps/ui && npm run test:visual`. Reserve the local Docker stack for material UI/backend runtime integration changes.
+Frontend rules for `apps/ui`.
+
+- Contract sync authority is `apps/ui/README.md` "Contract sync". Do not add a second sync path or hand-written API contract drift.
+- `src/app/runtime/` owns app-wide composition, startup, shell chrome, live transport, spectrum lifecycle, and long-lived controllers.
+- `src/app/features/` owns feature workflows, API calls, polling lifecycles, and app-state mutations for settings, realtime, history, updates, cars, and ESP flash.
+- `src/app/views/` owns DOM rendering, HTML helpers, and event-target decoding. Keep views data-in/DOM-out; runtime/feature modules translate events into workflow actions.
+- Keep computed/derived state outside views when practical; use runtime, feature, presenter, or shared adapter owners.
+- Centralize polling, timers, WebSocket/session state, and freshness. Reuse existing feature polling seams, `src/app/runtime/ui_live_transport_controller.ts`, and `src/app/ui_app_state.ts`.
+- Avoid parallel fetch, poll, transport, validation, or contract-sync paths. Reuse `src/api/http.ts`, `src/ws.ts`, generated contracts, `src/ws_payload_validator.ts`, and `src/server_payload.ts`.
+- Keep server/WebSocket inputs as `unknown` until Valibot, generated contracts, schema-backed validation, or a documented hot-path validator proves the shape.
+- Keep `src/` free of `any`/`as any`; prefer interfaces, unions, and narrowing helpers.
+- Validation: start with `make plan-validation`; run `make ui-typecheck` for frontend logic/contracts/composition. Add `cd apps/ui && npm run build` for bundle behavior, `npm run test:unit` for feature/runtime logic, and `npm run test:visual` for rendered UI or snapshots.

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -1,86 +1,51 @@
 ---
 applyTo: "**"
 ---
-Scope: shared workflow, validation, documentation maintenance, and execution guardrails. Keep canonical AI guidance and architectural invariants in `.github/copilot-instructions.md`, and keep repository layout/navigation in `docs/ai/repo-map.md`.
+Scope: global workflow, validation, docs, PR/CI, safety, and simplification rules. Keep repo invariants in `.github/copilot-instructions.md`, navigation in `docs/ai/repo-map.md`, and area deltas in sibling instruction files.
 
-Agent workflow
-- For medium/large tasks, always start with an explicit checklist plan. Use highly descriptive titles that include the problem, the fix, and user impact.
-- Work in iterative loops until done: `plan → verify current behavior → root cause → blast radius scan → implement complete maintainable fix → targeted tests → broader relevant tests → re-plan`.
-- Verify existing behavior before rewriting code; investigate root cause before patching symptoms.
-- Scan the blast radius for similar in-scope issues and fix them in the same run.
-- Prefer extending and hardening existing logic over adding parallel implementations.
-- When a larger refactor or other major in-scope change is the clearest path to better long-term maintainability, prefer that over a narrowly local patch that preserves poor structure.
-- Analysis-first default: examine the issue from multiple angles, choose the strongest approach, and deliver the most direct, validated, complete in-scope fix that addresses root cause and nearby in-scope blast radius.
-- Avoid symptom-only patches. Prefer fixes that make sense to a human maintainer and reduce future maintenance burden in the touched area.
-- Avoid over-conservative blocking behavior: do not hold a clear fix for exhaustive hypothetical analysis.
-- Use bounded risk rather than risk avoidance: keep changes reversible, validate early, and recover quickly on failures.
-- Continue autonomously on clearly adjacent in-scope issues without waiting for another prompt, but do not turn incidental cleanup into a new project.
-- Stop only when one of these conditions is true:
-  1. all plan items are complete and validated,
-  2. no similar in-scope issues remain,
-  3. a real blocker exists (credentials/hardware/external dependency),
-  4. the user explicitly asks to pause.
-- Long, thorough runs are allowed for deeper tasks when the requested scope and validation needs justify them.
-- Execution-completion bias: finish the requested work, not merely a first pass. Do not stop at analysis, planning, or partial implementation. Do not treat "first green test pass" as completion if architectural residue remains.
-- Task size is not a blocker by itself. For large tasks, decompose into execution buckets and work through the in-scope buckets in order.
-- Avoid hedging language such as "this is probably too large for one session" or "I'll do as much as possible." Instead, state the execution buckets, current validation target, and any real blocker.
-- Context/noise control:
-  - avoid scanning generated/build/cache/vendor artifacts unless debugging them (`artifacts/`, `.cache/`, `node_modules/`, `dist/`, `.venv/`, `.pytest_cache/`, `.ruff_cache/`),
-  - use focused file reads and scoped searches,
-  - avoid huge command output unless needed.
-- No-cheating implementation rules:
-  - put executable logic in proper code files, not hidden in docs/json/txt wrappers,
-  - when adding large inline data definitions, move them into appropriate data files (`.json`, `.yaml`, etc.),
-  - do not create duplicate parallel implementations when extending existing logic is cleaner.
+## Work loop
+- For medium/large tasks, start with an explicit checklist plan. For user-requested trackers, create and update the tracker as work progresses.
+- Iterate until done: plan -> verify current behavior -> identify owner/root cause -> scan bounded blast radius -> implement a maintainable fix -> run targeted then broader relevant validation -> re-plan if needed.
+- Inspect the repo instead of guessing. Verify current behavior before rewriting, and fix root cause rather than symptoms.
+- Continue autonomously through obvious safe next steps, including branch-caused test/CI failures. Stop only when complete and validated, explicitly blocked, or the user pauses.
+- Keep scope to the request, direct callers, root-cause fixes, and clearly adjacent regressions found during validation.
+- If blocked by credentials, hardware, external services, or unrelated failures, state the blocker and evidence plainly.
+- Avoid huge context dumps. Use focused reads/searches; skip generated/build/cache/vendor artifacts unless debugging them.
 
-Deep-thinking gate
-- Non-trivial work: no edits before owner, current behavior, root cause, chosen approach, and validation are named.
-- Compare two approaches; choose the one with one owner, one code path, one source of truth.
-- List one tempting wrong fix and why it is wrong.
-- For large refactors, use an ExecPlan.
+## Simplicity and architecture
+- Prefer one owner, one code path, and one source of truth.
+- Prefer direct fixes over new abstractions. Add indirection only for a concrete second consumer or clear maintainability win.
+- Do not add speculative config knobs, shims, deprecated aliases, compatibility adapters, fallback paths, duplicate implementations, or old/new parallel paths unless explicitly required.
+- When replacing behavior, update callers and remove obsolete paths in the same change.
+- Keep route handlers thin HTTP translators; put business logic in independently testable services/use cases.
+- Do not duplicate utility functions. Exception: standalone tooling that cannot import the server package may carry a local copy with a comment pointing to the primary source.
+- Put executable logic in code, not docs/json/txt wrappers. Move large inline data to appropriate data files.
+- Breaking internal-only interfaces is allowed when cleaner; this repo owns both producers and consumers.
 
-Complexity hygiene
-- Remove config fields that are not read by any code path. Do not add speculative config knobs.
-- Maintain one definition for each default value; do not duplicate defaults across files.
-- Do not add forward-extensibility machinery (overflow columns, plugin hooks, generic registries) until a concrete second consumer exists.
-- Prefer flat, direct structures. Only introduce grouping or wrapping when more than three consumers benefit from the indirection.
-- Aggressive simplification: remove wrappers, shims, compatibility adapters, and transitional architecture when they no longer serve a real consumer. Do not preserve them out of caution or habit.
-- Aggressive consolidation: collapse toward one canonical code path. Dead code, obsolete fallback branches, and duplicate implementations must be deleted outright, not archived or left behind.
-- Aggressive caller updates: when a refactor requires touching many files or all callers, touch all of them. Coordinated, invasive changes that produce a cleaner result are preferred over partial migrations that leave residue in place.
-- Aggressive deletion of dead code and transitional architecture is preferred. Do not keep migration scaffolding, deprecated aliases, or old DTO shapes once they are no longer consumed.
-- Route handlers must be thin HTTP translators. Extract business logic into service functions that are independently testable.
-- Do not create duplicate API endpoints for the same operation.
-- Do not duplicate utility functions across modules. Maintain one implementation and import from it. Exception: standalone tooling scripts (e.g. ``tools/build_ui_static.py``) that must run without the server package installed may carry a local copy; mark it with a comment pointing at the primary source.
+## Documentation
+- Update docs, runbooks, READMEs, repo maps, and instructions when behavior, contracts, commands, config, paths, or user-facing operations change. Avoid doc churn for unaffected areas.
+- Documentation scans must be bounded. Search touched symbols, paths, commands, config names, and public behavior with `rg`. Do not browse all docs unless the task is documentation-wide.
+- Keep docs consistent with code. Rewrite or remove stale guidance instead of layering caveats.
+- Historical or superseded docs are reference only unless they explicitly say they are Active.
 
-Documentation maintenance (always required)
-- Before merging, review whether docs, repo maps, runbooks, READMEs, and instruction files that reference the touched area have gone stale, and update the relevant ones unless the user explicitly asks you not to touch docs.
-- Remove or rewrite obsolete guidance instead of layering caveats on top of it.
-- Keep human-facing docs and AI-facing guidance aligned with the live code, paths, commands, and ownership boundaries.
+## Validation
+- Use proportionate validation. Start with `make plan-validation`; run `./.venv/bin/python tools/tests/plan_validation.py --run` for planned non-Docker jobs, or ACT only for workflow/Docker parity.
+- Run targeted tests for the changed seam, then broader relevant gates. Do not run heavy unrelated builds unless the touched area requires them.
+- Docs/instruction-only changes should run `make docs-lint` and the validation planner, not the local Docker stack.
+- Runtime-affecting backend/frontend changes that alter HTTP/WS flows, runtime wiring, static asset serving, container/dev-stack behavior, or live UI flows require the local Docker stack and simulator flow from the canonical command docs.
+- If a refactor changes seams, update tests to validate current behavior instead of obsolete internals.
+- Completion reports must state files changed, validation run, skipped validation with reasons, and whether docs/AI guidance were updated or unnecessary.
 
-Updater deployment policy
-- Treat updater delivery as wheel-first. Runtime fixes must land in repo code and flow through PR/CI; avoid relying on ad-hoc runtime file edits.
-- Emergency-only exception: if updater path is broken on a live device, temporary in-place patching on the device is allowed strictly to restore service.
-- After any emergency in-place patch, complete the follow-up loop in the same run when feasible: repo fix + tests/lint + PR green + merge + successful updater rerun on device.
+## PR and CI
+- After opening/updating a PR intended to land, run `./.venv/bin/python tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green`.
+- Treat watcher `RESULT=NON_GREEN`, `RESULT=MERGE_ISSUES`, or `RESULT=MERGE_FAILED` as actionable: inspect annotations and concise log tails, fix branch-caused failures, push, and restart the watcher.
+- `RESULT=MERGED` is success for merge-on-green; `RESULT=ALL_GREEN` is success only for watch-only.
+- Do not merge on red required checks. Document unrelated or flaky blockers.
+- Prefer squash merge unless the repo convention or user says otherwise.
+- Avoid full CI log dumps; use failing annotations, test names, and short tails first.
 
-Validation (always required)
-- Pull request default mode: after opening or updating a PR that should land once checks pass, start the compact watcher from the command list with `--merge-on-green`, use its state-change output as the default CI monitor, fix all blocking issues, push updates, and restart the watcher until it exits successfully. Omit `--merge-on-green` only when the user explicitly wants the PR left open or draft.
-- Use the command list (defined in the copilot instructions "Commands" section) for PR check watching, lint/type checks, CI-parity runs, single-area pytest runs, and local Docker bring-up; prefer the watcher over repeated full PR-status dumps, use `docs/testing.md` for test layout, CI limitations, and the optional `act` wrapper, and follow targeted → broader → local-GitHub-workflow validation before finalizing any task.
-- Treat watcher exit `RESULT=NON_GREEN` or `RESULT=MERGE_FAILED` as immediate action: inspect the latest failing run or merge blocker promptly, determine root cause, implement the smallest complete maintainable fix, push, and restart the watcher.
-- Treat watcher exit `RESULT=MERGED` as the success gate for merge-on-green runs. Treat `RESULT=ALL_GREEN` as the success gate only in watch-only mode.
-- If an intentional refactor changes function-level seams or helper boundaries, refactor the affected tests in the same change set so they validate current behavior instead of pinning obsolete internals.
-- For runtime-affecting backend or frontend changes that alter local integration behavior (HTTP/WS flows, runtime wiring, static asset serving, container/dev-stack behavior, or UI flows exercised against the live server), exercise the local Docker stack with the commands listed in copilot-instructions (compose up + simulator), confirm `http://127.0.0.1` updates live (`:8000` fallback if `:80` is not serving), then verify updates stop once the simulator stops; inspect container logs if needed.
-- Use proportionate validation instead of the local Docker stack for docs-only changes, AI-instruction-only changes, README/repo-map/docs-lint edits, pure test-only changes that do not alter runtime behavior, and CI/workflow-only changes unless they also change local stack behavior.
-- Breaking changes are allowed when intentional.
-- No-backward-compatibility policy: we own the full codebase end to end. Do not add or preserve backward-compatibility layers (deprecated paths, adapters, fallbacks, shims, version-bridging logic, or legacy schema support) unless explicitly asked. Remove them when encountered. Standardize on the current contract, schema, config, and runtime path. Do not add new compatibility code "just in case". If compatibility seems necessary, flag it explicitly rather than implementing it silently. Internal-only backward compatibility is never the default: when the repo controls both producers and consumers, coordinated breaking changes are preferred over preserving old shapes. The cleaner architecture always wins over old migration scaffolding.
-- Completion reports should state files changed, validation commands run, any validation skipped with the reason, and whether docs or AI guidance were updated or confirmed unnecessary.
-
-Docs (`docs/`)
-- Keep `docs/` short and focused. Add design changes (e.g. report layout) to `docs/design_language.md`.
-- Rewrite or remove stale sections aggressively; do not keep contradictory historical guidance in place.
-- Prefer direct pointers to the files that own current commands or workflows over long prose that will drift.
-- Keep ownership-language rare. Use it only when a file genuinely owns a fact that other docs should not restate.
-
-Infra / Docker / CI (`docker-compose.yml`, `.github/workflows/`)
-- CI: see `.github/workflows/ci.yml` for blocking job names and job commands; do not duplicate that list elsewhere.
-- Keep CI steps maintainable; larger CI/workflow updates are allowed when needed. If adding new test dependencies, update `apps/server/pyproject.toml` so CI installs them via the editable install.
-- Avoid embedding secrets in workflow files; use repository secrets for tokens.
+## Security and CI hygiene
+- Do not commit secrets, local credentials, `.secrets.act`, tokens, certificates, or device-specific private data.
+- Do not weaken authentication, validation, update integrity checks, network safety, or offline-first device defaults.
+- Keep CI steps maintainable. If workflow tests need new dependencies, declare them in the owning package config.
+- Avoid embedding secrets in workflows; use repository secrets.

--- a/.github/instructions/pi-image.instructions.md
+++ b/.github/instructions/pi-image.instructions.md
@@ -1,8 +1,9 @@
 ---
 applyTo: "infra/pi-image/**"
 ---
-Pi image (`infra/pi-image/**`)
-- `infra/pi-image/pi-gen/build.sh` stays a thin coordinator for `BUILD_MODE=app|image|all`; keep host-side helpers in `pi-gen/lib/`, tracked stage/config sources in `pi-gen/templates/`, and post-build validation in `pi-gen/validate-image.sh`.
-- Preserve the wheel-first, offline-first image flow: build app artifacts first, bake required packages and tools into the image, and avoid changes that make hotspot bring-up depend on internet access or ad-hoc post-boot mutation.
-- Do not move tracked stage/template content back into long heredocs or runtime-generated files when `pi-gen/templates/` already owns it.
-- Validation: choose the narrowest existing path that matches the change — `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh` for packaged app artifact changes, `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh` for image-stage logic, and `./infra/pi-image/pi-gen/validate-image.sh [artifact]` to rerun image validation without rebuilding. Use full `BUILD_MODE=all` only when both layers changed.
+Pi image rules for `infra/pi-image`.
+
+- `pi-gen/build.sh` stays a thin coordinator for `BUILD_MODE=app|image|all`. Host helpers belong in `pi-gen/lib/`, tracked stage/config sources in `pi-gen/templates/`, and post-build validation in `pi-gen/validate-image.sh`.
+- Preserve the wheel-first, offline-first image flow: build app artifacts first, bake required packages/tools into the image, and keep hotspot bring-up independent of internet access or ad-hoc post-boot mutation.
+- Do not move tracked stage/template content back into heredocs or runtime-generated files when `pi-gen/templates/` owns it.
+- Validation: start with `make plan-validation`; use the narrowest path: `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh` for packaged app artifacts, `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh` for image-stage logic, and `./infra/pi-image/pi-gen/validate-image.sh [artifact]` for existing artifacts. Use `BUILD_MODE=all` only when both layers changed.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,15 +1,15 @@
 ---
 applyTo: "apps/server/tests/**"
 ---
-Backend tests (`apps/server/tests/**`)
-- Detailed test layout, placement rules, shared root helpers, and CI command usage live in `docs/testing.md`; this file only captures test-specific deltas, so use the matching `tests/<module>/` directory from that map, reserve `integration/` for cross-cutting regressions, and use `hygiene/` for guards.
-- Import style: use `from test_support.X import Y` (short form). The `tests/` directory is on `sys.path` via `testpaths` in `pyproject.toml`. Do not use `from tests.test_support` or manipulate `sys.path` for test imports.
-- Use `test_support/findings.py` factories (`make_finding_payload`, `make_ref_finding`, `make_info_finding`) for constructing finding dicts in tests. Do not create local finding factories in individual test files.
-- Test helper re-exports that only alias another module's symbol should be replaced with direct imports. Keep test helper modules for functions that add real logic.
-- Use `test_support/sample_scenarios.py` builders as the single source for synthetic sample/phase construction. Do not duplicate sample-generation logic in other helpers.
-- Do not add new tests to existing large omnibus regression files — prefer a new focused test module in the matching feature-area directory.
-- Do not use `inspect.getsource` or `ast.parse` on production code in tests. These create brittle source-string-matching assertions that break on any refactor. Instead, test the observable behavior: call the function with representative inputs and assert on outputs, side-effects, or raised exceptions. If you need an AST/import guard, add it to `tools/dev/verify_backend_static_guards.py` so it runs under `make lint` instead of pytest.
-- Do not create local `FakeState` or fake runtime classes in individual test files. Use the shared `FakeState` from `conftest.py` and customise it via constructor arguments.
-- Do not add private bridge/shim methods to production classes solely for test access. Test sub-components directly (e.g. `proc._store._get_or_create_unlocked`, `proc._metrics.fft_params`) instead of adding pass-through wrappers on the outer class.
-- Oversized test/spec guardrails live in `tools/dev/check_hygiene.py` with the explicit allowlist at `tools/dev/oversized_test_allowlist.yml`; split oversized files by default, and only add an allowlist entry when the file is intentionally large and the reason is documented there.
-- Optional focused backend pytest run (for faster iteration, not a CI substitute): run `pytest -q apps/server/tests/<module>/` from the repo root, or `../.venv/bin/python -m pytest tests/<module>/ -q` from `apps/server` when you need to pin the repo-managed backend environment.
+Backend test rules. Use `docs/testing.md` for the concise test map and command router.
+
+- Put new tests in the matching `apps/server/tests/<module>/` directory. Reserve `integration/` for cross-cutting regressions and `hygiene/` for guards.
+- Import shared helpers as `from test_support.X import Y`; do not use `from tests.test_support` or mutate `sys.path`.
+- Use `test_support/findings.py` factories for finding payloads and `test_support/sample_scenarios.py` for synthetic sample/phase construction. Do not create local duplicates.
+- Replace helper re-exports with direct imports unless the helper adds real logic.
+- Prefer new focused test modules over adding to large omnibus regression files.
+- Test observable behavior, not source strings. Do not use `inspect.getsource` or `ast.parse` on production code in pytest; add needed AST/import guards to `tools/dev/verify_backend_static_guards.py` so `make lint` runs them.
+- Do not create per-file fake runtime classes. Use shared `FakeState` from `conftest.py` and customize it via constructor arguments.
+- Do not add private production bridge/shim methods solely for test access; test sub-components directly.
+- Oversized test/spec guardrails live in `tools/dev/check_hygiene.py`; intentional exceptions belong in `tools/dev/oversized_test_allowlist.yml`.
+- Focused validation: `pytest -q apps/server/tests/<module>/` from repo root, or `../.venv/bin/python -m pytest tests/<module>/ -q` from `apps/server` when the repo-managed backend environment must be pinned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,9 @@
 # Agent guidance
 
-VibeSensor is a mixed Python backend, TypeScript/Vite dashboard, ESP32 firmware, and Raspberry Pi image repository.
+VibeSensor includes a Python backend, TypeScript/Vite UI, ESP32 firmware, and Raspberry Pi image build. Read [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
-Read [.github/copilot-instructions.md](.github/copilot-instructions.md) for the canonical architecture, command, and validation guidance. Use `.github/instructions/` for Copilot path-scoped rules, and use `docs/ai/repo-map.md` for navigation only.
-
-Before changing code:
-- Identify the touched area: backend, frontend, firmware, Pi image, tests, docs, or instructions.
-- Follow the matching validation path from `.github/copilot-instructions.md`.
-- Update docs or AI guidance when the touched behavior changes their facts.
-- Keep changes scoped to the request plus direct root-cause fixes and clearly adjacent regressions found during validation.
+- Canonical repo guidance: `.github/copilot-instructions.md`.
+- Path-scoped rules: `.github/instructions/`.
+- Navigation fallback: `docs/ai/repo-map.md`; use `rg`, file names, imports, and tests first.
+- If your agent already auto-loads the relevant instruction files, do not reopen them just to duplicate context.
+- Before editing, identify the touched area, follow the matching validation path, update directly affected docs/guidance, and keep scope to the request plus root-cause fixes.

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -1,15 +1,9 @@
 # Backend agent guidance
 
-Backend-specific rules live in `../../.github/instructions/backend.instructions.md`; test-specific rules live in `tests/AGENTS.md` and `../../.github/instructions/tests.instructions.md`.
-
-Key anchors:
-- Package entry points and ownership boundaries: `../../docs/ai/repo-map.md`.
-- Domain object rules: `../../docs/domain-model.md`.
-- Layering guard: `../../tools/dev/verify_backend_static_guards.py`.
-
-Default validation for backend source changes:
-- `make lint`
-- `make typecheck-backend`
-- `pytest -q apps/server/tests/<module>/`
-
-Add `make sync-contracts` and `make ui-typecheck` when API payloads, generated contracts, or shared backend/frontend constants change.
+- Backend rules: `../../.github/instructions/backend.instructions.md`.
+- Updater-specific rules: `../../.github/instructions/backend-updates.instructions.md`.
+- Test rules: `tests/AGENTS.md` and `../../.github/instructions/tests.instructions.md`.
+- Ownership lookup: `../../docs/ai/repo-map.md`; domain graph: `../../docs/domain-model.md`.
+- Layer guard: `../../tools/dev/verify_backend_static_guards.py`.
+- Default validation: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
+- Add `make sync-contracts` and `make ui-typecheck` for API payloads, generated contracts, or shared backend/frontend constants.

--- a/apps/server/tests/AGENTS.md
+++ b/apps/server/tests/AGENTS.md
@@ -1,11 +1,7 @@
 # Backend test agent guidance
 
-Backend test rules live in `../../../.github/instructions/tests.instructions.md`; the full test map lives in `../../../docs/testing.md`.
-
-Use the matching `apps/server/tests/<module>/` directory for new tests. Reserve `integration/` for cross-cutting regressions and `hygiene/` for guards.
-
-Prefer focused test modules over adding to large omnibus regression files. Test observable behavior instead of source text.
-
-Default focused validation:
-- `pytest -q apps/server/tests/<module>/`
-- From `apps/server`, run `../.venv/bin/python -m pytest tests/<module>/ -q` when you need to pin the repo-managed backend environment.
+- Test rules: `../../../.github/instructions/tests.instructions.md`.
+- Test map and commands: `../../../docs/testing.md`.
+- Put new tests in the matching `apps/server/tests/<module>/`; reserve `integration/` for cross-cutting regressions and `hygiene/` for guards.
+- Prefer focused modules and observable behavior assertions.
+- Focused validation: `pytest -q apps/server/tests/<module>/`, or from `apps/server`, `../.venv/bin/python -m pytest tests/<module>/ -q`.

--- a/apps/ui/AGENTS.md
+++ b/apps/ui/AGENTS.md
@@ -1,15 +1,6 @@
 # Frontend agent guidance
 
-Frontend-specific rules live in `../../.github/instructions/frontend.instructions.md`.
-
-Key anchors:
-- Contract sync: `README.md` section "Contract sync".
-- Runtime composition: `src/app/runtime/`.
-- Feature workflows and API/polling state: `src/app/features/`.
-- DOM rendering and event decoding: `src/app/views/`.
-
-Default validation for frontend logic, contracts, or composition:
-- `make ui-typecheck`
-- `cd apps/ui && npm ci && npm run build` when bundle behavior matters.
-
-Add `cd apps/ui && npm run test:visual` when rendered UI states or snapshots change.
+- Frontend rules: `../../.github/instructions/frontend.instructions.md`.
+- Contract sync: `README.md` "Contract sync".
+- Owners: `src/app/runtime/` for composition/controllers, `src/app/features/` for workflows/API/polling, `src/app/views/` for DOM/event decoding.
+- Validation: `make ui-typecheck`; add `cd apps/ui && npm run build` for bundle behavior and `cd apps/ui && npm run test:visual` for rendered UI/snapshots.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ links onward to the scoped instruction files and repo map below.
 | `docs/ai/repo-map.md` | Detailed repo layout, entry points, and module ownership. |
 | `.github/instructions/general.instructions.md` | Shared workflow, validation, and execution guardrails for AI work. |
 | `.github/instructions/backend.instructions.md` | Backend-specific coding rules and deltas for AI work. |
+| `.github/instructions/backend-updates.instructions.md` | Updater-specific backend rules for app, firmware, Wi-Fi, release, install/rollback, and status update paths. |
 | `.github/instructions/frontend.instructions.md` | Frontend-specific rules and deltas for AI work. |
 | `.github/instructions/firmware.instructions.md` | Firmware-specific rules and validation deltas for `firmware/esp/**`. |
 | `.github/instructions/pi-image.instructions.md` | Pi-image-specific rules and validation deltas for `infra/pi-image/**`. |

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -1,76 +1,72 @@
 # Repo map
 
-Scope: detailed file layout, entry points, and stable ownership boundaries for navigation.
-This file is the repo map, not a workflow or policy guide. Use `.github/copilot-instructions.md` for canonical AI guidance and `.github/instructions/*.instructions.md` for workflow or area-specific rules.
-Paths below are repo-relative unless a line explicitly calls out a Python import namespace.
+This file is the repo map, not a workflow or policy guide. On-demand navigation help: do not read it by default; use `rg`, file names, imports, and tests first, and open this only when ownership is unclear. Workflow and policy rules live in `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md`.
 
 ## Primary entry points
 
-- Backend app: `apps/server/vibesensor/app/bootstrap.py` (builds the FastAPI runtime and launches it through the canonical Granian/uvloop server path)
-- Backend service wiring: `apps/server/vibesensor/app/container.py`
-- Backend route assembly: `apps/server/vibesensor/adapters/http/router.py` with domain bundles in `apps/server/vibesensor/adapters/http/route_bundles.py`
-- UI app entry: `apps/ui/src/main.ts`
-- UI runtime/composition root: `apps/ui/src/app/ui_app_runtime.ts`
-- UI runtime owners: `apps/ui/src/app/runtime/`
-- Simulator CLI: `apps/server/vibesensor/adapters/simulator/sim_sender.py` (thin CLI/orchestrator over `apps/server/vibesensor/adapters/simulator/sim_client.py`, `apps/server/vibesensor/adapters/simulator/sim_scene.py`, and `apps/server/vibesensor/adapters/simulator/sim_runtime.py`)
-- Firmware app: `firmware/esp/src/main.cpp` (thin orchestrator) plus `firmware/esp/src/runtime_*.{h,cpp}`
-- Pi image build: `infra/pi-image/pi-gen/build.sh` (thin entrypoint), `infra/pi-image/pi-gen/lib/`, `infra/pi-image/pi-gen/templates/`, and `infra/pi-image/pi-gen/validate-image.sh`
-- Local stack entry point: `docker-compose.yml`
+- Backend app/runtime: `apps/server/vibesensor/app/bootstrap.py`, `apps/server/vibesensor/app/container.py`
+- Backend HTTP assembly: `apps/server/vibesensor/adapters/http/router.py`, `apps/server/vibesensor/adapters/http/route_bundles.py`
+- Backend CLIs: `apps/server/vibesensor/cli/`
+- UI app/runtime: `apps/ui/src/main.ts`, `apps/ui/src/app/ui_app_runtime.ts`, `apps/ui/src/app/runtime/`
+- Simulator: `apps/server/vibesensor/adapters/simulator/`
+- Firmware: `firmware/esp/src/main.cpp`, `firmware/esp/src/runtime_*.{h,cpp}`
+- Pi image: `infra/pi-image/pi-gen/build.sh`, `infra/pi-image/pi-gen/lib/`, `infra/pi-image/pi-gen/templates/`, `infra/pi-image/pi-gen/validate-image.sh`
+- Local stack: `docker-compose.yml`
 
-## Top-level layout
+## Top-level ownership
 
-- `apps/server/`: backend package, configs, tests, scripts, systemd units, public UI assets, simulator, and config tooling.
-- `apps/ui/`: TypeScript/Vite dashboard and Playwright tests.
-- `firmware/esp/`: ESP32 firmware. `src/main.cpp` owns setup/loop orchestration, while `src/runtime_*.{h,cpp}` owns queue, sampling, transport, Wi-Fi, LED, config, and status logic.
-- `apps/server/vibesensor/cli/`: CLI entry points — `apps/server/vibesensor/cli/server.py` (main server), `apps/server/vibesensor/cli/report.py` (report generation), `apps/server/vibesensor/cli/preflight.py` (config preflight), `apps/server/vibesensor/cli/hotspot_config.py` (hotspot config export for shell scripts), `apps/server/vibesensor/cli/http_api_schema_export.py`, and `apps/server/vibesensor/cli/ws_schema_export.py`.
-- `apps/server/vibesensor/vibration_strength.py`, `apps/server/vibesensor/strength_bands.py`: shared vibration math and unit logic. Hot-path functions accept numpy arrays; scalar functions remain pure Python.
-- `apps/server/vibesensor/report_i18n.py`: canonical report-string/i18n helpers shared by boundary shaping and PDF rendering.
-- `infra/pi-image/pi-gen/`: Raspberry Pi image build pipeline. `build.sh` is the thin entrypoint for `BUILD_MODE=app|image|all`; `lib/` owns focused host-side helpers (prereqs, mirror selection, app artifacts, pi-gen repo prep, stage assembly, artifact selection, validation helpers); `templates/` owns tracked stage/config source files copied into `.cache/pi-gen/`; and `validate-image.sh` reruns the post-build mount/chroot/QEMU validator against an existing artifact.
-- `docs/`: human-facing docs plus AI repo maps and runbooks.
+- `apps/server/`: Python backend package, configs, tests, simulator, static UI assets, systemd units, and backend tooling.
+- `apps/ui/`: TypeScript/Vite dashboard and Playwright/Vitest tests.
+- `firmware/esp/`: ESP32 firmware; keep `main.cpp` thin and subsystem logic in `runtime_*`.
+- `infra/pi-image/`: Raspberry Pi image build, templates, validation, and image docs.
+- `docs/`: human-facing docs plus this navigation index.
+- `.github/instructions/`: path-scoped AI instructions.
 
-## Backend package layout
+## Backend package ownership
 
-- `apps/server/vibesensor/app/`: startup, dependency wiring, runtime state, and config loading.
-- `apps/server/vibesensor/adapters/http/`: API route groups, bundle-level router assembly (`apps/server/vibesensor/adapters/http/router.py`, `apps/server/vibesensor/adapters/http/route_bundles.py`), grouped route dependencies, and HTTP-specific Pydantic request/response models under `apps/server/vibesensor/adapters/http/models/`.
-- `apps/server/vibesensor/adapters/websocket/hub.py`: live WebSocket fan-out and payload delivery.
-- `apps/server/vibesensor/adapters/persistence/`: SQLite history storage and static car-library loading.
-- `apps/server/vibesensor/adapters/pdf/`: report mapping and PDF rendering, with page renderers and appendix renderers under `apps/server/vibesensor/adapters/pdf/` and `apps/server/vibesensor/adapters/pdf/pdf_appendices/`. See `docs/report_pipeline.md` for the report flow.
-- `apps/server/vibesensor/adapters/udp/`, `apps/server/vibesensor/adapters/gps/`, `apps/server/vibesensor/adapters/simulator/`, `apps/server/vibesensor/adapters/hotspot/`: transport and device-facing runtime adapters.
-- `apps/server/vibesensor/infra/runtime/`: runtime lifecycle, health, registry, and WebSocket coordination.
-- `apps/server/vibesensor/infra/processing/`: signal-processing execution and payload building. See `docs/intake_buffering.md` for the live ingest, snapshot/FFT, and buffering flow.
-- `apps/server/vibesensor/infra/config/`: runtime settings storage and read-side access.
-- `apps/server/vibesensor/infra/workers/`: worker-pool infrastructure.
-- `apps/server/vibesensor/use_cases/diagnostics/`: post-stop diagnostics pipeline. Core sample/statistics types stay in `_types.py`, while plot/table/output DTOs live in `_view_types.py`. See `docs/analysis_pipeline.md` for the module map/data flow and `docs/order_tracking.md` for the shared order-reference and matching flow.
-- `apps/server/vibesensor/use_cases/history/`: history queries, report loading/preparation/caching, and export orchestration. See `docs/report_pipeline.md` for report-specific flow.
-- `apps/server/vibesensor/infra/runtime/health_snapshot.py`: application-level runtime health snapshot assembly for the `/api/health` route.
-- `apps/server/vibesensor/use_cases/run/`: recording pipeline orchestration. `apps/server/vibesensor/use_cases/run/logger.py` is the `RunRecorder` entrypoint, `apps/server/vibesensor/use_cases/run/run_context.py` owns run/history context orchestration helpers, `apps/server/vibesensor/use_cases/run/capture_readiness.py` owns the backend idle/pre-record gate, and the `post_analysis*.py` modules split queueing, loading, execution, and summary shaping. See `docs/run_lifecycle.md` for the recording -> persistence -> post-analysis handoff.
-- `apps/server/vibesensor/use_cases/updates/`: wheel-based updater workflow and public facade. Focused subpackages group `apps/server/vibesensor/use_cases/updates/firmware/`, `apps/server/vibesensor/use_cases/updates/wifi/`, and `apps/server/vibesensor/use_cases/updates/releases/`, while the root package keeps installer/state/orchestration helpers.
-- `apps/server/vibesensor/shared/`: cross-cutting ports, model/payload types, JSON helpers, boundary codecs, split constant modules under `apps/server/vibesensor/shared/constants/`, and small package-level helpers such as `apps/server/vibesensor/shared/_data_files.py`, `apps/server/vibesensor/shared/sensor_units.py`, and `apps/server/vibesensor/shared/run_context_warning.py`. Key stable owners include `apps/server/vibesensor/shared/types/persisted_analysis.py`, `apps/server/vibesensor/shared/types/analysis_views.py`, `apps/server/vibesensor/shared/types/history_analysis_contracts.py`, `apps/server/vibesensor/shared/types/run_schema.py`, `apps/server/vibesensor/shared/types/car_config.py`, `apps/server/vibesensor/shared/types/speed_source_config.py`, and the codec/projection modules under `apps/server/vibesensor/shared/boundaries/` such as `apps/server/vibesensor/shared/boundaries/settings/snapshot.py`.
-- `apps/server/vibesensor/domain/`: domain model package for classification, ranking, lifecycle, and query logic. See `docs/domain-model.md` for the domain object graph.
-- `apps/ui/src/app/runtime/`: UI composition root and runtime controllers.
-- `apps/ui/src/app/shell_state.ts`, `apps/ui/src/app/transport_state.ts`, `apps/ui/src/app/realtime_state.ts`, `apps/ui/src/app/history_state.ts`, `apps/ui/src/app/settings_state.ts`, and `apps/ui/src/app/spectrum_state.ts`: focused owners for top-level AppState slice types, defaults, factories, and pure update helpers; `apps/ui/src/app/ui_app_state.ts` stays the thin composition/compatibility surface.
-- `apps/ui/src/app/features/`: UI feature workflows for settings, realtime, history, updates, cars, and ESP flash, plus the shared polling controller used by long-running status features.
-- `apps/ui/src/app/views/`: DOM renderers and event-target decoders, including the car wizard view helpers.
-- `apps/ui/src/config.ts`: centralized UI tuning constants (polling intervals, spectrum bounds, history heatmap positions).
+- `vibesensor/app/`: startup, dependency wiring, runtime state, config loading.
+- `vibesensor/domain/`: domain behavior; see `docs/domain-model.md`.
+- `vibesensor/shared/`: stable contracts, ports, codecs, constants, JSON helpers, and boundary serializers.
+- `vibesensor/use_cases/`: application workflows (`diagnostics`, `history`, `run`, `updates`).
+- `vibesensor/infra/`: runtime lifecycle/health, signal processing, config storage, workers.
+- `vibesensor/adapters/http/`: route groups, HTTP dependencies, Pydantic models.
+- `vibesensor/adapters/{persistence,pdf,udp,gps,simulator,hotspot,websocket}/`: persistence, rendering, device, simulator, and transport adapters.
+- Report flow details: `docs/report_pipeline.md`.
+- Analysis/run/live ingest details: `docs/analysis_pipeline.md`, `docs/run_lifecycle.md`, `docs/intake_buffering.md`, `docs/order_tracking.md`.
 
-## Backend layer dependency DAG
+## Backend layer DAG
 
-- Package-level import-direction enforcement lives in `apps/server/pyproject.toml`
-  under `[tool.importlinter]`. Repo-specific backend static guards remain in
-  `tools/dev/verify_backend_static_guards.py`.
-- Allowed dependency directions are:
-  - `domain` -> none
-  - `shared` -> `domain`
-  - `use_cases` -> `domain`, `shared`
-  - `infra` -> `domain`, `shared`
-  - `adapters` -> `domain`, `shared`, `infra`, `use_cases`
-  - `app` -> all backend layers
-- `shared -> domain` and `infra -> domain` are intentional allowed edges. Focus dependency cleanup on disallowed inward leakage such as `use_cases -> adapters` or `domain -> outer layers`, not these permitted edges.
+Enforced by `apps/server/pyproject.toml` import-linter config and `tools/dev/verify_backend_static_guards.py`.
 
-## Test layout
+| Layer | May import |
+|---|---|
+| `domain` | no project layers |
+| `shared` | `domain` |
+| `use_cases` | `domain`, `shared` |
+| `infra` | `domain`, `shared` |
+| `adapters` | `domain`, `shared`, `infra`, `use_cases` |
+| `app` | all backend layers |
 
-- `apps/server/tests/` mirrors the backend package layout with `app/`, `shared/`, `domain/`, `use_cases/`, `adapters/`, and `infra/` subtrees.
-- Cross-cutting coverage lives in `integration/` and `hygiene/`.
-- Regression tests live in the feature directory they primarily test, or in `integration/` for cross-cutting regressions.
-- Shared test support lives at the test root (`conftest.py`, `_paths.py`, focused helper modules, and the `test_support/` package including `findings.py` for shared finding-payload factories).
-- Full map: `docs/testing.md`.
+`shared -> domain` and `infra -> domain` are intentional. Fix inward leakage such as `use_cases -> adapters` or `domain -> outer layers`.
+
+## UI ownership
+
+- `apps/ui/src/app/runtime/`: app-wide composition, long-lived controllers, live transport, spectrum lifecycle.
+- `apps/ui/src/app/features/`: feature workflows, API calls, polling, app-state mutations.
+- `apps/ui/src/app/views/`: DOM rendering, HTML helpers, event-target decoding.
+- `apps/ui/src/api/http.ts`, `apps/ui/src/ws.ts`, generated contracts, validators: canonical transport/contract seams.
+- Contract sync details: `apps/ui/README.md`.
+
+## Firmware and Pi image
+
+- Firmware protocol contract: `docs/protocol.md`.
+- Firmware local guidance: `firmware/esp/AGENTS.md`, `.github/instructions/firmware.instructions.md`.
+- Pi image build/defaults: `infra/pi-image/pi-gen/README.md`.
+- Pi local guidance: `infra/pi-image/AGENTS.md`, `.github/instructions/pi-image.instructions.md`.
+
+## Tests and validation
+
+- Backend tests mirror package ownership under `apps/server/tests/{adapters,app,domain,infra,shared,use_cases}/`.
+- Cross-cutting regressions go in `apps/server/tests/integration/`; guards go in `apps/server/tests/hygiene/`.
+- Shared backend test helpers live in `apps/server/tests/test_support/`.
+- Full test placement and command router: `docs/testing.md`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,521 +1,180 @@
 # Testing
 
-## Key locations
+High-traffic validation router. Keep this concise; use Makefile targets and scripts as the source of executable truth.
 
-- Server tests live under `apps/server/tests/`.
-- UI validation lives under `apps/ui/` (Biome format/lint, Vite build/typecheck, and Playwright browser checks).
-- Firmware build/flash guidance lives in `firmware/esp/README.md`.
-- Pi-image build/validation guidance lives in `infra/pi-image/pi-gen/README.md`.
-- `make format` is the canonical Python formatting command for backend and tooling files; no other Python formatter is supported in the repo workflow.
-- Use `make plan-validation` first to turn the current diff into the CI-backed validation plan.
-- Use `./.venv/bin/python tools/tests/plan_validation.py --run` to run that plan through the non-Docker local runner.
-- Use `./.venv/bin/python tools/tests/plan_validation.py --act` when you need ACT/GitHub-workflow parity for the planned jobs.
-- Use `make test-ci-fast` for lint, docs, static guards, and type checks without browser, release, firmware, e2e, or backend test suites.
-- Use `make test-ci-lite` for the larger non-Docker workflow surface except e2e; it still includes backend shards, UI smoke, release smoke, and firmware native tests.
-- Local `shell-lint` parity requires host `shellcheck`; `make doctor` reports it, and ACT/GitHub CI install it inside the workflow job.
-- Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. Use `make benchmark-golden-replay` for the opt-in 30-minute dense post-run golden replay runtime/memory check. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
-- Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
-- The full end-to-end verification runner is `make test-full-suite` (`./.venv/bin/python tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
-- `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time. It also accepts `--xdist-workers` / `VIBESENSOR_BACKEND_XDIST_WORKERS` for controlled intra-shard xdist; CI currently pins that to `3` because the current five-shard benchmark beat the nearby `5x2`, `4x3`, `4x2`, and `6x2` alternatives without changing shard count or the failure/JUnit surface. Retune only from fresh measurements, not guesswork.
-- `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
-- Python test configuration lives in `apps/server/pyproject.toml`.
-- Backend pytest runs through `pytest-randomly`, which randomizes test module, class, and function order on every run and prints the active seed in the header (e.g. `Using --randomly-seed=1234567890`). Reproduce a failing run with `pytest --randomly-seed=<seed> ...`, pinning to the reported value. Disable per run with `-p no:randomly` only when isolating a tooling issue, not to mask a real order-dependent failure.
-- Use `pytest-httpx` for backend outbound HTTP boundary tests around `httpx` clients; prefer it over monkeypatching low-level request functions when the goal is to assert request URLs, methods, payloads, status codes, and transport failures.
-- Use the shared MSW helpers under `apps/ui/tests/msw/` for frontend HTTP-boundary tests; they normalize relative `/api/...` requests onto the test origin and fail unhandled requests loudly by default.
-- Use `cd apps/ui && npm run dev:mock` for the optional browser-worker MSW mode when you need to exercise the UI without a live backend HTTP stack. That mode keeps unmocked HTTP requests on bypass, does not mock WebSockets, and has a dedicated smoke entrypoint at `cd apps/ui && npm run test:smoke:mock`.
-- Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py`, and repo/frontend hygiene guards live in `tools/dev/check_hygiene.py`; both run via `make lint`.
-- Committed test-looking files are inventory-guarded in `tools/dev/check_hygiene.py`. New `test_*.py`, `*.spec.ts`, `benchmark_*.py`, and `firmware/esp/test/**/test_main.cpp` files must either map to a runner or, for intentional standalone benchmark scripts, carry a reason in `tools/dev/test_inventory_allowlist.yml`.
-- Pytest marker usage is also guardrailed in `tools/dev/check_hygiene.py`, with compact-path `smoke`, opt-in `long_sim`, and any `tests_e2e` file exemptions documented in `tools/dev/test_marker_policy_allowlist.yml`. The fast E2E lane uses `e2e and not long_sim`.
-- Oversized tracked test/spec files are guarded in `tools/dev/check_hygiene.py` with the allowlist at `tools/dev/oversized_test_allowlist.yml`. Files at or above the shared threshold must either be split or carry an explicit allowlist reason, and the hygiene output always prints the current largest tracked test/spec files.
-- `make sync-contracts` is the authoritative contract/doc regeneration path; `make lint` and the `backend-contract-drift` CI job run it in `--check` mode.
+## Quick router
 
-### Frontend HTTP tests with MSW
+- Start with `make plan-validation` to turn the current diff into a CI-backed plan.
+- Run planned non-Docker jobs with `./.venv/bin/python tools/tests/plan_validation.py --run`.
+- Use `./.venv/bin/python tools/tests/plan_validation.py --act` or `./tools/tests/run_ci_with_act.sh` only when GitHub workflow/Docker parity is needed.
+- Docs/instruction-only changes: `make docs-lint` plus `make plan-validation`.
+- Fast broad gate: `make test-ci-fast` for lint, docs, static guards, and type checks without heavy suites.
+- Larger non-Docker gate: `make test-ci-lite` for workflow jobs except e2e.
+- Backend iteration: `make test` or targeted `pytest -q apps/server/tests/<module>/`.
+- UI validation: `make ui-typecheck`; add UI test/build commands below when the changed seam requires them.
+- Firmware and Pi image validation: use the narrow commands below; avoid hardware/full image builds unless required.
+- Local `shell-lint` parity needs host `shellcheck`; `make doctor` reports prerequisites. Use ACT for the workflow-managed install path.
 
-Use MSW only for frontend tests that intentionally cross the real HTTP boundary.
-
-- Install the shared lifecycle from `apps/ui/tests/msw/node.ts` for Playwright
-  specs that call the real UI HTTP client. It rewrites relative `/api/...`
-  requests onto the test origin and throws on unhandled requests so missing
-  handlers fail loudly.
-- Keep reusable feature handlers in `apps/ui/tests/msw/handlers/` and cross-feature
-  primitives in `apps/ui/tests/msw/http.ts`. Follow the existing naming pattern:
-  `build<Feature>Handlers(...)`, `build<Feature><Scenario>Handlers(...)`, and
-  `make<Feature><Thing>Payload(...)`.
-- Prefer those shared scenario helpers over ad hoc `globalThis.fetch`
-  replacement when multiple specs in the same feature area need the same HTTP
-  behavior.
-- Do not add MSW to tests that already inject transport ports or stay inside
-  pure presenter/view/state seams. Those tests should remain network-free.
-- WebSocket mocking is outside the MSW boundary here; keep using the dedicated
-  fake WebSocket helpers for live-session flows.
-
-## Layout
-
-The test tree is feature-based. Most directories mirror the backend package or module they cover.
-
-```text
-apps/server/tests/
-├── _paths.py
-├── conftest.py
-├── test_support/
-├── adapters/
-├── app/
-├── domain/
-├── hygiene/
-├── infra/
-├── integration/
-├── shared/
-└── use_cases/
-```
-
-Older flat roots such as `analysis/`, `api/`, `config/`, `gps/`, `history/`,
-`hotspot/`, `metrics_log/`, `processing/`, `protocol/`, `report/`, `update/`,
-and `websocket/` were consolidated into the mirrored tree above. Do not create
-new top-level flat roots; use the matching mirrored area unless the test is
-intentionally cross-cutting.
-
-## Where tests belong
-
-| If you change... | Start with... |
-|---|---|
-| `vibesensor/adapters/http/*` | `apps/server/tests/adapters/http/` |
-| `vibesensor/adapters/{hotspot,pdf,persistence,simulator,udp,websocket}/*` | the matching `apps/server/tests/adapters/.../` directory |
-| `vibesensor/app/*` | `apps/server/tests/app/` |
-| `vibesensor/domain/*` | `apps/server/tests/domain/` |
-| `vibesensor/infra/{config,processing,runtime,workers}/*` | the matching `apps/server/tests/infra/.../` directory |
-| `vibesensor/shared/boundaries/*`, `vibesensor/shared/types/sensor_frame.py`, shared helper utilities | `apps/server/tests/shared/` |
-| Shared types and metadata contracts used across the domain boundary (`run_schema`, `car_config`, `sensor_config`, `speed_source_config`, `settings_snapshot`, `settings_types`) | `apps/server/tests/domain/` or `apps/server/tests/shared/` depending on the ownership boundary under test |
-| `vibesensor/use_cases/{diagnostics,history,run,updates}/*` | the matching `apps/server/tests/use_cases/.../` directory |
-
-Use cross-cutting directories when a test is intentionally broader than one package boundary:
-
-- `apps/server/tests/integration/`: scenario, pipeline, multi-module behavior, and bug-fix regressions spanning multiple subsystems.
-- `apps/server/tests/hygiene/`: architecture guards and repo hygiene.
-
-Those two directories are the intentional flat exceptions to the mirrored tree.
-
-Regression tests live alongside the feature they primarily test. Cross-cutting
-regressions that span multiple subsystems go in `integration/`.
-
-Prefer focused files grouped by behavior or maintenance boundary. Shared helpers live in `test_support/` — including `findings.py` (shared finding-payload factories), `report_helpers.py`, `scenario_ground_truth.py`, `sample_scenarios.py`, plus focused modules for synthetic data, assertions, and fault/perturbation scenarios. Per-directory helper modules (like `_report_pdf_test_helpers.py`, `_report_persistence_helpers.py`) stay local to their test directories.
-
-If a guard needs AST or source-text inspection of production modules, put backend-specific checks in `tools/dev/verify_backend_static_guards.py` and repo/frontend boundary checks in `tools/dev/check_hygiene.py` instead of re-parsing source inside pytest. Hygiene tests should call those helpers through stable module interfaces rather than duplicating the source inspection logic. Oversized test/spec guardrails also belong in `tools/dev/check_hygiene.py`, with intentional exceptions documented in `tools/dev/oversized_test_allowlist.yml` rather than hidden in ad-hoc test code.
-
-## Contract bridge tests
-
-Contract bridge tests live in `apps/server/tests/integration/` and validate that data produced by one subsystem is accepted by the next. They catch schema drift at subsystem boundaries that unit tests miss.
-
-| File | Boundary |
-|---|---|
-| `test_contract_analysis_report.py` | `summarize_run_data()` → `prepare_report_input()` → `build_report_document()` |
-| `test_contract_persistence_analysis.py` | `HistoryDB` write → read → `summarize_run_data()` |
-
-These tests are marked `smoke`, run in standard CI, use minimal synthetic data,
-and complete in under 5 seconds.
-
-## Running tests
-
-Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `./.venv/bin/python tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-fast` for lint/docs/static/typecheck gates without heavy suites, `make test-ci-lite` for non-Docker workflow jobs except e2e, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity. `make ui-typecheck` includes the UI Biome formatter drift check before lint/dependency/type gates. Local `shell-lint` runs need host `shellcheck`; use ACT if you need the workflow-managed install path.
-
-Main local tiers:
+## Command tiers
 
 ```bash
-# CI-backed changed-file validation plan
 make plan-validation
 ./.venv/bin/python tools/tests/plan_validation.py --run
 ./.venv/bin/python tools/tests/plan_validation.py --act
 
-# Changed-file heuristic (current branch vs origin/main, fallback to main)
+make docs-lint
 make test-changed
-
-# Generated dense post-run golden replay subset
-make test-golden-replay
-
-# Fast iteration — backend unit tests
-make test
-
-# Fast non-Docker CI gates, then larger non-Docker CI except e2e
 make test-ci-fast
 make test-ci-lite
-
-# Full local runner
 make test-all
+make test-full-suite
 
-# Explicit backend benchmarks
-make benchmark-backend BENCHMARK_OPTS="--benchmark-save=baseline"
-make benchmark-golden-replay BENCHMARK_OPTS="--benchmark-save=golden-replay"
-make benchmark-compare-backend
-
-# GitHub workflow via act (requires Docker); default wrapper is changed-scope
-./tools/tests/run_ci_with_act.sh
-```
-
-Focused feature-area and fuzzing runs:
-
-```bash
 pytest -q apps/server/tests/adapters/pdf/
 pytest -q apps/server/tests/use_cases/history/
 pytest -q apps/server/tests/use_cases/updates/
 pytest -q apps/server/tests/integration/
-python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100 --processes 16
 ```
 
-Explicit backend benchmark files stay out of default CI and normal pytest
-discovery so the blocking lanes do not turn noisy or hardware-sensitive.
-Run them on demand when you need regression evidence and save comparison data
-for later runs with `make benchmark-backend` / `make benchmark-compare-backend`.
-The generated dense post-run golden replay fixtures live in
-`apps/server/tests/test_support/golden_replay.py`; they avoid binary payloads by
-building deterministic raw waveforms and summary context from fixture seeds. Add
-new cases by extending the fixture catalog with expected source, confidence
-range, unavailable context reasons, and tolerance bands, then run
-`make test-golden-replay`. Use `make benchmark-golden-replay` for the opt-in
-30-minute dense replay benchmark. Failed golden runs write compact JSON
-snapshots under the pytest temp directory for debugging.
-
-Focused CI job groups and full-stack validation:
+Benchmarks and fuzzers are opt-in evidence, not default validation:
 
 ```bash
-./.venv/bin/python tools/tests/run_ci_parallel.py --ci-lite
-./.venv/bin/python tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-smoke
-./.venv/bin/python tools/tests/run_ci_parallel.py --job release-smoke
-make test-full-suite
+make benchmark-backend BENCHMARK_OPTS="--benchmark-save=baseline"
+make benchmark-golden-replay BENCHMARK_OPTS="--benchmark-save=golden-replay"
+make benchmark-compare-backend
+make test-golden-replay
+python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100 --processes 16
+python3 tools/dev/fuzz_processing_pipeline.py --target fft --duration-s 60 --processes 16
 ```
 
-Prefer the Makefile targets after `make setup`; they resolve the repo virtualenv
-Python automatically. Direct local CI runner scripts also self-check the
-`.python-version` major/minor and stop with a targeted setup hint if an ambient
-Python such as system `python3` is wrong.
+Direct pytest benchmark runs need `-o addopts=''` so default xdist addopts do not disable benchmark mode.
 
-When multiple selected local jobs have GitHub `needs` relationships,
-`run_ci_parallel.py` runs them in dependency waves and skips selected downstream
-jobs if a selected prerequisite fails. If you select only the downstream job, the
-runner reports the omitted prerequisite so the local-vs-GitHub ordering gap is
-visible. Workflow-only prerequisites that are substituted locally, such as CI
-artifact builder jobs, are reported as non-runnable local dependencies.
+## Backend test placement
 
-`release-smoke` is the packaged-artifact gate. It builds or reuses the server
-wheel, validates packaged static assets, boots the packaged server, and checks
-that `/api/health` reaches readiness. In GitHub CI it now consumes the
-same-commit `release-smoke-ui-static` artifact built after `frontend-typecheck`
-and runs `tools/tests/run_release_smoke.py --skip-ui-build` so the final smoke
-job validates packaged assets without rebuilding the UI from source again. That
-artifact build still runs `npm run sync:generated-contracts` to materialize the
-UI-only derivative files on a fresh checkout, but it now switches to the
-prevalidated-contracts build path instead of re-running the late
-`check:contracts` gate already owned by `backend-contract-drift` and
-`frontend-typecheck`. It is complementary to Docker/e2e validation, not a
-duplicate of it.
+`apps/server/tests/` mirrors backend package ownership:
+
+| Production change | Test start |
+|---|---|
+| `vibesensor/adapters/http/*` | `apps/server/tests/adapters/http/` |
+| `vibesensor/adapters/{hotspot,pdf,persistence,simulator,udp,websocket}/*` | matching `apps/server/tests/adapters/.../` |
+| `vibesensor/app/*` | `apps/server/tests/app/` |
+| `vibesensor/domain/*` | `apps/server/tests/domain/` |
+| `vibesensor/infra/{config,processing,runtime,workers}/*` | matching `apps/server/tests/infra/.../` |
+| `vibesensor/shared/*` | `apps/server/tests/shared/` or `domain/` when testing domain-owned contracts |
+| `vibesensor/use_cases/{diagnostics,history,run,updates}/*` | matching `apps/server/tests/use_cases/.../` |
+
+- Cross-cutting regressions go in `apps/server/tests/integration/`.
+- Architecture/repo guards go in `apps/server/tests/hygiene/` or the owning guard script.
+- Shared helpers live in `apps/server/tests/test_support/`.
+- Do not create old flat roots such as `analysis/`, `api/`, `config/`, `gps/`, `history/`, `hotspot/`, `metrics_log/`, `processing/`, `protocol/`, `report/`, `update/`, or `websocket/`.
+- Contract bridge tests live in `apps/server/tests/integration/` and validate subsystem handoffs such as analysis -> report and persistence -> analysis.
+
+## Backend test rules
+
+- Python test config lives in `apps/server/pyproject.toml`.
+- Backend pytest uses `pytest-randomly`; reproduce order failures with the printed `--randomly-seed=<seed>`. Disable it only to isolate tooling, not to hide order-dependence.
+- Use `pytest-httpx` for backend outbound HTTP boundary tests.
+- Put AST/import guards in `tools/dev/verify_backend_static_guards.py`; repo/frontend hygiene guards live in `tools/dev/check_hygiene.py`. Both run via `make lint`.
+- New test-looking files must map to a runner or be explicitly allowed in `tools/dev/test_inventory_allowlist.yml`.
+- Marker policy lives in `tools/dev/test_marker_policy_allowlist.yml`. Use `smoke`, `long_sim`, and `e2e` sparingly.
+- Oversized test/spec guardrails live in `tools/dev/check_hygiene.py`; intentional exceptions require a reason in `tools/dev/oversized_test_allowlist.yml`.
+- For cached helpers, clear caches in tests that monkeypatch underlying files, paths, or cached state.
 
 ## Frontend validation
-
-Use the standard UI workflow for `apps/ui/**` changes:
 
 ```bash
 make ui-typecheck
 cd apps/ui && npm run test:unit
 cd apps/ui && npm run build
 cd apps/ui && npm run test:visual
-cd apps/ui && npm run test:visual:audit   # optional broader visual sweep
+cd apps/ui && npm run test:visual:audit
 ./.venv/bin/python tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke
 ```
 
-The UI has three test layers; pick the one that matches the seam under test:
+| Layer | Runner | Use for |
+|---|---|---|
+| Unit/integration | `npm run test:unit` | logic below browser boundary, payload decoders, runtime helpers, feature workflows, pure view helpers |
+| Smoke | `npm run test:smoke` | end-to-end flows against a real Vite dev/preview server |
+| Visual/snapshot | `npm run test:visual` | rendered-state regression baselines |
 
-| Layer | Runner | What it covers | Command |
-|-------|--------|----------------|---------|
-| Unit / integration | Vitest + `happy-dom` | Logic-heavy modules below the browser boundary (payload decoders, runtime helpers, feature workflows, signal-mounted islands, view-level pure helpers) | `npm run test:unit` |
-| Smoke | Playwright (Chromium) | End-to-end flows against a real Vite dev/preview server; file pattern `tests/smoke*.spec.ts` | `npm run test:smoke` |
-| Visual / snapshot | Playwright (Chromium) | Rendered-state regression baselines under `tests/snapshots/`; file pattern `tests/visual.spec.ts` | `npm run test:visual` |
+- `make ui-typecheck` materializes generated UI contracts, then runs format/lint/type gates.
+- Use `npm run test:visual:update` only for intentional baseline changes.
+- Use shared MSW helpers under `apps/ui/tests/msw/` for frontend tests that intentionally cross the real HTTP boundary. They normalize relative `/api/...` requests and fail unhandled requests loudly.
+- Do not add MSW to tests that inject transport ports or stay inside presenter/view/state seams. Keep WebSocket mocking on the dedicated fake WebSocket helpers.
+- Optional browser-worker MSW mode: `cd apps/ui && npm run dev:mock`; smoke entrypoint `cd apps/ui && npm run test:smoke:mock`.
 
-- `npm run test:unit` is the canonical fast test lane. It auto-discovers
-  `tests/**/*.spec.ts` and excludes the Playwright-owned browser/visual/smoke
-  specs via [`apps/ui/vitest.config.ts`](../apps/ui/vitest.config.ts). Prefer it
-  for anything that does not need a real browser.
-- `npm run test:visual` is the rendered-state and snapshot gate; use
-  `npm run test:visual:update` only for intentional baseline changes.
-- `npm run test:visual:audit` is the opt-in four-project visual audit sweep
-  when you need dark/tablet coverage on purpose instead of in the default lane.
-- `frontend-quality` is the UI lint/tooling gate: it runs Biome,
-  dependency-cruiser, and knip. `frontend-typecheck` is the generated-contract
-  and TypeScript gate: it syncs generated contract artifacts, then runs
-  `npm run typecheck`. `ui-unit` runs the Vitest suite and `ui-smoke` is the CI
-  browser path. Use `act -j frontend-quality -W .github/workflows/ci.yml`,
-  `act -j frontend-typecheck -W .github/workflows/ci.yml`,
-  `act -j ui-unit -W .github/workflows/ci.yml`, or
-  `act -j ui-smoke -W .github/workflows/ci.yml` when you need GitHub-workflow
-  parity for those jobs.
-
-## Firmware and Pi-image validation
-
-Use the narrowest existing validation path that matches the layer you changed:
+## Firmware and Pi image validation
 
 ```bash
 cd firmware/esp && pio run
 python tools/firmware/generate_protocol_contract_fixtures.py --check
 cd firmware/esp && pio test -e native
+
 BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh
 BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh
-./infra/pi-image/pi-gen/validate-image.sh
+./infra/pi-image/pi-gen/validate-image.sh [artifact]
 ./.venv/bin/python tools/tests/run_ci_parallel.py --job release-smoke
 ```
 
-- Use `cd firmware/esp && pio run` for firmware compile coverage.
-- Use the protocol fixture check plus `cd firmware/esp && pio test -e native`
-  when firmware/protocol changes need CI firmware-lane parity.
-- Use `pio run -t upload` and `pio device monitor` only when hardware-backed
-  firmware behavior needs confirmation.
-- Use `BUILD_MODE=app` for packaged app artifact changes, `BUILD_MODE=image` for
-  image-stage logic, and `validate-image.sh` to rerun image validation without a
-  rebuild. `BUILD_MODE=all` is only needed when both layers changed.
-- `release-smoke` validates packaged server/UI artifacts; it complements the
-  full Pi-image build rather than replacing it.
+- Use `pio run -t upload` and `pio device monitor` only when hardware-backed firmware behavior needs confirmation.
+- Use `BUILD_MODE=app` for packaged app artifacts, `BUILD_MODE=image` for image-stage logic, and `validate-image.sh` for existing artifacts. `BUILD_MODE=all` is only for changes spanning both layers.
+- Do not use ACT for `.github/workflows/manual-pi-image-arm.yml` or `.github/workflows/weekly-pi-image.yml`; those require GitHub's `ubuntu-24.04-arm` runner label, intentionally not mapped in `.actrc`.
+- `release-smoke` validates packaged server/UI artifacts; it complements, not replaces, Pi-image validation.
 
-## Fuzzing
+## Local CI with ACT
 
-Use `tools/dev/fuzz_analysis_engine.py` for randomized diagnostics coverage
-against the real `summarize_run_data()` analysis entrypoint. The harness uses
-Hypothesis, validates the produced summary against the typed analysis contract,
-and writes a minimized reproduction artifact under `artifacts/fuzz/` when it
-finds a failure.
+Use the wrapper unless raw ACT flags are necessary. The default wrapper mode is a changed-scope ACT run as a `pull_request` event; `--full-stack` forces a forced full-stack ACT run.
 
 ```bash
-python3 tools/dev/fuzz_analysis_engine.py
-python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100 --processes 16
-python3 tools/dev/fuzz_processing_pipeline.py
-python3 tools/dev/fuzz_processing_pipeline.py --target fft --duration-s 60 --processes 16
-```
-
-The script expects the backend package plus dev dependencies to be installed,
-for example via:
-
-```bash
-.venv/bin/python -m pip install -e "./apps/server[dev]"
-```
-
-`tools/dev/fuzz_processing_pipeline.py` covers upstream live-processing entry
-points that sit before persisted diagnostics:
-
-- `strength`: canonical vibration-strength math in `vibesensor.vibration_strength`
-- `fft`: pure FFT spectrum assembly in `vibesensor.shared.fft_analysis`
-- `processor`: live ingest / compute / debug payload paths in `SignalProcessor`
-
-Both fuzzers default to 16 concurrent worker processes. Use `--processes` to
-tune parallelism if you need to trade off CPU saturation against local
-interactivity. `--threads` remains accepted as a compatibility alias.
-
-## Characterization
-
-Use `python3 -m vibesensor.cli.characterize_aliasing` to inspect which
-out-of-band tones can fold into the current live-analysis band for the
-configured sample rate and FFT setup:
-
-```bash
-python3 -m vibesensor.cli.characterize_aliasing
-```
-
-The tool characterizes the current **digital** chain only. It does not replace
-hardware sweep tests of the physical sensor/front-end.
-
-## Local CI with `act`
-
-[`act`](https://nektosact.com/) runs the real `.github/workflows/ci.yml` locally
-inside Docker containers. It is the primary path for CI-parity validation.
-
-Prerequisites: Docker and [`act`](https://nektosact.com/installation/index.html).
-
-### Raw `act` commands (primary interface)
-
-```bash
-# List available CI jobs
-act -l -W .github/workflows/ci.yml
-
-# Run changed-scope CI jobs for the current branch as a pull_request event.
-# Generate the event first so ci-scope sees real base/head SHAs.
-python3 tools/tests/act_event.py --output /tmp/vibesensor-act-event.json
-act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
-
-# Force a full-stack workflow run through ci-scope.
-act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json \
-  --env VIBESENSOR_CI_FORCE_FULL_STACK=1
-
-# Run a single job
-act -j backend-lint -W .github/workflows/ci.yml
-act -j repo-hygiene -W .github/workflows/ci.yml
-act -j backend-static-guards -W .github/workflows/ci.yml
-act -j backend-preflight -W .github/workflows/ci.yml
-act -j docs-lint -W .github/workflows/ci.yml
-act -j backend-contract-drift -W .github/workflows/ci.yml
-act -j backend-typecheck -W .github/workflows/ci.yml
-act -j frontend-quality -W .github/workflows/ci.yml
-act -j frontend-typecheck -W .github/workflows/ci.yml
-act -j backend-tests -W .github/workflows/ci.yml
-act -j ui-smoke -W .github/workflows/ci.yml
-act -j release-smoke -W .github/workflows/ci.yml
-
-# Use a non-default base ref when needed.
-python3 tools/tests/act_event.py --base-ref main --output /tmp/vibesensor-act-event.json
-act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
-```
-
-### Optional wrapper (convenience only)
-
-A thin shell wrapper is provided at `tools/tests/run_ci_with_act.sh`. It checks
-prerequisites, generates a temporary pull-request event from the local checkout
-using `origin/main` then `main` as the base-ref fallback, and passes remaining
-arguments through to `act`:
-
-```bash
-./tools/tests/run_ci_with_act.sh -l               # list jobs
-./tools/tests/run_ci_with_act.sh                   # changed-scope ACT run as pull_request
-./tools/tests/run_ci_with_act.sh --full-stack      # forced full-stack ACT run
-./tools/tests/run_ci_with_act.sh -j backend-lint  # run one job as pull_request
-./tools/tests/run_ci_with_act.sh -j backend-tests # run backend test matrix job
+./tools/tests/run_ci_with_act.sh -l
+./tools/tests/run_ci_with_act.sh
+./tools/tests/run_ci_with_act.sh --full-stack
+./tools/tests/run_ci_with_act.sh -j backend-lint
+./tools/tests/run_ci_with_act.sh -j backend-tests
 ./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 ```
 
-For ACT `-j`, use raw GitHub workflow job ids from `.github/workflows/ci.yml`
-such as `backend-tests`. Do not use the local logical backend shard ids
-`backend-tests-1` through `backend-tests-5` with ACT.
-
-### Secrets
-
-No secrets are currently required. If needed in the future, copy
-`.secrets.act.example` to `.secrets.act`, fill in values, and the wrapper (or
-`--secret-file .secrets.act`) will pick them up. Never commit `.secrets.act`.
-
-### Known limitations under `act`
-
-ACT parity is currently scoped to `.github/workflows/ci.yml`. Do not use ACT for
-the Pi-image workflows `manual-pi-image-arm.yml` or `weekly-pi-image.yml`: they
-run on GitHub's `ubuntu-24.04-arm` runner label, and `.actrc` intentionally does
-not map that ARM runner to a local container image. Validate Pi-image changes
-with the supported local path instead:
+Raw equivalents:
 
 ```bash
-BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh
-BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh
-./infra/pi-image/pi-gen/validate-image.sh
+act -l -W .github/workflows/ci.yml
+python3 tools/tests/act_event.py --output /tmp/vibesensor-act-event.json
+act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
+act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json --env VIBESENSOR_CI_FORCE_FULL_STACK=1
+act -j backend-lint -W .github/workflows/ci.yml
+act -j backend-tests -W .github/workflows/ci.yml
 ```
 
-| Job | Status | Notes |
-|---|---|---|
-| `backend-lint` | ✅ Fully supported | — |
-| `repo-hygiene` | ✅ Fully supported | — |
-| `backend-static-guards` | ✅ Fully supported | — |
-| `backend-preflight` | ✅ Fully supported | — |
-| `docs-lint` | ✅ Fully supported | — |
-| `backend-contract-drift` | ✅ Fully supported | — |
-| `backend-typecheck` | ✅ Fully supported | — |
-| `frontend-quality` | ✅ Fully supported | — |
-| `frontend-typecheck` | ✅ Fully supported | — |
-| `ui-smoke` | ✅ Fully supported | — |
-| `release-smoke` | ✅ Fully supported | — |
-| `backend-tests` | ✅ Fully supported | This matrix job emits the `Backend tests (shard 1/5)` through `Backend tests (shard 5/5)` checks. Update-module workflow tests now patch tool lookup and privilege checks through shared fakes, so missing `nmcli` or non-root host state does not create `act`-only flakes. |
-| `e2e` | ✅ Fully supported | Runs isolated server subprocess shards directly; no Docker-in-Docker dependency. |
-| `manual-pi-image-arm.yml` / `weekly-pi-image.yml` | ❌ Not supported | ARM Pi-image workflows use `ubuntu-24.04-arm`, which is not mapped in `.actrc`; use `BUILD_MODE=app`, `BUILD_MODE=image`, and `validate-image.sh` instead. |
+- ACT `-j` uses raw workflow job IDs such as `backend-tests`, not local shard IDs like `backend-tests-1`.
+- No ACT secrets are currently required. If needed later, copy `.secrets.act.example` to `.secrets.act`; never commit it.
+- `run_ci_parallel.py` is a faster non-container local runner. It respects selected GitHub `needs`, reports omitted prerequisites, and expands backend matrix shards as `backend-tests-1` through `backend-tests-5`.
+- Changed-path gating lives in `tools/tests/ci_path_rules.py` and `tools/tests/ci_changed_scope.py`; update workflow wiring and focused hygiene tests together.
 
-### Relationship to `run_ci_parallel.py`
+## CI job reference
 
-`tools/tests/run_ci_parallel.py` (`make test-all`) remains available as a fast
-local convenience runner. Its job surface is derived from
-`.github/workflows/ci.yml`, while `act` remains the primary CI-parity mechanism
-because it runs the actual GitHub workflow file. Use `run_ci_parallel.py` when
-you want a faster non-containerized local run without Docker. The workflow’s raw
-job id is `backend-tests` because GitHub expands it as a matrix, while
-`run_ci_parallel.py` expands that same matrix source back into logical local
-jobs `backend-tests-1` through `backend-tests-5` so you can run individual
-backend shards directly. The path-planning `ci-scope` job stays workflow-only;
-it feeds GitHub job gating but is intentionally excluded from the local
-manifest-backed runner surface.
+Blocking job names come from `.github/workflows/ci.yml`. Common local job selectors:
 
-### Path-aware CI gating
+```bash
+./.venv/bin/python tools/tests/run_ci_parallel.py --ci-lite
+./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck
+./.venv/bin/python tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke
+./.venv/bin/python tools/tests/run_ci_parallel.py --job release-smoke
+```
 
-Changed-path gating lives in `tools/tests/ci_path_rules.py` and is applied by
-the workflow’s `ci-scope` job via `tools/tests/ci_changed_scope.py`. Keep those
-rules explicit, documented, and test-backed.
+Path-aware CI intent:
 
-The current gating contract is:
+- docs-only markdown changes run `docs-lint`;
+- frontend-only changes run repo hygiene, frontend quality/typecheck, UI unit/smoke, and release smoke;
+- backend-only changes run backend quality/typecheck/tests plus release smoke and e2e;
+- firmware-only changes run firmware native tests;
+- workflow/CI meta changes fall back to full stack.
 
-- docs-only markdown changes run `docs-lint` without the backend, frontend, release, firmware, or e2e stacks
-- frontend-only changes run `repo-hygiene`, `frontend-quality`, `frontend-typecheck`, `ui-unit`, `ui-smoke`, and `release-smoke`
-- backend-only changes run the split backend quality gates, `backend-typecheck`, `backend-tests`, `release-smoke`, and `e2e`
-- firmware-only changes run `firmware-native-tests`
-- workflow / CI meta changes such as `.github/workflows/ci.yml`, `Makefile`, version pins, Dockerfiles, and workflow-manifest tooling fall back to the full stack
-
-When you change these rules, update both the workflow wiring and the focused
-hygiene tests so path scope does not silently drift.
-
-## Coverage reporting
-
-Use coverage runs to expose untested paths before they become release risk.
+## Coverage and characterization
 
 ```bash
 make coverage
-
-# Optional pytest-cov overrides pass through COV_OPTS.
 COV_OPTS="--cov-report=html --cov-report=term-missing:skip-covered" make coverage
-COV_OPTS="--cov-fail-under=80 --cov-report=term-missing:skip-covered" make coverage
-```
-
-For direct control over thresholds and output:
-
-```bash
 cd apps/server && python -m pytest -q --cov=vibesensor --cov-report=term-missing:skip-covered tests
+python3 -m vibesensor.cli.characterize_aliasing
 ```
 
-Coverage guidance:
-
-- Treat coverage as a risk-finding tool, not the only quality signal.
-- High-risk backend areas such as `apps/server/vibesensor/use_cases/diagnostics/`,
-  `apps/server/vibesensor/infra/processing/`,
-  `apps/server/vibesensor/adapters/persistence/history_db/`, and
-  `apps/server/vibesensor/use_cases/updates/` should stay above the repo-wide
-  baseline whenever practical.
-
-The default CI-parity suite now derives these blocking GitHub checks from the
-workflow-backed CI manifest:
-
-- `backend-lint`: Ruff lint and formatter drift checks for backend and tooling Python code.
-- `repo-hygiene`: line endings plus repo/path/runtime/CI hygiene checks.
-- `backend-static-guards`: import-linter backend architecture contracts plus the
-  remaining repo-specific backend static guards.
-- `backend-preflight`: `pip check`, backend `deptry` dependency-declaration
-  validation, and config preflight validation for dev, docker, and pi configs.
-- `docs-lint`: docs misuse and markdown-link validation.
-- `backend-contract-drift`: WS schema and HTTP API contract drift checks.
-- `backend-typecheck`: mypy on the `vibesensor` backend package; package discovery keeps new backend files checked by default without an internal module denylist.
-- `frontend-quality`: `npm run lint`, `npm run lint:deps`, and `npm run lint:unused` in `apps/ui/`.
-- `frontend-typecheck`: `npm run sync:generated-contracts` and `npm run typecheck` in `apps/ui/`.
-- `release-smoke`: builds packaged UI and a server wheel, then runs the release smoke validator against the built artifact.
-- `ui-smoke`, `backend-tests` (matrix job emitting shard `1/5` through `5/5` checks), `e2e`: required test jobs.
-
-## Adding or moving tests
-
-1. Put the test in the narrowest directory that matches the production ownership boundary.
-2. Keep files focused on one behavior, scenario family, or maintenance boundary.
-3. Reuse shared helpers only when multiple files need the same setup or assertions.
-4. Import `SERVER_ROOT` and `REPO_ROOT` from `_paths.py` instead of using fragile parent traversals.
-
-Cached helpers such as `@lru_cache` are acceptable when they memoize immutable
-test data. If a test monkeypatches the underlying file, path, or other cached
-state, clear the cache in that test before asserting on the changed behavior.
-
-## Markers
-
-| Marker | Meaning |
-|---|---|
-| `e2e` | End-to-end tests |
-| `long_sim` | Longer simulated-run tests |
-| `smoke` | Minimal critical-path checks |
-
-Use markers sparingly:
-
-- `@pytest.mark.smoke`: fast, deterministic, high-signal checks for critical
-  paths such as schema/contract bridges or minimal end-to-end behavior.
-- `@pytest.mark.long_sim`: slower simulated-run tests that intentionally trade
-  speed for more scenario coverage.
-- `@pytest.mark.e2e`: end-to-end tests.
-
-Do not mark every fast unit test as `smoke`; keep it a compact slice that is
-useful for quick feedback.
+Treat coverage as a risk-finding tool, not the only quality signal. High-risk backend areas (`diagnostics`, `infra/processing`, persistence history DB, updates) should stay above the repo baseline when practical.

--- a/firmware/esp/AGENTS.md
+++ b/firmware/esp/AGENTS.md
@@ -1,10 +1,6 @@
 # Firmware agent guidance
 
-Firmware-specific rules live in `../../.github/instructions/firmware.instructions.md`.
-
-Keep `src/main.cpp` as a thin orchestrator. Put queue, sampling, transport, Wi-Fi, LED, config, and status behavior in the matching `src/runtime_*.{h,cpp}` owner.
-
-Keep firmware aligned with `../../docs/protocol.md` and `../../infra/pi-image/pi-gen/README.md`; do not add internet-dependent hotspot boot assumptions.
-
-Default validation:
-- `cd firmware/esp && pio run`
+- Firmware rules: `../../.github/instructions/firmware.instructions.md`.
+- Keep `src/main.cpp` thin; subsystem behavior belongs in `src/runtime_*.{h,cpp}`.
+- Keep protocol/hotspot behavior aligned with `../../docs/protocol.md` and `../../infra/pi-image/pi-gen/README.md`.
+- Validation: `cd firmware/esp && pio run`.

--- a/infra/pi-image/AGENTS.md
+++ b/infra/pi-image/AGENTS.md
@@ -1,12 +1,6 @@
 # Pi image agent guidance
 
-Pi image-specific rules live in `../../.github/instructions/pi-image.instructions.md`.
-
-Keep `pi-gen/build.sh` as a thin coordinator. Host-side helpers belong in `pi-gen/lib/`, tracked stage/config sources belong in `pi-gen/templates/`, and post-build validation belongs in `pi-gen/validate-image.sh`.
-
-Preserve the wheel-first, offline-first image flow.
-
-Default validation:
-- `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh` for packaged app artifact changes.
-- `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh` for image-stage logic.
-- `./infra/pi-image/pi-gen/validate-image.sh [artifact]` to rerun validation against an existing image artifact.
+- Pi image rules: `../../.github/instructions/pi-image.instructions.md`.
+- Keep `pi-gen/build.sh` thin; helpers in `pi-gen/lib/`, tracked sources in `pi-gen/templates/`, validation in `pi-gen/validate-image.sh`.
+- Preserve wheel-first, offline-first image behavior.
+- Validation: `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh`, `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`, or `./infra/pi-image/pi-gen/validate-image.sh [artifact]`.


### PR DESCRIPTION
## Summary

- Shortened always-opened AI guidance, repo map, testing docs, and AGENTS files while preserving functional guardrails.
- Moved updater-specific backend rules into a narrow `.github/instructions/backend-updates.instructions.md`.
- Replaced duplicated command catalogs and workflow prose with concise routers and links to the owning files.

## Before/after size table

| File | Before bytes | After bytes | Delta |
|---|---:|---:|---:|
| `.github/copilot-instructions.md` | 11569 | 5214 | -6355 |
| `.github/instructions/backend.instructions.md` | 4411 | 2533 | -1878 |
| `.github/instructions/backend-updates.instructions.md` | 0 | 1380 | +1380 |
| `.github/instructions/firmware.instructions.md` | 1192 | 915 | -277 |
| `.github/instructions/frontend.instructions.md` | 3083 | 1689 | -1394 |
| `.github/instructions/general.instructions.md` | 10587 | 4984 | -5603 |
| `.github/instructions/pi-image.instructions.md` | 1079 | 999 | -80 |
| `.github/instructions/tests.instructions.md` | 2720 | 1559 | -1161 |
| `docs/ai/repo-map.md` | 9664 | 4194 | -5470 |
| `docs/testing.md` | 30172 | 9849 | -20323 |
| `AGENTS.md` | 782 | 686 | -96 |
| `apps/server/AGENTS.md` | 694 | 676 | -18 |
| `apps/server/tests/AGENTS.md` | 653 | 495 | -158 |
| `apps/ui/AGENTS.md` | 590 | 448 | -142 |
| `firmware/esp/AGENTS.md` | 484 | 343 | -141 |
| `infra/pi-image/AGENTS.md` | 680 | 470 | -210 |
| `docs/README.md` | 5326 | 5496 | +170 |

Tracked high-traffic total: 81860 -> 35418 bytes, net -46442 bytes. `docs/README.md` grew by 170 bytes to list the new updater instruction file required by docs lint.

## Files changed

- `.github/copilot-instructions.md`
- `.github/instructions/*.instructions.md`
- `docs/ai/repo-map.md`
- `docs/testing.md`
- `docs/README.md`
- `AGENTS.md` files at root, backend, backend tests, UI, firmware, and Pi image scopes

## Rules preserved

- Agent autonomy, root-cause investigation, bounded blast-radius scans, tracker updates, blockers, and continuation through branch-caused validation failures.
- Simplicity rules: no speculative shims, compatibility layers, duplicate implementations, stale fallback paths, or old/new parallel paths.
- Backend layer DAG, domain ownership, route/import boundaries, report behavior, JSON serialization, payload type-safety, and backend validation.
- Frontend runtime/features/views ownership, generated contracts, API/WS validation seams, `unknown` boundary handling, no `any`, and UI validation commands.
- Firmware protocol/hotspot alignment, PlatformIO/native protocol validation, and hardware-test limits.
- Pi image wheel-first/offline-first behavior, narrow `BUILD_MODE` validation, templates ownership, and ACT ARM-runner limitation.
- Docs policy, bounded docs scans with `rg`, context/log economy, secrets/security/update-integrity warnings, generated contract drift checks, and PR watcher merge-on-green flow.

## Rules moved and new locations

- Updater package ownership, release JSON typed decoding, `tenacity` import caveat, update integrity, and update validation moved from broad backend instructions to `.github/instructions/backend-updates.instructions.md`.
- Detailed validation and ACT guidance centralized in concise `docs/testing.md`.
- Generic workflow/PR/docs policy removed from local AGENTS files and retained in `.github/instructions/general.instructions.md`.

## High-traffic docs shortened

- `.github/copilot-instructions.md`: now short canonical entrypoint with invariants, validation router, and PR watcher pointer.
- `.github/instructions/general.instructions.md`: compressed global workflow, simplification, docs, validation, PR/CI, and security policy.
- Area instruction files: kept area-specific guardrails and validation commands only.
- `docs/ai/repo-map.md`: now an on-demand navigation index, not a module catalog.
- `docs/testing.md`: now a concise validation/test-placement router.
- AGENTS files: thinned to local routing and validation anchors.

## Duplication removed

- Repeated command catalogs, generic PR flow, generic docs policy, and broad validation prose were removed from area/local files after preserving behavior in canonical or narrower locations.

## Validation run

- `git diff --check`
- `./.venv/bin/python tools/dev/docs_lint.py`
- `./.venv/bin/python tools/tests/plan_validation.py`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/plan_validation.py --run`
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_ci_changed_scope.py::test_act_wrapper_distinguishes_changed_scope_and_full_stack_modes apps/server/tests/hygiene/test_weekly_pi_image_workflow.py::test_arm_pi_image_act_limitation_stays_documented`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-tests-5`

## Known tradeoffs

- The global entrypoint still keeps explicit validation and PR watcher commands because replacing them with generic wording would weaken mandatory behavior.
- Backend DAG and Pi/ACT limitations remain explicit because repo hygiene tests and common agent failures depend on those exact facts.
- Local `make docs-lint` / `make plan-validation` could not run directly because this host lacks `make`; the equivalent Makefile commands were run with the repo virtualenv.
- One local planned-run backend shard hit an unrelated `raw_capture_writer` timeout flake; the targeted test and rerun shard passed.

No functional guardrails were intentionally removed.
