### PR TITLE
Split post-analysis and PDF hotspots

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py
@@ -45,6 +45,18 @@ def _appendix_b_page(c: Canvas, plan: AppendixBRenderPlan) -> None:
     )
     appendix = plan.appendix
     width = PAGE_W - 2 * MARGIN
+    top_y = _draw_appendix_b_top_panels(c, plan=plan, title_y=title_y, width=width)
+    _draw_appendix_b_bottom_panel(c, plan=plan, appendix=appendix, top_y=top_y, width=width)
+
+
+def _draw_appendix_b_top_panels(
+    c: Canvas,
+    *,
+    plan: AppendixBRenderPlan,
+    title_y: float,
+    width: float,
+) -> float:
+    appendix = plan.appendix
     top_h = 114 * mm
     left_w = width * 0.56
     right_w = width - left_w - GAP
@@ -175,7 +187,17 @@ def _appendix_b_page(c: Canvas, plan: AppendixBRenderPlan) -> None:
             )
             - 1.0 * mm
         )
+    return float(top_y)
 
+
+def _draw_appendix_b_bottom_panel(
+    c: Canvas,
+    *,
+    plan: AppendixBRenderPlan,
+    appendix: AppendixBData,
+    top_y: float,
+    width: float,
+) -> None:
     bottom_h = top_y - (MARGIN + 8 * mm)
     bottom_y = MARGIN + 8 * mm
     if appendix.sensor_observation_rows:

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py
@@ -51,9 +51,30 @@ def _appendix_c_page(c: Canvas, plan: AppendixCRenderPlan) -> None:
         width=PAGE_W - 2 * MARGIN,
         page_top=PAGE_H - MARGIN,
     )
-    appendix = plan.appendix
     width = PAGE_W - 2 * MARGIN
+    chain_y = _draw_appendix_c_evidence_chain_panel(c, plan=plan, width=width, title_y=title_y)
+    measurement_y = _draw_appendix_c_measurement_panel(
+        c,
+        plan=plan,
+        width=width,
+        chain_y=chain_y,
+    )
+    _draw_appendix_c_lower_panels(
+        c,
+        plan=plan,
+        width=width,
+        measurement_y=measurement_y,
+    )
 
+
+def _draw_appendix_c_evidence_chain_panel(
+    c: Canvas,
+    *,
+    plan: AppendixCRenderPlan,
+    width: float,
+    title_y: float,
+) -> float:
+    appendix = plan.appendix
     chain_h = _evidence_chain_panel_height(appendix)
     chain_y = title_y - chain_h
     _draw_panel(c, MARGIN, chain_y, width, chain_h, _tr(plan.lang, "REPORT_EVIDENCE_CHAIN_TITLE"))
@@ -122,7 +143,17 @@ def _appendix_c_page(c: Canvas, plan: AppendixCRenderPlan) -> None:
             count="{count}",
         ),
     )
+    return chain_y
 
+
+def _draw_appendix_c_measurement_panel(
+    c: Canvas,
+    *,
+    plan: AppendixCRenderPlan,
+    width: float,
+    chain_y: float,
+) -> float:
+    appendix = plan.appendix
     measurement_h = _measurement_panel_height(appendix)
     measurement_y = chain_y - GAP - measurement_h
     _draw_panel(
@@ -209,7 +240,17 @@ def _appendix_c_page(c: Canvas, plan: AppendixCRenderPlan) -> None:
             count="{count}",
         ),
     )
+    return float(measurement_y)
 
+
+def _draw_appendix_c_lower_panels(
+    c: Canvas,
+    *,
+    plan: AppendixCRenderPlan,
+    width: float,
+    measurement_y: float,
+) -> None:
+    appendix = plan.appendix
     context_w = width * 0.24
     suitability_w = width * 0.31
     trace_w = width - context_w - suitability_w - (2 * GAP)

