### PR TITLE
Add pristine cleanup workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,7 @@ This file is the canonical AI guidance entrypoint and short index. Preserve guar
 - Backend layer DAG, enforced by `apps/server/pyproject.toml` and `tools/dev/verify_backend_static_guards.py`: `domain` imports no project layers; `shared` may import `domain`; `use_cases` may import `domain, shared`; `infra` may import `domain, shared`; `adapters` may import `domain, shared, infra, use_cases`; `app` may import all. `shared -> domain` and `infra -> domain` are allowed; inward leakage such as `use_cases -> adapters` is not.
 
 ## Validation router
+- Cleanup: `make clean` removes fast regenerated build/test/generated outputs; `make pristine` removes ignored generated/cache/runtime outputs and then requires `make setup` for native dev.
 - Start with `make plan-validation`; run planned non-Docker jobs with `./.venv/bin/python tools/tests/plan_validation.py --run`, or use `--act` / `./tools/tests/run_ci_with_act.sh` only when GitHub workflow or Docker parity is needed.
 - Use `./tools/tests/run_ci_with_act.sh --full-stack` only when you must force all gated CI jobs.
 - Docs or instruction-only changes: run `make docs-lint` plus `make plan-validation`.

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.import_linter_cache/
+.deptry_cache/
+htmlcov/
+coverage.xml
 
 # Runtime data
 apps/server/data/*.csv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,18 @@ If you want the browser to open automatically on local desktop workflows, use
 If you prefer the source-mounted Docker workflow instead of the native path,
 run `make dev`.
 
+## Cleanup workflow
+
+- `make clean` removes fast-regenerated build outputs, test caches, static UI
+  output, and generated UI contract derivatives. It keeps dependency installs
+  and local runtime data.
+- `make pristine` runs `make clean`, then removes ignored generated/cache/runtime
+  outputs including `.venv`, UI `node_modules`, Pi image output/cache dirs,
+  artifacts, and tmp dirs. It intentionally keeps local secret files such as
+  `.secrets.act` and server Wi-Fi secret env files.
+- After `make pristine`, run `make setup` to recreate the native dev checkout
+  and materialize missing generated UI contract derivatives.
+
 ## Hooks and local safeguards
 
 `make setup` enables the versioned repo hooks automatically. If you skipped that

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean pristine format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -12,12 +12,45 @@ PYTHON_BOOTSTRAP := python$(PYTHON_MAJOR_MINOR)
 VENV_DIR := $(CURDIR)/.venv
 VENV_PYTHON := $(VENV_DIR)/bin/python
 BACKEND_BENCHMARK_TARGETS ?= tests/infra/workers/benchmark_compute_all.py tests/use_cases/diagnostics/benchmark_whole_run_spectra.py tests/use_cases/updates/benchmark_update_status_codec.py
+UI_GENERATED_DERIVATIVES := \
+	$(UI_DIR)/src/constants.ts \
+	$(UI_DIR)/src/generated/http_api_contracts.ts \
+	$(UI_DIR)/src/contracts/ws_payload_schema.generated.ts \
+	$(UI_DIR)/src/contracts/ws_payload_types.ts
+CLEAN_PATHS := \
+	$(SERVER_DIR)/build \
+	$(SERVER_DIR)/dist \
+	$(SERVER_DIR)/vibesensor.egg-info \
+	$(SERVER_DIR)/.mypy_cache \
+	$(SERVER_DIR)/.pytest_cache \
+	$(SERVER_DIR)/.ruff_cache \
+	$(SERVER_DIR)/.import_linter_cache \
+	$(SERVER_DIR)/vibesensor/static \
+	$(UI_DIR)/dist \
+	$(UI_DIR)/test-results \
+	$(UI_DIR)/playwright-report \
+	.pytest_cache \
+	.ruff_cache \
+	.mypy_cache \
+	.coverage \
+	htmlcov \
+	infra/pi-image/pi-gen/.cache \
+	tools/dev/.ruff_cache \
+	$(UI_GENERATED_DERIVATIVES)
 
 # Prefer the repo venv after setup, but still allow bootstrap targets to run
 # against the pinned host interpreter before `.venv` exists.
 define RESOLVE_PYTHON
 PYTHON="$(VENV_PYTHON)"; \
 if [ ! -x "$$PYTHON" ]; then PYTHON="$(PYTHON_BOOTSTRAP)"; fi;
+endef
+
+define CREATE_VENV
+if command -v uv >/dev/null 2>&1; then \
+	uv venv --seed --python "$(PYTHON_VERSION)" "$(VENV_DIR)"; \
+else \
+	"$(PYTHON_BOOTSTRAP)" -m venv "$(VENV_DIR)"; \
+fi
 endef
 
 help: ## Show the available make targets and what each one does
@@ -32,7 +65,7 @@ setup: ## Install backend dev dependencies and UI node_modules
 		echo "Recreating .venv for Python $(PYTHON_VERSION)"; \
 		rm -rf "$(VENV_DIR)"; \
 	fi
-	@if [ ! -x "$(VENV_PYTHON)" ]; then "$(PYTHON_BOOTSTRAP)" -m venv "$(VENV_DIR)"; fi
+	@if [ ! -x "$(VENV_PYTHON)" ]; then $(CREATE_VENV); fi
 	"$(VENV_PYTHON)" -m pip install --upgrade pip
 	"$(VENV_PYTHON)" -m pip install -e "./apps/server[dev]"
 	cd $(UI_DIR) && node ../../tools/ui/ensure_ui_bootstrap.mjs
@@ -41,8 +74,11 @@ setup: ## Install backend dev dependencies and UI node_modules
 dev: ## Start the source-mounted Docker dev stack with backend reload + Vite HMR
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 
-clean: ## Remove local build, package, and Pi image cache artifacts
-	rm -rf $(SERVER_DIR)/build $(SERVER_DIR)/dist $(SERVER_DIR)/vibesensor.egg-info infra/pi-image/pi-gen/.cache
+clean: ## Remove fast local build, test cache, static UI, and generated derivative outputs
+	rm -rf $(CLEAN_PATHS)
+
+pristine: clean ## Remove all ignored generated/cache/runtime outputs; keep local secrets
+	git clean -fdX -e .secrets.act -e apps/server/wifi-secrets.env
 
 format: ## Run Ruff formatter over backend and tooling files
 	@$(RESOLVE_PYTHON) \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ workflow paths are available on your machine. Run bare `make` to list the
 supported repo commands. Use `make format` as the only supported Python
 formatter for backend and tooling files.
 
+Cleanup levels are explicit: `make clean` removes fast regenerated build, test
+cache, static UI, and generated derivative outputs; `make pristine` also removes
+ignored local generated/cache/runtime outputs such as `.venv`, UI
+`node_modules`, Pi image outputs, artifacts, and tmp dirs while preserving local
+secret files. Run `make setup` after `make pristine` to restore the native dev
+checkout.
+
 ## Quick Start
 
 ### Docker (quick product check)

--- a/apps/server/tests/hygiene/test_verify_backend_static_guards_entrypoints.py
+++ b/apps/server/tests/hygiene/test_verify_backend_static_guards_entrypoints.py
@@ -8,17 +8,15 @@ from types import ModuleType
 
 from _paths import REPO_ROOT
 
-_VERIFY_BACKEND_STATIC_GUARDS = REPO_ROOT / "tools" / "dev" / "verify_backend_static_guards.py"
+_BACKEND_STATIC_GUARDS = REPO_ROOT / "tools" / "dev" / "static_guards" / "checks.py"
 
 
 def _load_verify_backend_static_guards_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         "verify_backend_static_guards_test_entrypoints",
-        _VERIFY_BACKEND_STATIC_GUARDS,
+        _BACKEND_STATIC_GUARDS,
     )
-    assert spec is not None and spec.loader is not None, (
-        f"Unable to load {_VERIFY_BACKEND_STATIC_GUARDS}"
-    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_BACKEND_STATIC_GUARDS}"
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/apps/server/tests/test_support/check_hygiene_loader.py
+++ b/apps/server/tests/test_support/check_hygiene_loader.py
@@ -8,7 +8,7 @@ from types import ModuleType
 
 from tests._paths import REPO_ROOT
 
-_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "check_hygiene.py"
+_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "hygiene" / "checks.py"
 
 
 def load_check_hygiene_module(

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -79,6 +79,8 @@ Those derivative outputs are materialized locally from the tracked inputs and ar
 
 Fresh checkouts can materialize only the missing derivative files with `npm run setup:generated-contracts`. That setup command is safe to rerun, reuses the shared UI bootstrap helper, and intentionally leaves the authoritative `make sync-contracts` / `npm run sync:generated-contracts` refresh flow unchanged for stale-derivative updates.
 
+`make clean` and `make pristine` may remove the derivative files because they are local generated outputs. Restore them with `make setup`, `make ui-typecheck`, `make sync-contracts`, or `npm run setup:generated-contracts` depending on the workflow you are about to run.
+
 `npm run build` and `npm run typecheck` no longer regenerate those files automatically. They run `npm run check:contracts` first and fail fast with guidance to `make sync-contracts` if the local derivative copy is missing or stale. CI contract drift and human-facing regeneration should still use `make sync-contracts`.
 
 The release-smoke artifact helper is the intentional narrow exception: after the same commit already passed `backend-contract-drift` and `frontend-typecheck`, `tools/build_ui_static.py --skip-typecheck --assume-prevalidated-contracts` still regenerates the UI-only derivatives for that fresh checkout but switches to `npm run build:prevalidated-contracts` so the late packaged smoke path does not repeat `check:contracts`.

--- a/tools/dev/check_prerequisites.py
+++ b/tools/dev/check_prerequisites.py
@@ -28,13 +28,16 @@ def _which(command: str) -> str | None:
 
 
 def _run(command: list[str]) -> tuple[bool, str]:
-    proc = subprocess.run(
-        command,
-        cwd=ROOT,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except OSError as exc:
+        return False, str(exc)
     output = (proc.stdout or "").strip()
     return proc.returncode == 0, output
 


### PR DESCRIPTION
## What changed

- Added explicit cleanup levels: `make clean` for fast regenerated outputs and `make pristine` for ignored generated/cache/runtime state.
- Kept local secrets out of pristine cleanup.
- Made `make setup` use seeded `uv venv` when uv is available, with the existing stdlib venv fallback.
- Hardened prerequisite checks so broken tool shims warn instead of crashing.
- Updated README, CONTRIBUTING, UI contract-sync docs, `.gitignore`, and AI guidance to match the cleanup/generated-artifact workflow.

## Why

The repo had many ignored outputs but only a narrow `clean` target. Developers needed one clear way to reset generated state and then rebuild a usable checkout.

## Validation

Host `make` is unavailable in this container, so I ran direct equivalents:

- pristine dry-run and pristine+setup equivalent with tracker backup/restore
- doctor equivalent
- setup equivalent
- sync-contracts equivalent
- ui-typecheck equivalent
- docs-lint
- repo hygiene
- backend static guards
- ruff format/check for the changed Python tool
- validation planner
- `git diff --check`

## Risks and tradeoffs

`make pristine` is intentionally broad because it uses ignored-file cleanup. It preserves local secret files, but it will remove ignored temp state and dependency installs; rerun `make setup` afterward.

Closes #3768