--- a/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
@@ -8,6 +8,7 @@ in ``diagram_layout``.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from vibesensor.adapters.pdf.diagram_layout import (
@@ -79,6 +80,29 @@ def _fit_vehicle_shell_rect(
 # ── Canvas drawing functions ─────────────────────────────────────────────────
 
 
+@dataclass(frozen=True, slots=True)
+class _VehicleShellContext:
+    x0: float
+    y0: float
+    car_w: float
+    car_h: float
+    color_surface: Any
+    color_border: Any
+    color_row_border: Any
+    color_text_primary: Any
+    hex_color: Any
+
+    @property
+    def center_x(self) -> float:
+        return self.x0 + (self.car_w / 2)
+
+    def px(self, ratio: float) -> float:
+        return self.x0 + (self.car_w * ratio)
+
+    def py(self, ratio: float) -> float:
+        return self.y0 + (self.car_h * ratio)
+
+
 def _draw_vehicle_shell(
     drawing: Any,
     *,
@@ -92,21 +116,34 @@ def _draw_vehicle_shell(
     color_text_primary: Any,
     hex_color: Any,
 ) -> None:
-    from reportlab.graphics.shapes import Circle, Line, Path, Polygon, Rect, String
+    ctx = _VehicleShellContext(
+        x0=x0,
+        y0=y0,
+        car_w=car_w,
+        car_h=car_h,
+        color_surface=color_surface,
+        color_border=color_border,
+        color_row_border=color_row_border,
+        color_text_primary=color_text_primary,
+        hex_color=hex_color,
+    )
+    _draw_vehicle_body(drawing, ctx)
+    _draw_vehicle_windows(drawing, ctx)
+    _draw_vehicle_seams(drawing, ctx)
+    _draw_vehicle_mirrors_and_lights(drawing, ctx)
+    _draw_vehicle_wheels(drawing, ctx)
+    _draw_vehicle_orientation_labels(drawing, ctx)
 
-    center_x = x0 + (car_w / 2)
-    tire_w = max(10.0, car_w * 0.11)
-    tire_h = max(20.0, car_h * 0.12)
 
-    def px(ratio: float) -> float:
-        return x0 + (car_w * ratio)
+def _draw_vehicle_body(drawing: Any, ctx: _VehicleShellContext) -> None:
+    from reportlab.graphics.shapes import Path
 
-    def py(ratio: float) -> float:
-        return y0 + (car_h * ratio)
-
+    center_x = ctx.center_x
+    px = ctx.px
+    py = ctx.py
     body = Path(
-        fillColor=color_surface,
-        strokeColor=color_border,
+        fillColor=ctx.color_surface,
+        strokeColor=ctx.color_border,
         strokeWidth=1.55,
     )
     body.moveTo(center_x, py(0.985))
@@ -121,75 +158,95 @@ def _draw_vehicle_shell(
     body.closePath()
     drawing.add(body)
 
+
+def _draw_vehicle_windows(drawing: Any, ctx: _VehicleShellContext) -> None:
+    from reportlab.graphics.shapes import Path, Polygon
+
     roof_shell = Path(
-        fillColor=hex_color("#ffffff"),
-        strokeColor=color_row_border,
+        fillColor=ctx.hex_color("#ffffff"),
+        strokeColor=ctx.color_row_border,
         strokeWidth=1.0,
     )
-    roof_shell.moveTo(center_x, py(0.79))
-    roof_shell.curveTo(px(0.35), py(0.785), px(0.25), py(0.70), px(0.23), py(0.58))
-    roof_shell.lineTo(px(0.23), py(0.34))
-    roof_shell.curveTo(px(0.25), py(0.24), px(0.35), py(0.18), center_x, py(0.17))
-    roof_shell.curveTo(px(0.65), py(0.18), px(0.75), py(0.24), px(0.77), py(0.34))
-    roof_shell.lineTo(px(0.77), py(0.58))
-    roof_shell.curveTo(px(0.75), py(0.70), px(0.65), py(0.785), center_x, py(0.79))
+    roof_shell.moveTo(ctx.center_x, ctx.py(0.79))
+    roof_shell.curveTo(
+        ctx.px(0.35), ctx.py(0.785), ctx.px(0.25), ctx.py(0.70), ctx.px(0.23), ctx.py(0.58)
+    )
+    roof_shell.lineTo(ctx.px(0.23), ctx.py(0.34))
+    roof_shell.curveTo(
+        ctx.px(0.25), ctx.py(0.24), ctx.px(0.35), ctx.py(0.18), ctx.center_x, ctx.py(0.17)
+    )
+    roof_shell.curveTo(
+        ctx.px(0.65), ctx.py(0.18), ctx.px(0.75), ctx.py(0.24), ctx.px(0.77), ctx.py(0.34)
+    )
+    roof_shell.lineTo(ctx.px(0.77), ctx.py(0.58))
+    roof_shell.curveTo(
+        ctx.px(0.75), ctx.py(0.70), ctx.px(0.65), ctx.py(0.785), ctx.center_x, ctx.py(0.79)
+    )
     roof_shell.closePath()
     drawing.add(roof_shell)
 
     windshield = Polygon(
         [
-            px(0.34),
-            py(0.73),
-            px(0.66),
-            py(0.73),
-            px(0.72),
-            py(0.60),
-            px(0.28),
-            py(0.60),
+            ctx.px(0.34),
+            ctx.py(0.73),
+            ctx.px(0.66),
+            ctx.py(0.73),
+            ctx.px(0.72),
+            ctx.py(0.60),
+            ctx.px(0.28),
+            ctx.py(0.60),
         ],
-        fillColor=hex_color("#f6f9ff"),
-        strokeColor=color_row_border,
+        fillColor=ctx.hex_color("#f6f9ff"),
+        strokeColor=ctx.color_row_border,
         strokeWidth=0.75,
     )
     rear_window = Polygon(
         [
-            px(0.31),
-            py(0.31),
-            px(0.69),
-            py(0.31),
-            px(0.62),
-            py(0.20),
-            px(0.38),
-            py(0.20),
+            ctx.px(0.31),
+            ctx.py(0.31),
+            ctx.px(0.69),
+            ctx.py(0.31),
+            ctx.px(0.62),
+            ctx.py(0.20),
+            ctx.px(0.38),
+            ctx.py(0.20),
         ],
-        fillColor=hex_color("#f6f9ff"),
-        strokeColor=color_row_border,
+        fillColor=ctx.hex_color("#f6f9ff"),
+        strokeColor=ctx.color_row_border,
         strokeWidth=0.75,
     )
     drawing.add(windshield)
     drawing.add(rear_window)
 
-    hood_seam = Path(strokeColor=color_row_border, strokeWidth=0.82)
-    hood_seam.moveTo(px(0.27), py(0.83))
-    hood_seam.curveTo(px(0.37), py(0.79), px(0.63), py(0.79), px(0.73), py(0.83))
+
+def _draw_vehicle_seams(drawing: Any, ctx: _VehicleShellContext) -> None:
+    from reportlab.graphics.shapes import Line, Path
+
+    hood_seam = Path(strokeColor=ctx.color_row_border, strokeWidth=0.82)
+    hood_seam.moveTo(ctx.px(0.27), ctx.py(0.83))
+    hood_seam.curveTo(
+        ctx.px(0.37), ctx.py(0.79), ctx.px(0.63), ctx.py(0.79), ctx.px(0.73), ctx.py(0.83)
+    )
     drawing.add(hood_seam)
 
-    hatch_seam = Path(strokeColor=color_row_border, strokeWidth=0.82)
-    hatch_seam.moveTo(px(0.30), py(0.15))
-    hatch_seam.curveTo(px(0.40), py(0.18), px(0.60), py(0.18), px(0.70), py(0.15))
+    hatch_seam = Path(strokeColor=ctx.color_row_border, strokeWidth=0.82)
+    hatch_seam.moveTo(ctx.px(0.30), ctx.py(0.15))
+    hatch_seam.curveTo(
+        ctx.px(0.40), ctx.py(0.18), ctx.px(0.60), ctx.py(0.18), ctx.px(0.70), ctx.py(0.15)
+    )
     drawing.add(hatch_seam)
 
-    door_left_x = px(0.37)
-    door_right_x = px(0.63)
-    belt_low_y = py(0.42)
-    belt_high_y = py(0.56)
+    door_left_x = ctx.px(0.37)
+    door_right_x = ctx.px(0.63)
+    belt_low_y = ctx.py(0.42)
+    belt_high_y = ctx.py(0.56)
     drawing.add(
         Line(
             door_left_x,
             belt_low_y,
             door_left_x,
             belt_high_y,
-            strokeColor=color_row_border,
+            strokeColor=ctx.color_row_border,
             strokeWidth=0.72,
         ),
     )
@@ -199,84 +256,94 @@ def _draw_vehicle_shell(
             belt_low_y,
             door_right_x,
             belt_high_y,
-            strokeColor=color_row_border,
+            strokeColor=ctx.color_row_border,
             strokeWidth=0.72,
         ),
     )
     drawing.add(
         Line(
-            center_x,
-            py(0.18),
-            center_x,
-            py(0.79),
-            strokeColor=color_row_border,
+            ctx.center_x,
+            ctx.py(0.18),
+            ctx.center_x,
+            ctx.py(0.79),
+            strokeColor=ctx.color_row_border,
             strokeWidth=0.92,
         ),
     )
     drawing.add(
         Line(
-            px(0.29),
-            py(0.47),
-            px(0.71),
-            py(0.47),
-            strokeColor=color_row_border,
+            ctx.px(0.29),
+            ctx.py(0.47),
+            ctx.px(0.71),
+            ctx.py(0.47),
+            strokeColor=ctx.color_row_border,
             strokeWidth=0.62,
         ),
     )
 
-    mirror_fill = hex_color("#ffffff")
+
+def _draw_vehicle_mirrors_and_lights(drawing: Any, ctx: _VehicleShellContext) -> None:
+    from reportlab.graphics.shapes import Circle, Polygon
+
+    mirror_fill = ctx.hex_color("#ffffff")
     mirror_left = Polygon(
         [
-            px(0.15),
-            py(0.70),
-            px(0.07),
-            py(0.67),
-            px(0.12),
-            py(0.63),
+            ctx.px(0.15),
+            ctx.py(0.70),
+            ctx.px(0.07),
+            ctx.py(0.67),
+            ctx.px(0.12),
+            ctx.py(0.63),
         ],
         fillColor=mirror_fill,
-        strokeColor=color_row_border,
+        strokeColor=ctx.color_row_border,
         strokeWidth=0.8,
     )
     mirror_right = Polygon(
         [
-            px(0.85),
-            py(0.70),
-            px(0.93),
-            py(0.67),
-            px(0.88),
-            py(0.63),
+            ctx.px(0.85),
+            ctx.py(0.70),
+            ctx.px(0.93),
+            ctx.py(0.67),
+            ctx.px(0.88),
+            ctx.py(0.63),
         ],
         fillColor=mirror_fill,
-        strokeColor=color_row_border,
+        strokeColor=ctx.color_row_border,
         strokeWidth=0.8,
     )
     drawing.add(mirror_left)
     drawing.add(mirror_right)
 
-    lamp_fill = hex_color("#fff7d9")
-    tail_fill = hex_color("#ffe3e6")
+    lamp_fill = ctx.hex_color("#fff7d9")
+    tail_fill = ctx.hex_color("#ffe3e6")
     for lx, ly, fill in (
-        (px(0.24), py(0.90), lamp_fill),
-        (px(0.76), py(0.90), lamp_fill),
-        (px(0.24), py(0.08), tail_fill),
-        (px(0.76), py(0.08), tail_fill),
+        (ctx.px(0.24), ctx.py(0.90), lamp_fill),
+        (ctx.px(0.76), ctx.py(0.90), lamp_fill),
+        (ctx.px(0.24), ctx.py(0.08), tail_fill),
+        (ctx.px(0.76), ctx.py(0.08), tail_fill),
     ):
         drawing.add(
             Circle(
                 lx,
                 ly,
-                max(2.2, car_w * 0.022),
+                max(2.2, ctx.car_w * 0.022),
                 fillColor=fill,
-                strokeColor=color_row_border,
+                strokeColor=ctx.color_row_border,
                 strokeWidth=0.58,
             ),
         )
 
-    front_axle_y = y0 + (car_h * 0.84)
-    rear_axle_y = y0 + (car_h * 0.16)
-    wheel_x_left = x0 + (car_w * 0.14)
-    wheel_x_right = x0 + (car_w * 0.86)
+
+def _draw_vehicle_wheels(drawing: Any, ctx: _VehicleShellContext) -> None:
+    from reportlab.graphics.shapes import Line, Rect
+
+    tire_w = max(10.0, ctx.car_w * 0.11)
+    tire_h = max(20.0, ctx.car_h * 0.12)
+    front_axle_y = ctx.y0 + (ctx.car_h * 0.84)
+    rear_axle_y = ctx.y0 + (ctx.car_h * 0.16)
+    wheel_x_left = ctx.x0 + (ctx.car_w * 0.14)
+    wheel_x_right = ctx.x0 + (ctx.car_w * 0.86)
     for axle_y in (front_axle_y, rear_axle_y):
         drawing.add(
             Line(
@@ -284,12 +351,12 @@ def _draw_vehicle_shell(
                 axle_y,
                 wheel_x_right,
                 axle_y,
-                strokeColor=color_row_border,
+                strokeColor=ctx.color_row_border,
                 strokeWidth=0.7,
             ),
         )
-    wheel_fill = hex_color("#f7f9fd")
-    wheel_stroke = hex_color(REPORT_COLORS["axis"])
+    wheel_fill = ctx.hex_color("#f7f9fd")
+    wheel_stroke = ctx.hex_color(REPORT_COLORS["axis"])
     for wx, wy in (
         (wheel_x_left, front_axle_y),
         (wheel_x_right, front_axle_y),
@@ -309,25 +376,30 @@ def _draw_vehicle_shell(
                 strokeWidth=1.0,
             ),
         )
+
+
+def _draw_vehicle_orientation_labels(drawing: Any, ctx: _VehicleShellContext) -> None:
+    from reportlab.graphics.shapes import String
+
     drawing.add(
         String(
-            center_x,
-            y0 + car_h + 10.5,
+            ctx.center_x,
+            ctx.y0 + ctx.car_h + 10.5,
             "DIAGRAM_LABEL_FRONT",
             fontName="Helvetica-Bold",
             fontSize=7.5,
-            fillColor=color_text_primary,
+            fillColor=ctx.color_text_primary,
             textAnchor="middle",
         ),
     )
     drawing.add(
         String(
-            center_x,
-            y0 - 11.5,
+            ctx.center_x,
+            ctx.y0 - 11.5,
             "DIAGRAM_LABEL_REAR",
             fontName="Helvetica-Bold",
             fontSize=7.5,
-            fillColor=color_text_primary,
+            fillColor=ctx.color_text_primary,
             textAnchor="middle",
         ),
     )

--- a/apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from vibesensor.adapters.pdf.pdf_drawing import _hex
@@ -10,6 +11,19 @@ from vibesensor.adapters.pdf.pdf_style import FONT, FONT_B, FS_SMALL, REPORT_COL
 from vibesensor.shared.boundaries.reporting.document import TimelineGraphData, TimelineGraphInterval
 
 __all__ = ["run_timeline_graph"]
+
+
+@dataclass(frozen=True, slots=True)
+class _TimelineLayout:
+    legend_y: float
+    plot_x: float
+    plot_y: float
+    plot_w: float
+    plot_h: float
+    detection_lane_h: float
+    detection_lane_gap: float
+    speed_plot_y: float
+    speed_plot_h: float
 
 
 def _format_time_label(seconds: float) -> str:
@@ -47,33 +61,10 @@ def _y_for_speed(
     return plot_y + ((bounded / speed_ceiling_kmh) * plot_h)
 
 
-def run_timeline_graph(
-    timeline_graph: TimelineGraphData,
-    *,
-    tr: Callable[..., str],
-    graph_width: float,
-    graph_height: float,
-    show_title: bool = True,
-) -> Any:
-    """Build and return a ReportLab drawing for the proof-block run timeline."""
-    from reportlab.graphics.shapes import Circle, Drawing, Line, PolyLine, Rect, String
-
-    drawing = Drawing(graph_width, graph_height)
+def _build_layout(*, graph_width: float, graph_height: float, show_title: bool) -> _TimelineLayout:
     top_cursor = graph_height - 4.0
     if show_title:
-        title_y = top_cursor - 5.0
-        drawing.add(
-            String(
-                0.0,
-                title_y,
-                tr("REPORT_TIMELINE_TITLE"),
-                fontName=FONT_B,
-                fontSize=7.5,
-                fillColor=_hex(REPORT_COLORS["text_primary"]),
-            ),
-        )
-        top_cursor = title_y - 10.0
-
+        top_cursor = top_cursor - 5.0 - 10.0
     legend_y = top_cursor - 1.0
     plot_x = 24.0
     plot_y = 12.0
@@ -84,15 +75,72 @@ def run_timeline_graph(
     detection_lane_gap = 4.0
     speed_plot_y = plot_y + detection_lane_h + detection_lane_gap
     speed_plot_h = max(18.0, plot_h - detection_lane_h - detection_lane_gap)
+    return _TimelineLayout(
+        legend_y=legend_y,
+        plot_x=plot_x,
+        plot_y=plot_y,
+        plot_w=plot_w,
+        plot_h=plot_h,
+        detection_lane_h=detection_lane_h,
+        detection_lane_gap=detection_lane_gap,
+        speed_plot_y=speed_plot_y,
+        speed_plot_h=speed_plot_h,
+    )
 
-    speed_legend_x = plot_x + 2.0
-    detection_legend_x = min(plot_x + 78.0, plot_x + plot_w - 34.0)
+
+def run_timeline_graph(
+    timeline_graph: TimelineGraphData,
+    *,
+    tr: Callable[..., str],
+    graph_width: float,
+    graph_height: float,
+    show_title: bool = True,
+) -> Any:
+    """Build and return a ReportLab drawing for the proof-block run timeline."""
+    from reportlab.graphics.shapes import Drawing
+
+    drawing = Drawing(graph_width, graph_height)
+    layout = _build_layout(
+        graph_width=graph_width,
+        graph_height=graph_height,
+        show_title=show_title,
+    )
+    if show_title:
+        _draw_timeline_title(drawing, tr=tr, graph_height=graph_height)
+    _draw_timeline_legend(drawing, tr=tr, layout=layout)
+    _draw_timeline_axes(drawing, timeline_graph=timeline_graph, layout=layout)
+    _draw_timeline_intervals(drawing, timeline_graph=timeline_graph, layout=layout)
+    return drawing
+
+
+def _draw_timeline_title(drawing: Any, *, tr: Callable[..., str], graph_height: float) -> None:
+    from reportlab.graphics.shapes import String
+
+    top_cursor = graph_height - 4.0
+    title_y = top_cursor - 5.0
+    drawing.add(
+        String(
+            0.0,
+            title_y,
+            tr("REPORT_TIMELINE_TITLE"),
+            fontName=FONT_B,
+            fontSize=7.5,
+            fillColor=_hex(REPORT_COLORS["text_primary"]),
+        ),
+    )
+
+
+def _draw_timeline_legend(drawing: Any, *, tr: Callable[..., str], layout: _TimelineLayout) -> None:
+    from reportlab.graphics.shapes import Circle, Line, Rect, String
+
+    speed_legend_x = layout.plot_x + 2.0
+    detection_legend_x = min(layout.plot_x + 78.0, layout.plot_x + layout.plot_w - 34.0)
     drawing.add(
         Line(
             speed_legend_x,
-            legend_y,
+            layout.legend_y,
             speed_legend_x + 10.0,
-            legend_y,
+            layout.legend_y,
             strokeColor=_hex(REPORT_COLORS["brand"]),
             strokeWidth=1.8,
         ),
@@ -100,7 +148,7 @@ def run_timeline_graph(
     drawing.add(
         String(
             speed_legend_x + 13.0,
-            legend_y - 2.6,
+            layout.legend_y - 2.6,
             tr("REPORT_TIMELINE_SPEED_LABEL"),
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -110,7 +158,7 @@ def run_timeline_graph(
     drawing.add(
         Rect(
             detection_legend_x,
-            legend_y - 2.6,
+            layout.legend_y - 2.6,
             10.0,
             4.2,
             fillColor=_hex(REPORT_COLORS["card_error_bg"]),
@@ -121,7 +169,7 @@ def run_timeline_graph(
     drawing.add(
         Circle(
             detection_legend_x + 5.0,
-            legend_y - 0.5,
+            layout.legend_y - 0.5,
             2.2,
             fillColor=_hex(REPORT_COLORS["danger"]),
             strokeColor=_hex(REPORT_COLORS["surface"]),
@@ -131,7 +179,7 @@ def run_timeline_graph(
     drawing.add(
         String(
             detection_legend_x + 13.0,
-            legend_y - 2.6,
+            layout.legend_y - 2.6,
             tr("REPORT_TIMELINE_DETECTIONS_LABEL"),
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -139,12 +187,21 @@ def run_timeline_graph(
         ),
     )
 
+
+def _draw_timeline_axes(
+    drawing: Any,
+    *,
+    timeline_graph: TimelineGraphData,
+    layout: _TimelineLayout,
+) -> None:
+    from reportlab.graphics.shapes import Line, Rect, String
+
     drawing.add(
         Rect(
-            plot_x,
-            plot_y,
-            plot_w,
-            plot_h,
+            layout.plot_x,
+            layout.plot_y,
+            layout.plot_w,
+            layout.plot_h,
             fillColor=_hex(REPORT_COLORS["surface"]),
             strokeColor=_hex(REPORT_COLORS["border"]),
             strokeWidth=0.8,
@@ -152,10 +209,10 @@ def run_timeline_graph(
     )
     drawing.add(
         Rect(
-            plot_x,
-            plot_y,
-            plot_w,
-            detection_lane_h,
+            layout.plot_x,
+            layout.plot_y,
+            layout.plot_w,
+            layout.detection_lane_h,
             fillColor=_hex(REPORT_COLORS["surface_alt"]),
             strokeColor=None,
             strokeWidth=0.0,
@@ -163,22 +220,22 @@ def run_timeline_graph(
     )
     drawing.add(
         Line(
-            plot_x,
-            speed_plot_y - (detection_lane_gap / 2.0),
-            plot_x + plot_w,
-            speed_plot_y - (detection_lane_gap / 2.0),
+            layout.plot_x,
+            layout.speed_plot_y - (layout.detection_lane_gap / 2.0),
+            layout.plot_x + layout.plot_w,
+            layout.speed_plot_y - (layout.detection_lane_gap / 2.0),
             strokeColor=_hex(REPORT_COLORS["table_row_border"]),
             strokeWidth=0.5,
         ),
     )
 
-    mid_y = speed_plot_y + (speed_plot_h / 2.0)
-    for y_value in (speed_plot_y, mid_y, speed_plot_y + speed_plot_h):
+    mid_y = layout.speed_plot_y + (layout.speed_plot_h / 2.0)
+    for y_value in (layout.speed_plot_y, mid_y, layout.speed_plot_y + layout.speed_plot_h):
         drawing.add(
             Line(
-                plot_x,
+                layout.plot_x,
                 y_value,
-                plot_x + plot_w,
+                layout.plot_x + layout.plot_w,
                 y_value,
                 strokeColor=_hex(REPORT_COLORS["table_row_border"]),
                 strokeWidth=0.5,
@@ -187,8 +244,8 @@ def run_timeline_graph(
 
     drawing.add(
         String(
-            plot_x - 4.0,
-            speed_plot_y - 2.0,
+            layout.plot_x - 4.0,
+            layout.speed_plot_y - 2.0,
             "0",
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -198,8 +255,8 @@ def run_timeline_graph(
     )
     drawing.add(
         String(
-            plot_x - 4.0,
-            speed_plot_y + speed_plot_h - 2.0,
+            layout.plot_x - 4.0,
+            layout.speed_plot_y + layout.speed_plot_h - 2.0,
             str(int(round(timeline_graph.speed_ceiling_kmh))),
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -209,8 +266,8 @@ def run_timeline_graph(
     )
     drawing.add(
         String(
-            plot_x,
-            plot_y - 9.0,
+            layout.plot_x,
+            layout.plot_y - 9.0,
             "0",
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -219,8 +276,8 @@ def run_timeline_graph(
     )
     drawing.add(
         String(
-            plot_x + plot_w,
-            plot_y - 9.0,
+            layout.plot_x + layout.plot_w,
+            layout.plot_y - 9.0,
             _format_time_label(timeline_graph.duration_s),
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -229,24 +286,33 @@ def run_timeline_graph(
         ),
     )
 
+
+def _draw_timeline_intervals(
+    drawing: Any,
+    *,
+    timeline_graph: TimelineGraphData,
+    layout: _TimelineLayout,
+) -> None:
+    from reportlab.graphics.shapes import Circle, PolyLine, Rect
+
     speed_line_points: list[float] = []
     for interval in timeline_graph.intervals:
         x_start = _x_for_time(
             t_s=interval.start_t_s,
-            plot_x=plot_x,
-            plot_w=plot_w,
+            plot_x=layout.plot_x,
+            plot_w=layout.plot_w,
             duration_s=timeline_graph.duration_s,
         )
         x_end = _x_for_time(
             t_s=interval.end_t_s,
-            plot_x=plot_x,
-            plot_w=plot_w,
+            plot_x=layout.plot_x,
+            plot_w=layout.plot_w,
             duration_s=timeline_graph.duration_s,
         )
         interval_w = max(1.5, x_end - x_start)
         if interval.has_fault_evidence:
-            detection_bar_y = plot_y + 1.1
-            detection_bar_h = max(3.4, detection_lane_h - 2.2)
+            detection_bar_y = layout.plot_y + 1.1
+            detection_bar_h = max(3.4, layout.detection_lane_h - 2.2)
             drawing.add(
                 Rect(
                     x_start,
@@ -279,14 +345,14 @@ def run_timeline_graph(
             assert band_high is not None
             y_low = _y_for_speed(
                 speed_kmh=min(band_low, band_high),
-                plot_y=speed_plot_y,
-                plot_h=speed_plot_h,
+                plot_y=layout.speed_plot_y,
+                plot_h=layout.speed_plot_h,
                 speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
             )
             y_high = _y_for_speed(
                 speed_kmh=max(band_low, band_high),
-                plot_y=speed_plot_y,
-                plot_h=speed_plot_h,
+                plot_y=layout.speed_plot_y,
+                plot_h=layout.speed_plot_h,
                 speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
             )
             drawing.add(
@@ -304,8 +370,8 @@ def run_timeline_graph(
         if speed_value is not None:
             y_speed = _y_for_speed(
                 speed_kmh=speed_value,
-                plot_y=speed_plot_y,
-                plot_h=speed_plot_h,
+                plot_y=layout.speed_plot_y,
+                plot_h=layout.speed_plot_h,
                 speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
             )
             speed_line_points.extend([x_start, y_speed, x_end, y_speed])
@@ -317,4 +383,3 @@ def run_timeline_graph(
                 strokeWidth=1.8,
             ),
         )
-    return drawing

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -2,52 +2,19 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
-from typing import Any, Literal, NoReturn, Protocol
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
 
 import aiosqlite
 from opentelemetry.trace import SpanKind
 
-from vibesensor.domain import CarOrderReferenceStatus
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.tracing import mark_span_error, start_span
-from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
-from vibesensor.shared.types.raw_capture import RawRunCapture
-from vibesensor.shared.types.run_schema import RunMetadata
-from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
-from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
-from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
-    WholeRunOrderFamilySummaryArtifactBundle,
-)
-from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
-    WholeRunOrderTraceSummaryArtifactBundle,
-)
-from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
-    WholeRunOrderTraceArtifactBundle,
-)
-from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
-    SpatialEvidenceSummary,
-)
-from vibesensor.use_cases.diagnostics.whole_run_context import (
-    WholeRunContextArtifactBundle,
-)
-from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
-    WholeRunDiagnosisSummary,
-)
-from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
-    WholeRunSpatialCoherenceArtifactBundle,
-)
-from vibesensor.use_cases.diagnostics.whole_run_spectra import (
-    WholeRunSpectralArtifactBundle,
-    WholeRunSpectralBuildResult,
-)
-from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.use_cases.run.post_analysis_input import (
     PostAnalysisRunInput,
     build_post_analysis_input,
@@ -69,18 +36,25 @@ from vibesensor.use_cases.run.post_analysis_outcomes import (
     PostAnalysisExecutionSuccess,
     is_retryable_post_analysis_error,
 )
-from vibesensor.use_cases.run.post_analysis_raw_capture_policy import (
-    assess_whole_run_raw_capture_policy,
+from vibesensor.use_cases.run.post_analysis_stage_runner import (
+    PostAnalysisStageFailure,
+    PostAnalysisStageResult,
+    make_stage_result,
+    raise_stage_failure,
+    sync_run_persistence_call,
+    warning_codes,
 )
-from vibesensor.use_cases.run.post_analysis_whole_run_builders import (
-    build_whole_run_artifacts,
-    build_whole_run_context_artifacts,
-    build_whole_run_order_family_summary_artifacts,
-    build_whole_run_order_trace_artifacts,
-    build_whole_run_order_trace_summary_artifacts,
-    build_whole_run_spatial_coherence_artifacts,
-    merge_whole_run_artifact_bundles,
-    whole_run_total_sample_count,
+from vibesensor.use_cases.run.post_analysis_whole_run_pipeline import (
+    WholeRunArtifactBuilder,
+    WholeRunContextBuilder,
+    WholeRunDiagnosisSummaryBuilder,
+    WholeRunOrderFamilySummaryBuilder,
+    WholeRunOrderTraceBuilder,
+    WholeRunOrderTraceSummaryBuilder,
+    WholeRunPipelineStageOutput,
+    WholeRunSpatialCoherenceBuilder,
+    resolve_whole_run_builders,
+    run_whole_run_pipeline_stages,
 )
 from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
     append_run_context_warnings,
@@ -95,31 +69,12 @@ from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
     append_whole_run_spatial_coherence_metadata,
     append_whole_run_spatial_summaries,
     append_whole_run_spectral_metadata,
-    build_diagnosis_summary_rows,
     ranked_whole_run_order_summaries,
     ranked_whole_run_spatial_summaries,
     refresh_report_fallback_metadata,
 )
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _sync_call(db: Any, method_name: str, *args: Any, **kwargs: Any) -> Any:
-    """Invoke ``db.<method_name>`` synchronously from a worker thread.
-
-    If the db exposes a real async method and an engine loop runner, go
-    through that loop so aiosqlite futures resolve on the connection's
-    owning loop. Otherwise (test fakes, sync stubs) fall back to
-    ``asyncio.run`` or direct sync call.
-    """
-    method = getattr(db, method_name)
-    result = method(*args, **kwargs)
-    if asyncio.iscoroutine(result):
-        runner = getattr(db, "_run_on_engine_loop", None)
-        if callable(runner):
-            return runner(result)
-        return asyncio.run(result)
-    return result
 
 
 def _coerce_persisted_analysis(
@@ -147,107 +102,6 @@ class PostAnalysisLoader(Protocol):
     ) -> PostAnalysisLoadResult: ...
 
 
-class WholeRunArtifactBuilder(Protocol):
-    """Injected boundary for building dense whole-run sidecar artifacts."""
-
-    def __call__(
-        self,
-        *,
-        run_id: str,
-        metadata: RunMetadata,
-        raw_capture: RawRunCapture,
-    ) -> WholeRunSpectralBuildResult: ...
-
-
-class WholeRunContextBuilder(Protocol):
-    """Injected boundary for building dense whole-run context sidecars."""
-
-    def __call__(
-        self,
-        *,
-        run: PostAnalysisRunInput,
-        total_sample_count: int | None = None,
-        window_plan: WholeRunWindowPlan | None = None,
-    ) -> WholeRunContextArtifactBundle | None: ...
-
-
-class WholeRunOrderTraceBuilder(Protocol):
-    """Injected boundary for building dense whole-run order-trace sidecars."""
-
-    def __call__(
-        self,
-        *,
-        run: PostAnalysisRunInput,
-        spectral_bundle: WholeRunSpectralArtifactBundle,
-        context_bundle: WholeRunContextArtifactBundle,
-    ) -> WholeRunOrderTraceArtifactBundle | None: ...
-
-
-class WholeRunOrderTraceSummaryBuilder(Protocol):
-    """Injected boundary for building compact whole-run order-trace summaries."""
-
-    def __call__(
-        self,
-        *,
-        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
-        context_bundle: WholeRunContextArtifactBundle,
-    ) -> WholeRunOrderTraceSummaryArtifactBundle | None: ...
-
-
-class WholeRunOrderFamilySummaryBuilder(Protocol):
-    """Injected boundary for building family-level whole-run order summaries."""
-
-    def __call__(
-        self,
-        *,
-        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
-        order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle,
-        context_bundle: WholeRunContextArtifactBundle,
-    ) -> WholeRunOrderFamilySummaryArtifactBundle | None: ...
-
-
-class WholeRunSpatialCoherenceBuilder(Protocol):
-    """Injected boundary for building candidate-level whole-run spatial coherence."""
-
-    def __call__(
-        self,
-        *,
-        run: PostAnalysisRunInput,
-        spectral_bundle: WholeRunSpectralArtifactBundle,
-        context_bundle: WholeRunContextArtifactBundle,
-        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
-    ) -> WholeRunSpatialCoherenceArtifactBundle | None: ...
-
-
-class WholeRunDiagnosisSummaryBuilder(Protocol):
-    """Injected boundary for building compact fused whole-run diagnosis summaries."""
-
-    def __call__(
-        self,
-        *,
-        analysis_metadata: Mapping[str, object],
-        context_bundle: WholeRunContextArtifactBundle,
-        order_summaries: tuple[OrderTraceSummary, ...],
-        spatial_summaries: tuple[SpatialEvidenceSummary, ...],
-        car_order_reference_status: CarOrderReferenceStatus | None,
-    ) -> tuple[WholeRunDiagnosisSummary, ...]: ...
-
-
-type PostAnalysisStageStatus = Literal["ok", "skipped", "degraded", "failed"]
-
-
-@dataclass(frozen=True, slots=True)
-class PostAnalysisStageResult:
-    """Structured result for one executor pipeline stage."""
-
-    stage_name: str
-    status: PostAnalysisStageStatus
-    duration_ms: int
-    artifacts_created: tuple[str, ...] = ()
-    warnings: tuple[str, ...] = ()
-    diagnostic_context: JsonObject = field(default_factory=dict)
-
-
 @dataclass(frozen=True, slots=True)
 class PostAnalysisLoadStageOutput:
     """Output of the load stage before input shaping begins."""
@@ -263,166 +117,6 @@ class PostAnalysisInputStageOutput:
 
     run_input: PostAnalysisRunInput
     stage_result: PostAnalysisStageResult
-
-
-@dataclass(frozen=True, slots=True)
-class WholeRunPipelineStageOutput:
-    """Artifacts and stage reports from the whole-run sidecar pipeline."""
-
-    stage_results: tuple[PostAnalysisStageResult, ...]
-    stored_artifact_manifest: WholeRunArtifactManifest | None = None
-    spectral_result: WholeRunSpectralBuildResult | None = None
-    spectral_bundle: WholeRunSpectralArtifactBundle | None = None
-    context_bundle: WholeRunContextArtifactBundle | None = None
-    order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
-    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
-    order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
-    spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class WholeRunStageExecution[ResultT]:
-    """Stage runner payload before conversion into a public stage result."""
-
-    result: ResultT
-    status: PostAnalysisStageStatus
-    artifact_manifest: WholeRunArtifactManifest | None = None
-    warnings: tuple[str, ...] = ()
-    diagnostic_context: JsonObject = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class ResolvedWholeRunBuilders:
-    """Resolved builder callables used by the explicit whole-run pipeline stages."""
-
-    artifact_builder: WholeRunArtifactBuilder
-    context_builder: WholeRunContextBuilder
-    order_trace_builder: WholeRunOrderTraceBuilder
-    order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder
-    order_family_summary_builder: WholeRunOrderFamilySummaryBuilder
-    spatial_coherence_builder: WholeRunSpatialCoherenceBuilder
-    diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder
-
-
-class PostAnalysisStageFailure(Exception):
-    """Retryable or persistence-bound stage failure with explicit stage metadata."""
-
-    def __init__(self, stage_result: PostAnalysisStageResult, cause: BaseException) -> None:
-        super().__init__(str(cause))
-        self.stage_result = stage_result
-        self.cause = cause
-
-
-def _duration_ms(stage_start: float) -> int:
-    return max(0, int(round((time.monotonic() - stage_start) * 1000)))
-
-
-def _make_stage_result(
-    *,
-    stage_name: str,
-    status: PostAnalysisStageStatus,
-    stage_start: float,
-    artifacts_created: tuple[str, ...] = (),
-    warnings: tuple[str, ...] = (),
-    diagnostic_context: JsonObject | None = None,
-) -> PostAnalysisStageResult:
-    return PostAnalysisStageResult(
-        stage_name=stage_name,
-        status=status,
-        duration_ms=_duration_ms(stage_start),
-        artifacts_created=artifacts_created,
-        warnings=warnings,
-        diagnostic_context={} if diagnostic_context is None else diagnostic_context,
-    )
-
-
-def _artifact_keys(manifest: WholeRunArtifactManifest | None) -> tuple[str, ...]:
-    if manifest is None:
-        return ()
-    return tuple(artifact.artifact_key for artifact in manifest.artifacts)
-
-
-def _warning_codes(warnings: tuple[object, ...]) -> tuple[str, ...]:
-    codes: list[str] = []
-    for warning in warnings:
-        code = getattr(warning, "code", None)
-        if isinstance(code, str) and code:
-            codes.append(code)
-    return tuple(codes)
-
-
-def _bundle_artifact_manifest(
-    bundle: object | None,
-) -> WholeRunArtifactManifest | None:
-    manifest = getattr(bundle, "manifest", None)
-    return manifest if isinstance(manifest, WholeRunArtifactManifest) else None
-
-
-def _stage_execution[ResultT](
-    result: ResultT | None,
-    *,
-    artifact_manifest: WholeRunArtifactManifest | None = None,
-    status_when_present: PostAnalysisStageStatus = "ok",
-    status_when_none: PostAnalysisStageStatus = "skipped",
-    warnings: tuple[str, ...] = (),
-    present_diagnostic_context: JsonObject | None = None,
-    none_reason: str = "builder_returned_none",
-    none_diagnostic_context: JsonObject | None = None,
-) -> WholeRunStageExecution[ResultT | None]:
-    if result is None:
-        diagnostic_context: JsonObject = {"reason": none_reason}
-        if none_diagnostic_context is not None:
-            diagnostic_context = {**none_diagnostic_context, **diagnostic_context}
-        return WholeRunStageExecution(
-            result=None,
-            status=status_when_none,
-            warnings=warnings,
-            diagnostic_context=diagnostic_context,
-        )
-    return WholeRunStageExecution(
-        result=result,
-        status=status_when_present,
-        artifact_manifest=artifact_manifest,
-        warnings=warnings,
-        diagnostic_context=(
-            {} if present_diagnostic_context is None else present_diagnostic_context
-        ),
-    )
-
-
-def _run_whole_run_stage[ResultT](
-    *,
-    stage_name: str,
-    run_id: str,
-    prerequisites_met: bool,
-    prerequisite_reason: str,
-    runner: Callable[[], WholeRunStageExecution[ResultT]],
-) -> tuple[ResultT | None, PostAnalysisStageResult]:
-    stage_start = time.monotonic()
-    if not prerequisites_met:
-        return None, _make_stage_result(
-            stage_name=stage_name,
-            status="skipped",
-            stage_start=stage_start,
-            diagnostic_context={"reason": prerequisite_reason},
-        )
-    try:
-        execution = runner()
-    except (aiosqlite.Error, OSError, MemoryError) as exc:
-        _raise_stage_failure(
-            stage_name=stage_name,
-            stage_start=stage_start,
-            exc=exc,
-            diagnostic_context={"run_id": run_id},
-        )
-    return execution.result, _make_stage_result(
-        stage_name=stage_name,
-        status=execution.status,
-        stage_start=stage_start,
-        artifacts_created=_artifact_keys(execution.artifact_manifest),
-        warnings=execution.warnings,
-        diagnostic_context=execution.diagnostic_context,
-    )
 
 
 def _log_stage_result(run_id: str, stage_result: PostAnalysisStageResult) -> None:
@@ -443,77 +137,6 @@ def _log_stage_result(run_id: str, stage_result: PostAnalysisStageResult) -> Non
             artifacts_created=list(stage_result.artifacts_created),
             warnings=list(stage_result.warnings),
             diagnostic_context=stage_result.diagnostic_context,
-        ),
-    )
-
-
-def _raise_stage_failure(
-    *,
-    stage_name: str,
-    stage_start: float,
-    exc: BaseException,
-    diagnostic_context: JsonObject | None = None,
-) -> NoReturn:
-    raise PostAnalysisStageFailure(
-        _make_stage_result(
-            stage_name=stage_name,
-            status="failed",
-            stage_start=stage_start,
-            diagnostic_context=(
-                {"error_message": str(exc)}
-                if diagnostic_context is None
-                else {**diagnostic_context, "error_message": str(exc)}
-            ),
-        ),
-        exc,
-    ) from exc
-
-
-def resolve_whole_run_builders(
-    *,
-    whole_run_artifact_builder: WholeRunArtifactBuilder | None,
-    whole_run_context_builder: WholeRunContextBuilder | None,
-    whole_run_order_trace_builder: WholeRunOrderTraceBuilder | None,
-    whole_run_order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None,
-    whole_run_order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None,
-    whole_run_spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None,
-    whole_run_diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder | None,
-) -> ResolvedWholeRunBuilders:
-    return ResolvedWholeRunBuilders(
-        artifact_builder=(
-            build_whole_run_artifacts
-            if whole_run_artifact_builder is None
-            else whole_run_artifact_builder
-        ),
-        context_builder=(
-            build_whole_run_context_artifacts
-            if whole_run_context_builder is None
-            else whole_run_context_builder
-        ),
-        order_trace_builder=(
-            build_whole_run_order_trace_artifacts
-            if whole_run_order_trace_builder is None
-            else whole_run_order_trace_builder
-        ),
-        order_trace_summary_builder=(
-            build_whole_run_order_trace_summary_artifacts
-            if whole_run_order_trace_summary_builder is None
-            else whole_run_order_trace_summary_builder
-        ),
-        order_family_summary_builder=(
-            build_whole_run_order_family_summary_artifacts
-            if whole_run_order_family_summary_builder is None
-            else whole_run_order_family_summary_builder
-        ),
-        spatial_coherence_builder=(
-            build_whole_run_spatial_coherence_artifacts
-            if whole_run_spatial_coherence_builder is None
-            else whole_run_spatial_coherence_builder
-        ),
-        diagnosis_summary_builder=(
-            build_diagnosis_summary_rows
-            if whole_run_diagnosis_summary_builder is None
-            else whole_run_diagnosis_summary_builder
         ),
     )
 
@@ -548,7 +171,7 @@ def run_load_run_stage(
                 stage_name=stage_name,
             )
         return PostAnalysisLoadStageOutput(
-            stage_result=_make_stage_result(
+            stage_result=make_stage_result(
                 stage_name=stage_name,
                 status="failed",
                 stage_start=stage_start,
@@ -568,7 +191,7 @@ def run_load_run_stage(
             ),
         )
         return PostAnalysisLoadStageOutput(
-            stage_result=_make_stage_result(
+            stage_result=make_stage_result(
                 stage_name=stage_name,
                 status="failed",
                 stage_start=stage_start,
@@ -593,7 +216,7 @@ def run_load_run_stage(
             ),
         )
         return PostAnalysisLoadStageOutput(
-            stage_result=_make_stage_result(
+            stage_result=make_stage_result(
                 stage_name=stage_name,
                 status="failed",
                 stage_start=stage_start,
@@ -608,7 +231,7 @@ def run_load_run_stage(
         )
 
     return PostAnalysisLoadStageOutput(
-        stage_result=_make_stage_result(
+        stage_result=make_stage_result(
             stage_name=stage_name,
             status="ok",
             stage_start=stage_start,
@@ -630,7 +253,7 @@ def run_build_post_analysis_input_stage(
     try:
         run_input = build_post_analysis_input(loaded)
     except (aiosqlite.Error, OSError, MemoryError) as exc:
-        _raise_stage_failure(
+        raise_stage_failure(
             stage_name=stage_name,
             stage_start=stage_start,
             exc=exc,
@@ -638,7 +261,7 @@ def run_build_post_analysis_input_stage(
         )
     return PostAnalysisInputStageOutput(
         run_input=run_input,
-        stage_result=_make_stage_result(
+        stage_result=make_stage_result(
             stage_name=stage_name,
             status="ok",
             stage_start=stage_start,
@@ -648,236 +271,6 @@ def run_build_post_analysis_input_stage(
                 "sampling_method": run_input.sampling_method,
             },
         ),
-    )
-
-
-def run_whole_run_pipeline_stages(
-    *,
-    db: RunPersistence,
-    loaded: LoadedPostAnalysisRun,
-    run_input: PostAnalysisRunInput,
-    builders: ResolvedWholeRunBuilders,
-) -> WholeRunPipelineStageOutput:
-    stage_results: list[PostAnalysisStageResult] = []
-    spectral_result: WholeRunSpectralBuildResult | None = None
-    spectral_bundle: WholeRunSpectralArtifactBundle | None = None
-    context_bundle: WholeRunContextArtifactBundle | None = None
-    order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
-    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
-    order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
-    spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
-    stored_artifact_manifest: WholeRunArtifactManifest | None = None
-    raw_capture_policy = assess_whole_run_raw_capture_policy(loaded)
-
-    def record_stage[ResultT](
-        *,
-        stage_name: str,
-        prerequisites_met: bool,
-        prerequisite_reason: str,
-        runner: Callable[[], WholeRunStageExecution[ResultT | None]],
-    ) -> ResultT | None:
-        result, stage_result = _run_whole_run_stage(
-            stage_name=stage_name,
-            run_id=loaded.run_id,
-            prerequisites_met=prerequisites_met,
-            prerequisite_reason=prerequisite_reason,
-            runner=runner,
-        )
-        stage_results.append(stage_result)
-        return result
-
-    def run_optional_bundle_stage[BundleT](
-        *,
-        stage_name: str,
-        prerequisites_met: bool,
-        runner: Callable[[], BundleT | None],
-    ) -> BundleT | None:
-        def execute() -> WholeRunStageExecution[BundleT | None]:
-            bundle = runner()
-            return _stage_execution(
-                bundle,
-                artifact_manifest=_bundle_artifact_manifest(bundle),
-            )
-
-        return record_stage(
-            stage_name=stage_name,
-            prerequisites_met=prerequisites_met,
-            prerequisite_reason="missing_prerequisites",
-            runner=execute,
-        )
-
-    def build_spectral_stage() -> WholeRunStageExecution[WholeRunSpectralBuildResult | None]:
-        raw_capture = loaded.raw_capture
-        assert raw_capture is not None
-        result = builders.artifact_builder(
-            run_id=loaded.run_id,
-            metadata=loaded.metadata,
-            raw_capture=raw_capture,
-        )
-        spectral_manifest = result.bundle.manifest if result.bundle is not None else None
-        return _stage_execution(
-            result,
-            artifact_manifest=spectral_manifest,
-            warnings=_warning_codes(tuple(result.coverage_summary.warnings)),
-            present_diagnostic_context={
-                "bundle_available": result.bundle is not None,
-                "coverage_confidence": result.coverage_summary.coverage_confidence,
-            },
-        )
-
-    def build_context_stage() -> WholeRunStageExecution[WholeRunContextArtifactBundle | None]:
-        raw_capture_manifest = raw_capture_policy.manifest
-        assert raw_capture_manifest is not None
-        if spectral_result is not None and spectral_result.window_plan is not None:
-            bundle = builders.context_builder(
-                run=run_input,
-                window_plan=spectral_result.window_plan,
-            )
-            return _stage_execution(
-                bundle,
-                artifact_manifest=_bundle_artifact_manifest(bundle),
-                present_diagnostic_context={"build_mode": "window_plan"},
-                none_diagnostic_context={"build_mode": "window_plan"},
-            )
-        bundle = builders.context_builder(
-            run=run_input,
-            total_sample_count=whole_run_total_sample_count(raw_capture_manifest),
-        )
-        return _stage_execution(
-            bundle,
-            artifact_manifest=_bundle_artifact_manifest(bundle),
-            status_when_present="degraded",
-            present_diagnostic_context={"build_mode": "total_sample_count_fallback"},
-            none_diagnostic_context={"build_mode": "total_sample_count_fallback"},
-        )
-
-    spectral_result = record_stage(
-        stage_name="BuildWholeRunSpectraStage",
-        prerequisites_met=raw_capture_policy.spectra_prerequisites_met(loaded.raw_capture),
-        prerequisite_reason=raw_capture_policy.spectra_prerequisite_reason(loaded.raw_capture),
-        runner=build_spectral_stage,
-    )
-    spectral_bundle = spectral_result.bundle if spectral_result is not None else None
-    context_bundle = record_stage(
-        stage_name="BuildWholeRunContextStage",
-        prerequisites_met=raw_capture_policy.context_prerequisites_met(),
-        prerequisite_reason=raw_capture_policy.context_prerequisite_reason(),
-        runner=build_context_stage,
-    )
-
-    def build_order_trace_stage() -> WholeRunOrderTraceArtifactBundle | None:
-        assert spectral_bundle is not None
-        assert context_bundle is not None
-        return builders.order_trace_builder(
-            run=run_input,
-            spectral_bundle=spectral_bundle,
-            context_bundle=context_bundle,
-        )
-
-    order_trace_bundle = run_optional_bundle_stage(
-        stage_name="BuildOrderTraceStage",
-        prerequisites_met=spectral_bundle is not None and context_bundle is not None,
-        runner=build_order_trace_stage,
-    )
-
-    def build_order_trace_summary_stage() -> WholeRunOrderTraceSummaryArtifactBundle | None:
-        assert order_trace_bundle is not None
-        assert context_bundle is not None
-        return builders.order_trace_summary_builder(
-            order_trace_bundle=order_trace_bundle,
-            context_bundle=context_bundle,
-        )
-
-    order_trace_summary_bundle = run_optional_bundle_stage(
-        stage_name="BuildOrderTraceSummaryStage",
-        prerequisites_met=order_trace_bundle is not None and context_bundle is not None,
-        runner=build_order_trace_summary_stage,
-    )
-
-    def build_order_family_stage() -> WholeRunOrderFamilySummaryArtifactBundle | None:
-        assert order_trace_bundle is not None
-        assert order_trace_summary_bundle is not None
-        assert context_bundle is not None
-        return builders.order_family_summary_builder(
-            order_trace_bundle=order_trace_bundle,
-            order_trace_summary_bundle=order_trace_summary_bundle,
-            context_bundle=context_bundle,
-        )
-
-    order_family_summary_bundle = run_optional_bundle_stage(
-        stage_name="BuildOrderFamilySummaryStage",
-        prerequisites_met=(
-            order_trace_bundle is not None
-            and order_trace_summary_bundle is not None
-            and context_bundle is not None
-        ),
-        runner=build_order_family_stage,
-    )
-
-    def build_spatial_stage() -> WholeRunSpatialCoherenceArtifactBundle | None:
-        assert spectral_bundle is not None
-        assert context_bundle is not None
-        assert order_trace_bundle is not None
-        return builders.spatial_coherence_builder(
-            run=run_input,
-            spectral_bundle=spectral_bundle,
-            context_bundle=context_bundle,
-            order_trace_bundle=order_trace_bundle,
-        )
-
-    spatial_coherence_bundle = run_optional_bundle_stage(
-        stage_name="BuildSpatialSummaryStage",
-        prerequisites_met=(
-            spectral_bundle is not None
-            and context_bundle is not None
-            and order_trace_bundle is not None
-        ),
-        runner=build_spatial_stage,
-    )
-
-    merged_bundle = merge_whole_run_artifact_bundles(
-        spectral_bundle,
-        context_bundle,
-        order_trace_bundle,
-        order_trace_summary_bundle,
-        order_family_summary_bundle,
-        spatial_coherence_bundle,
-    )
-
-    def persist_artifacts_stage() -> WholeRunStageExecution[WholeRunArtifactManifest | None]:
-        assert merged_bundle is not None
-        stored_manifest = _sync_call(
-            db,
-            "astore_whole_run_artifacts",
-            loaded.run_id,
-            merged_bundle.manifest,
-            artifact_contents=merged_bundle.artifact_contents,
-        )
-        if stored_manifest is None:
-            raise OSError(f"Failed to persist whole-run artifacts for run {loaded.run_id}")
-        return _stage_execution(
-            stored_manifest,
-            artifact_manifest=stored_manifest,
-            present_diagnostic_context={"artifact_count": len(stored_manifest.artifacts)},
-        )
-
-    stored_artifact_manifest = record_stage(
-        stage_name="PersistArtifactsStage",
-        prerequisites_met=merged_bundle is not None,
-        prerequisite_reason="no_artifacts_to_persist",
-        runner=persist_artifacts_stage,
-    )
-
-    return WholeRunPipelineStageOutput(
-        stage_results=tuple(stage_results),
-        stored_artifact_manifest=stored_artifact_manifest,
-        spectral_result=spectral_result,
-        spectral_bundle=spectral_bundle,
-        context_bundle=context_bundle,
-        order_trace_bundle=order_trace_bundle,
-        order_trace_summary_bundle=order_trace_summary_bundle,
-        order_family_summary_bundle=order_family_summary_bundle,
-        spatial_coherence_bundle=spatial_coherence_bundle,
     )
 
 
@@ -893,7 +286,7 @@ def run_build_report_facts_stage(
     try:
         summary = _coerce_persisted_analysis(analysis_runner(run_input))
     except (aiosqlite.Error, OSError, MemoryError) as exc:
-        _raise_stage_failure(
+        raise_stage_failure(
             stage_name=stage_name,
             stage_start=stage_start,
             exc=exc,
@@ -969,12 +362,12 @@ def run_build_report_facts_stage(
     if stored_artifact_manifest is not None:
         summary = append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
 
-    return refresh_report_fallback_metadata(summary), _make_stage_result(
+    return refresh_report_fallback_metadata(summary), make_stage_result(
         stage_name=stage_name,
         status="ok",
         stage_start=stage_start,
         warnings=(
-            _warning_codes(tuple(spectral_result.coverage_summary.warnings))
+            warning_codes(tuple(spectral_result.coverage_summary.warnings))
             if spectral_result is not None
             else ()
         ),
@@ -996,15 +389,15 @@ def run_persist_analysis_summary_stage(
     stage_name = "PersistAnalysisSummaryStage"
     stage_start = time.monotonic()
     try:
-        _sync_call(db, "astore_analysis", run_id, summary)
+        sync_run_persistence_call(db, "astore_analysis", run_id, summary)
     except (aiosqlite.Error, OSError, MemoryError) as exc:
-        _raise_stage_failure(
+        raise_stage_failure(
             stage_name=stage_name,
             stage_start=stage_start,
             exc=exc,
             diagnostic_context={"run_id": run_id},
         )
-    return _make_stage_result(
+    return make_stage_result(
         stage_name=stage_name,
         status="ok",
         stage_start=stage_start,
@@ -1139,7 +532,7 @@ def _store_load_error(
     kind: str,
 ) -> PostAnalysisExecutionResult:
     try:
-        _sync_call(db, "astore_analysis_error", run_id, completed_error)
+        sync_run_persistence_call(db, "astore_analysis_error", run_id, completed_error)
     except aiosqlite.Error:
         LOGGER.warning(
             "Failed to store analysis error for run %s",
@@ -1223,7 +616,7 @@ def _persistence_failure_result(
     callback_errors = (callback_error,)
 
     try:
-        _sync_call(db, "astore_analysis_error", run_id, completed_error)
+        sync_run_persistence_call(db, "astore_analysis_error", run_id, completed_error)
     except aiosqlite.Error as store_exc:
         LOGGER.warning(
             "Failed to store analysis error for run %s",

--- a/apps/server/vibesensor/use_cases/run/post_analysis_stage_runner.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_stage_runner.py
@@ -1,0 +1,95 @@
+"""Shared stage result and persistence-call helpers for post-analysis."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any, Literal, NoReturn
+
+from vibesensor.shared.types.json_types import JsonObject
+
+type PostAnalysisStageStatus = Literal["ok", "skipped", "degraded", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisStageResult:
+    """Structured result for one executor pipeline stage."""
+
+    stage_name: str
+    status: PostAnalysisStageStatus
+    duration_ms: int
+    artifacts_created: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    diagnostic_context: JsonObject = field(default_factory=dict)
+
+
+class PostAnalysisStageFailure(Exception):
+    """Retryable or persistence-bound stage failure with explicit stage metadata."""
+
+    def __init__(self, stage_result: PostAnalysisStageResult, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.stage_result = stage_result
+        self.cause = cause
+
+
+def sync_run_persistence_call(db: Any, method_name: str, *args: Any, **kwargs: Any) -> Any:
+    """Invoke ``db.<method_name>`` synchronously from a worker thread."""
+    method = getattr(db, method_name)
+    result = method(*args, **kwargs)
+    if asyncio.iscoroutine(result):
+        runner = getattr(db, "_run_on_engine_loop", None)
+        if callable(runner):
+            return runner(result)
+        return asyncio.run(result)
+    return result
+
+
+def make_stage_result(
+    *,
+    stage_name: str,
+    status: PostAnalysisStageStatus,
+    stage_start: float,
+    artifacts_created: tuple[str, ...] = (),
+    warnings: tuple[str, ...] = (),
+    diagnostic_context: JsonObject | None = None,
+) -> PostAnalysisStageResult:
+    return PostAnalysisStageResult(
+        stage_name=stage_name,
+        status=status,
+        duration_ms=max(0, int(round((time.monotonic() - stage_start) * 1000))),
+        artifacts_created=artifacts_created,
+        warnings=warnings,
+        diagnostic_context={} if diagnostic_context is None else diagnostic_context,
+    )
+
+
+def warning_codes(warnings: tuple[object, ...]) -> tuple[str, ...]:
+    codes: list[str] = []
+    for warning in warnings:
+        code = getattr(warning, "code", None)
+        if isinstance(code, str) and code:
+            codes.append(code)
+    return tuple(codes)
+
+
+def raise_stage_failure(
+    *,
+    stage_name: str,
+    stage_start: float,
+    exc: BaseException,
+    diagnostic_context: JsonObject | None = None,
+) -> NoReturn:
+    raise PostAnalysisStageFailure(
+        make_stage_result(
+            stage_name=stage_name,
+            status="failed",
+            stage_start=stage_start,
+            diagnostic_context=(
+                {"error_message": str(exc)}
+                if diagnostic_context is None
+                else {**diagnostic_context, "error_message": str(exc)}
+            ),
+        ),
+        exc,
+    ) from exc

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_pipeline.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_pipeline.py
@@ -1,0 +1,604 @@
+"""Whole-run sidecar pipeline stages for post-analysis."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Protocol
+
+import aiosqlite
+
+from vibesensor.domain import CarOrderReferenceStatus
+from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.raw_capture import RawRunCapture
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
+from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
+    WholeRunOrderFamilySummaryArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    WholeRunOrderTraceSummaryArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    WholeRunDiagnosisSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WholeRunSpatialCoherenceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunSpectralArtifactBundle,
+    WholeRunSpectralBuildResult,
+)
+from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
+from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_raw_capture_policy import (
+    WholeRunRawCapturePolicy,
+    assess_whole_run_raw_capture_policy,
+)
+from vibesensor.use_cases.run.post_analysis_stage_runner import (
+    PostAnalysisStageResult,
+    PostAnalysisStageStatus,
+    make_stage_result,
+    raise_stage_failure,
+    sync_run_persistence_call,
+    warning_codes,
+)
+from vibesensor.use_cases.run.post_analysis_whole_run_builders import (
+    StoredWholeRunArtifactBundle,
+    build_whole_run_artifacts,
+    build_whole_run_context_artifacts,
+    build_whole_run_order_family_summary_artifacts,
+    build_whole_run_order_trace_artifacts,
+    build_whole_run_order_trace_summary_artifacts,
+    build_whole_run_spatial_coherence_artifacts,
+    merge_whole_run_artifact_bundles,
+    whole_run_total_sample_count,
+)
+from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
+    build_diagnosis_summary_rows,
+)
+
+
+class WholeRunArtifactBuilder(Protocol):
+    """Injected boundary for building dense whole-run sidecar artifacts."""
+
+    def __call__(
+        self,
+        *,
+        run_id: str,
+        metadata: RunMetadata,
+        raw_capture: RawRunCapture,
+    ) -> WholeRunSpectralBuildResult: ...
+
+
+class WholeRunContextBuilder(Protocol):
+    """Injected boundary for building dense whole-run context sidecars."""
+
+    def __call__(
+        self,
+        *,
+        run: PostAnalysisRunInput,
+        total_sample_count: int | None = None,
+        window_plan: WholeRunWindowPlan | None = None,
+    ) -> WholeRunContextArtifactBundle | None: ...
+
+
+class WholeRunOrderTraceBuilder(Protocol):
+    """Injected boundary for building dense whole-run order-trace sidecars."""
+
+    def __call__(
+        self,
+        *,
+        run: PostAnalysisRunInput,
+        spectral_bundle: WholeRunSpectralArtifactBundle,
+        context_bundle: WholeRunContextArtifactBundle,
+    ) -> WholeRunOrderTraceArtifactBundle | None: ...
+
+
+class WholeRunOrderTraceSummaryBuilder(Protocol):
+    """Injected boundary for building compact whole-run order-trace summaries."""
+
+    def __call__(
+        self,
+        *,
+        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+        context_bundle: WholeRunContextArtifactBundle,
+    ) -> WholeRunOrderTraceSummaryArtifactBundle | None: ...
+
+
+class WholeRunOrderFamilySummaryBuilder(Protocol):
+    """Injected boundary for building family-level whole-run order summaries."""
+
+    def __call__(
+        self,
+        *,
+        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+        order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle,
+        context_bundle: WholeRunContextArtifactBundle,
+    ) -> WholeRunOrderFamilySummaryArtifactBundle | None: ...
+
+
+class WholeRunSpatialCoherenceBuilder(Protocol):
+    """Injected boundary for building candidate-level whole-run spatial coherence."""
+
+    def __call__(
+        self,
+        *,
+        run: PostAnalysisRunInput,
+        spectral_bundle: WholeRunSpectralArtifactBundle,
+        context_bundle: WholeRunContextArtifactBundle,
+        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+    ) -> WholeRunSpatialCoherenceArtifactBundle | None: ...
+
+
+class WholeRunDiagnosisSummaryBuilder(Protocol):
+    """Injected boundary for building compact fused whole-run diagnosis summaries."""
+
+    def __call__(
+        self,
+        *,
+        analysis_metadata: Mapping[str, object],
+        context_bundle: WholeRunContextArtifactBundle,
+        order_summaries: tuple[OrderTraceSummary, ...],
+        spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+        car_order_reference_status: CarOrderReferenceStatus | None,
+    ) -> tuple[WholeRunDiagnosisSummary, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunPipelineStageOutput:
+    """Artifacts and stage reports from the whole-run sidecar pipeline."""
+
+    stage_results: tuple[PostAnalysisStageResult, ...]
+    stored_artifact_manifest: WholeRunArtifactManifest | None = None
+    spectral_result: WholeRunSpectralBuildResult | None = None
+    spectral_bundle: WholeRunSpectralArtifactBundle | None = None
+    context_bundle: WholeRunContextArtifactBundle | None = None
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
+    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
+    order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
+    spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunStageExecution[ResultT]:
+    """Stage runner payload before conversion into a public stage result."""
+
+    result: ResultT
+    status: PostAnalysisStageStatus
+    artifact_manifest: WholeRunArtifactManifest | None = None
+    warnings: tuple[str, ...] = ()
+    diagnostic_context: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedWholeRunBuilders:
+    """Resolved builder callables used by the explicit whole-run pipeline stages."""
+
+    artifact_builder: WholeRunArtifactBuilder
+    context_builder: WholeRunContextBuilder
+    order_trace_builder: WholeRunOrderTraceBuilder
+    order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder
+    order_family_summary_builder: WholeRunOrderFamilySummaryBuilder
+    spatial_coherence_builder: WholeRunSpatialCoherenceBuilder
+    diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunPipelineContext:
+    db: RunPersistence
+    loaded: LoadedPostAnalysisRun
+    run_input: PostAnalysisRunInput
+    builders: ResolvedWholeRunBuilders
+    raw_capture_policy: WholeRunRawCapturePolicy
+
+
+@dataclass(slots=True)
+class WholeRunPipelineState:
+    stage_results: list[PostAnalysisStageResult] = field(default_factory=list)
+    stored_artifact_manifest: WholeRunArtifactManifest | None = None
+    spectral_result: WholeRunSpectralBuildResult | None = None
+    spectral_bundle: WholeRunSpectralArtifactBundle | None = None
+    context_bundle: WholeRunContextArtifactBundle | None = None
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
+    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
+    order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
+    spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
+
+    def output(self) -> WholeRunPipelineStageOutput:
+        return WholeRunPipelineStageOutput(
+            stage_results=tuple(self.stage_results),
+            stored_artifact_manifest=self.stored_artifact_manifest,
+            spectral_result=self.spectral_result,
+            spectral_bundle=self.spectral_bundle,
+            context_bundle=self.context_bundle,
+            order_trace_bundle=self.order_trace_bundle,
+            order_trace_summary_bundle=self.order_trace_summary_bundle,
+            order_family_summary_bundle=self.order_family_summary_bundle,
+            spatial_coherence_bundle=self.spatial_coherence_bundle,
+        )
+
+
+def resolve_whole_run_builders(
+    *,
+    whole_run_artifact_builder: WholeRunArtifactBuilder | None,
+    whole_run_context_builder: WholeRunContextBuilder | None,
+    whole_run_order_trace_builder: WholeRunOrderTraceBuilder | None,
+    whole_run_order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None,
+    whole_run_order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None,
+    whole_run_spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None,
+    whole_run_diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder | None,
+) -> ResolvedWholeRunBuilders:
+    return ResolvedWholeRunBuilders(
+        artifact_builder=(
+            build_whole_run_artifacts
+            if whole_run_artifact_builder is None
+            else whole_run_artifact_builder
+        ),
+        context_builder=(
+            build_whole_run_context_artifacts
+            if whole_run_context_builder is None
+            else whole_run_context_builder
+        ),
+        order_trace_builder=(
+            build_whole_run_order_trace_artifacts
+            if whole_run_order_trace_builder is None
+            else whole_run_order_trace_builder
+        ),
+        order_trace_summary_builder=(
+            build_whole_run_order_trace_summary_artifacts
+            if whole_run_order_trace_summary_builder is None
+            else whole_run_order_trace_summary_builder
+        ),
+        order_family_summary_builder=(
+            build_whole_run_order_family_summary_artifacts
+            if whole_run_order_family_summary_builder is None
+            else whole_run_order_family_summary_builder
+        ),
+        spatial_coherence_builder=(
+            build_whole_run_spatial_coherence_artifacts
+            if whole_run_spatial_coherence_builder is None
+            else whole_run_spatial_coherence_builder
+        ),
+        diagnosis_summary_builder=(
+            build_diagnosis_summary_rows
+            if whole_run_diagnosis_summary_builder is None
+            else whole_run_diagnosis_summary_builder
+        ),
+    )
+
+
+def run_whole_run_pipeline_stages(
+    *,
+    db: RunPersistence,
+    loaded: LoadedPostAnalysisRun,
+    run_input: PostAnalysisRunInput,
+    builders: ResolvedWholeRunBuilders,
+) -> WholeRunPipelineStageOutput:
+    context = WholeRunPipelineContext(
+        db=db,
+        loaded=loaded,
+        run_input=run_input,
+        builders=builders,
+        raw_capture_policy=assess_whole_run_raw_capture_policy(loaded),
+    )
+    return WholeRunPipelineRunner(context).run()
+
+
+def _artifact_keys(manifest: WholeRunArtifactManifest | None) -> tuple[str, ...]:
+    if manifest is None:
+        return ()
+    return tuple(artifact.artifact_key for artifact in manifest.artifacts)
+
+
+def _bundle_artifact_manifest(bundle: object | None) -> WholeRunArtifactManifest | None:
+    manifest = getattr(bundle, "manifest", None)
+    return manifest if isinstance(manifest, WholeRunArtifactManifest) else None
+
+
+def _stage_execution[ResultT](
+    result: ResultT | None,
+    *,
+    artifact_manifest: WholeRunArtifactManifest | None = None,
+    status_when_present: PostAnalysisStageStatus = "ok",
+    status_when_none: PostAnalysisStageStatus = "skipped",
+    warnings: tuple[str, ...] = (),
+    present_diagnostic_context: JsonObject | None = None,
+    none_reason: str = "builder_returned_none",
+    none_diagnostic_context: JsonObject | None = None,
+) -> WholeRunStageExecution[ResultT | None]:
+    if result is None:
+        diagnostic_context: JsonObject = {"reason": none_reason}
+        if none_diagnostic_context is not None:
+            diagnostic_context = {**none_diagnostic_context, **diagnostic_context}
+        return WholeRunStageExecution(
+            result=None,
+            status=status_when_none,
+            warnings=warnings,
+            diagnostic_context=diagnostic_context,
+        )
+    return WholeRunStageExecution(
+        result=result,
+        status=status_when_present,
+        artifact_manifest=artifact_manifest,
+        warnings=warnings,
+        diagnostic_context={} if present_diagnostic_context is None else present_diagnostic_context,
+    )
+
+
+class WholeRunPipelineRunner:
+    def __init__(self, context: WholeRunPipelineContext) -> None:
+        self.context = context
+        self.state = WholeRunPipelineState()
+
+    def run(self) -> WholeRunPipelineStageOutput:
+        self._run_spectral_stage()
+        self._run_context_stage()
+        self._run_order_trace_stage()
+        self._run_order_trace_summary_stage()
+        self._run_order_family_stage()
+        self._run_spatial_stage()
+        self._run_persist_artifacts_stage()
+        return self.state.output()
+
+    def _record_stage[ResultT](
+        self,
+        *,
+        stage_name: str,
+        prerequisites_met: bool,
+        prerequisite_reason: str,
+        runner: Callable[[], WholeRunStageExecution[ResultT]],
+    ) -> ResultT | None:
+        stage_start = time.monotonic()
+        if not prerequisites_met:
+            self.state.stage_results.append(
+                make_stage_result(
+                    stage_name=stage_name,
+                    status="skipped",
+                    stage_start=stage_start,
+                    diagnostic_context={"reason": prerequisite_reason},
+                )
+            )
+            return None
+        try:
+            execution = runner()
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            raise_stage_failure(
+                stage_name=stage_name,
+                stage_start=stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": self.context.loaded.run_id},
+            )
+        self.state.stage_results.append(
+            make_stage_result(
+                stage_name=stage_name,
+                status=execution.status,
+                stage_start=stage_start,
+                artifacts_created=_artifact_keys(execution.artifact_manifest),
+                warnings=execution.warnings,
+                diagnostic_context=execution.diagnostic_context,
+            )
+        )
+        return execution.result
+
+    def _run_optional_bundle_stage[BundleT](
+        self,
+        *,
+        stage_name: str,
+        prerequisites_met: bool,
+        runner: Callable[[], BundleT | None],
+    ) -> BundleT | None:
+        def execute() -> WholeRunStageExecution[BundleT | None]:
+            bundle = runner()
+            return _stage_execution(
+                bundle,
+                artifact_manifest=_bundle_artifact_manifest(bundle),
+            )
+
+        return self._record_stage(
+            stage_name=stage_name,
+            prerequisites_met=prerequisites_met,
+            prerequisite_reason="missing_prerequisites",
+            runner=execute,
+        )
+
+    def _run_spectral_stage(self) -> None:
+        loaded = self.context.loaded
+        raw_capture_policy = self.context.raw_capture_policy
+        self.state.spectral_result = self._record_stage(
+            stage_name="BuildWholeRunSpectraStage",
+            prerequisites_met=raw_capture_policy.spectra_prerequisites_met(loaded.raw_capture),
+            prerequisite_reason=raw_capture_policy.spectra_prerequisite_reason(loaded.raw_capture),
+            runner=self._build_spectral_stage,
+        )
+        if self.state.spectral_result is not None:
+            self.state.spectral_bundle = self.state.spectral_result.bundle
+
+    def _build_spectral_stage(
+        self,
+    ) -> WholeRunStageExecution[WholeRunSpectralBuildResult | None]:
+        loaded = self.context.loaded
+        raw_capture = loaded.raw_capture
+        assert raw_capture is not None
+        result = self.context.builders.artifact_builder(
+            run_id=loaded.run_id,
+            metadata=loaded.metadata,
+            raw_capture=raw_capture,
+        )
+        spectral_manifest = result.bundle.manifest if result.bundle is not None else None
+        return _stage_execution(
+            result,
+            artifact_manifest=spectral_manifest,
+            warnings=warning_codes(tuple(result.coverage_summary.warnings)),
+            present_diagnostic_context={
+                "bundle_available": result.bundle is not None,
+                "coverage_confidence": result.coverage_summary.coverage_confidence,
+            },
+        )
+
+    def _run_context_stage(self) -> None:
+        raw_capture_policy = self.context.raw_capture_policy
+        self.state.context_bundle = self._record_stage(
+            stage_name="BuildWholeRunContextStage",
+            prerequisites_met=raw_capture_policy.context_prerequisites_met(),
+            prerequisite_reason=raw_capture_policy.context_prerequisite_reason(),
+            runner=self._build_context_stage,
+        )
+
+    def _build_context_stage(self) -> WholeRunStageExecution[WholeRunContextArtifactBundle | None]:
+        raw_capture_manifest = self.context.raw_capture_policy.manifest
+        assert raw_capture_manifest is not None
+        spectral_result = self.state.spectral_result
+        if spectral_result is not None and spectral_result.window_plan is not None:
+            bundle = self.context.builders.context_builder(
+                run=self.context.run_input,
+                window_plan=spectral_result.window_plan,
+            )
+            return _stage_execution(
+                bundle,
+                artifact_manifest=_bundle_artifact_manifest(bundle),
+                present_diagnostic_context={"build_mode": "window_plan"},
+                none_diagnostic_context={"build_mode": "window_plan"},
+            )
+        bundle = self.context.builders.context_builder(
+            run=self.context.run_input,
+            total_sample_count=whole_run_total_sample_count(raw_capture_manifest),
+        )
+        return _stage_execution(
+            bundle,
+            artifact_manifest=_bundle_artifact_manifest(bundle),
+            status_when_present="degraded",
+            present_diagnostic_context={"build_mode": "total_sample_count_fallback"},
+            none_diagnostic_context={"build_mode": "total_sample_count_fallback"},
+        )
+
+    def _run_order_trace_stage(self) -> None:
+        self.state.order_trace_bundle = self._run_optional_bundle_stage(
+            stage_name="BuildOrderTraceStage",
+            prerequisites_met=(
+                self.state.spectral_bundle is not None and self.state.context_bundle is not None
+            ),
+            runner=self._build_order_trace_stage,
+        )
+
+    def _build_order_trace_stage(self) -> WholeRunOrderTraceArtifactBundle | None:
+        assert self.state.spectral_bundle is not None
+        assert self.state.context_bundle is not None
+        return self.context.builders.order_trace_builder(
+            run=self.context.run_input,
+            spectral_bundle=self.state.spectral_bundle,
+            context_bundle=self.state.context_bundle,
+        )
+
+    def _run_order_trace_summary_stage(self) -> None:
+        self.state.order_trace_summary_bundle = self._run_optional_bundle_stage(
+            stage_name="BuildOrderTraceSummaryStage",
+            prerequisites_met=(
+                self.state.order_trace_bundle is not None and self.state.context_bundle is not None
+            ),
+            runner=self._build_order_trace_summary_stage,
+        )
+
+    def _build_order_trace_summary_stage(
+        self,
+    ) -> WholeRunOrderTraceSummaryArtifactBundle | None:
+        assert self.state.order_trace_bundle is not None
+        assert self.state.context_bundle is not None
+        return self.context.builders.order_trace_summary_builder(
+            order_trace_bundle=self.state.order_trace_bundle,
+            context_bundle=self.state.context_bundle,
+        )
+
+    def _run_order_family_stage(self) -> None:
+        self.state.order_family_summary_bundle = self._run_optional_bundle_stage(
+            stage_name="BuildOrderFamilySummaryStage",
+            prerequisites_met=(
+                self.state.order_trace_bundle is not None
+                and self.state.order_trace_summary_bundle is not None
+                and self.state.context_bundle is not None
+            ),
+            runner=self._build_order_family_stage,
+        )
+
+    def _build_order_family_stage(self) -> WholeRunOrderFamilySummaryArtifactBundle | None:
+        assert self.state.order_trace_bundle is not None
+        assert self.state.order_trace_summary_bundle is not None
+        assert self.state.context_bundle is not None
+        return self.context.builders.order_family_summary_builder(
+            order_trace_bundle=self.state.order_trace_bundle,
+            order_trace_summary_bundle=self.state.order_trace_summary_bundle,
+            context_bundle=self.state.context_bundle,
+        )
+
+    def _run_spatial_stage(self) -> None:
+        self.state.spatial_coherence_bundle = self._run_optional_bundle_stage(
+            stage_name="BuildSpatialSummaryStage",
+            prerequisites_met=(
+                self.state.spectral_bundle is not None
+                and self.state.context_bundle is not None
+                and self.state.order_trace_bundle is not None
+            ),
+            runner=self._build_spatial_stage,
+        )
+
+    def _build_spatial_stage(self) -> WholeRunSpatialCoherenceArtifactBundle | None:
+        assert self.state.spectral_bundle is not None
+        assert self.state.context_bundle is not None
+        assert self.state.order_trace_bundle is not None
+        return self.context.builders.spatial_coherence_builder(
+            run=self.context.run_input,
+            spectral_bundle=self.state.spectral_bundle,
+            context_bundle=self.state.context_bundle,
+            order_trace_bundle=self.state.order_trace_bundle,
+        )
+
+    def _run_persist_artifacts_stage(self) -> None:
+        merged_bundle = merge_whole_run_artifact_bundles(
+            self.state.spectral_bundle,
+            self.state.context_bundle,
+            self.state.order_trace_bundle,
+            self.state.order_trace_summary_bundle,
+            self.state.order_family_summary_bundle,
+            self.state.spatial_coherence_bundle,
+        )
+        self.state.stored_artifact_manifest = self._record_stage(
+            stage_name="PersistArtifactsStage",
+            prerequisites_met=merged_bundle is not None,
+            prerequisite_reason="no_artifacts_to_persist",
+            runner=lambda: self._persist_artifacts_stage(merged_bundle),
+        )
+
+    def _persist_artifacts_stage(
+        self,
+        merged_bundle: StoredWholeRunArtifactBundle | None,
+    ) -> WholeRunStageExecution[WholeRunArtifactManifest | None]:
+        assert merged_bundle is not None
+        stored_manifest = sync_run_persistence_call(
+            self.context.db,
+            "astore_whole_run_artifacts",
+            self.context.loaded.run_id,
+            merged_bundle.manifest,
+            artifact_contents=merged_bundle.artifact_contents,
+        )
+        if stored_manifest is None:
+            raise OSError(
+                f"Failed to persist whole-run artifacts for run {self.context.loaded.run_id}"
+            )
+        return _stage_execution(
+            stored_manifest,
+            artifact_manifest=stored_manifest,
+            present_diagnostic_context={"artifact_count": len(stored_manifest.artifacts)},
+        )

--- a/tools/dev/maintainability_allowlist.yml
+++ b/tools/dev/maintainability_allowlist.yml
@@ -7,9 +7,6 @@ files:
   tools/dev/verify_backend_static_guards.py:
     max_lines: 2612
     reason: Static guard collection retained as one entrypoint until guard modules are split.
-  apps/server/vibesensor/use_cases/run/post_analysis_executor.py:
-    max_lines: 1250
-    reason: Whole-run post-analysis orchestration retained until stage runner extraction; raw-capture quality gating is centralized but still adds stage wiring.
   apps/server/tests/adapters/pdf/test_report_document_projection.py:
     max_lines: 1217
     reason: High-density report projection regression matrix kept together by document-output seam.
@@ -23,24 +20,12 @@ functions:
   tools/dev/check_hygiene.py::check_contract_sync_entrypoint:
     max_lines: 281
     reason: Contract sync and UI validation entrypoint guards stay together until workflow/config checks are split.
-  apps/server/vibesensor/use_cases/run/post_analysis_executor.py::run_whole_run_pipeline_stages:
-    max_lines: 229
-    reason: Whole-run stage orchestration retained until table-driven stage runner extraction; raw-capture quality gating is kept at the stage prerequisite seam.
-  apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py::_appendix_c_page:
-    max_lines: 434
-    reason: Dense appendix drawing routine retained until PDF rendering is split into smaller layout helpers; complex evidence panel sizing kept in the same renderer for now.
   apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py::test_execute_post_analysis_persists_whole_run_diagnosis_summaries:
     max_lines: 353
     reason: End-to-end whole-run diagnosis persistence scenario kept together to preserve setup/assertion context.
-  apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py::run_timeline_graph:
-    max_lines: 271
-    reason: Timeline graph rendering path retained until chart layout and drawing steps are separated.
   apps/server/tests_e2e/test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys:
     max_lines: 263
     reason: Docker user journey scenario intentionally keeps full workflow assertions together.
-  apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py::_draw_vehicle_shell:
-    max_lines: 252
-    reason: Vehicle diagram drawing routine retained until geometry/layout primitives are extracted.
   apps/server/vibesensor/use_cases/run/raw_capture_replay.py::build_raw_backed_samples:
     max_lines: 234
     reason: Raw-capture replay assembly retained until sample-building phases are separated.
@@ -53,9 +38,6 @@ functions:
   apps/server/tests/integration/test_ingest_backpressure_metrics.py::test_ingest_metrics_hold_ci_budget_under_sensor_load:
     max_lines: 220
     reason: Integration load scenario intentionally keeps timing, ingest, and metric assertions in one flow.
-  apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py::_appendix_b_page:
-    max_lines: 275
-    reason: Dense appendix drawing routine retained until PDF rendering is split into smaller layout helpers; location snapshot rendering remains colocated with the sensor matrix.
   apps/server/tests/use_cases/run/test_post_analysis_executor.py::test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar:
     max_lines: 206
     reason: Post-analysis context summary persistence scenario kept together to preserve setup/assertion context.


### PR DESCRIPTION
## What changed
- Moved shared post-analysis stage result/persistence helpers into `post_analysis_stage_runner.py`.
- Moved the whole-run sidecar stages into `post_analysis_whole_run_pipeline.py` with an explicit context/state runner.
- Split Appendix B/C, timeline graph, and vehicle shell drawing into smaller layout/drawing helpers.
- Removed the targeted maintainability allowlist entries for these backend/PDF hotspots.

## Why
The executor and PDF drawing functions no longer need temporary size exceptions. The runtime behavior stays on the same public seams.

Closes #3766

## Validation
- `python tools/dev/loc_check.py`
- `cd apps/server && python -m ruff format ... && python -m ruff check ...`
- `pytest -q apps/server/tests/use_cases/run/`
- `pytest -q apps/server/tests/adapters/pdf/`
- `cd apps/server && python -m mypy --config-file pyproject.toml`
- `python tools/dev/verify_backend_static_guards.py`
- `python tools/dev/check_hygiene.py`
- `cd apps/server && deptry . tests --config pyproject.toml && lint-imports --config pyproject.toml`
- config preflight for dev/docker/pi
- `python tools/dev/docs_lint.py`
- direct contract drift check
- `python tools/tests/run_release_smoke.py`
- planned local CI subset: runnable selected jobs passed; local dependency runner could not complete workflow steps that call missing host `make`, so contract drift and release smoke were run directly

## Risks / tradeoffs
- This is a structural split; behavior is preserved by existing run and PDF regression suites.
- `post_analysis_executor.py` still imports the moved whole-run helpers so existing internal imports keep working.

## Follow-ups
None.