### PR TITLE
Wire whole-run spectra to bounded raw ranges

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py
@@ -16,12 +16,14 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureSensorData,
     RawCaptureSensorLossStats,
     RawCaptureSensorManifest,
+    RawCaptureSensorRange,
     RawRunCapture,
 )
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunWindowSpectralSummary,
     build_whole_run_spectral_artifact_bundle,
+    build_whole_run_spectral_artifact_bundle_from_ranges,
 )
 
 _RUN_START_US = 1_000_000
@@ -147,6 +149,37 @@ def _summaries(bundle, sensor_id: str) -> tuple[WholeRunWindowSpectralSummary, .
     return tuple(WholeRunWindowSpectralSummary.from_mapping(row) for row in _summary_rows(payload))
 
 
+def _range_reader(raw_capture: RawRunCapture, read_sizes: list[int]):
+    sensors = {sensor.manifest.client_id: sensor for sensor in raw_capture.sensors}
+
+    def read_range(
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None:
+        sensor = sensors[client_id]
+        read_sizes.append(sample_count)
+        sample_end = sample_start + sample_count
+        return RawCaptureSensorRange(
+            client_id=client_id,
+            requested_sample_start=sample_start,
+            requested_sample_count=sample_count,
+            coverage_state="full",
+            samples_i16=np.ascontiguousarray(sensor.samples_i16[sample_start:sample_end]),
+            manifest=sensor.manifest,
+            returned_sample_start=sample_start,
+            chunks=tuple(
+                chunk
+                for chunk in sensor.chunks
+                if chunk.sample_start < sample_end
+                and (chunk.sample_start + chunk.sample_count) > sample_start
+            ),
+        )
+
+    return read_range
+
+
 def test_whole_run_spectra_are_deterministic_across_serial_and_parallel_execution() -> None:
     raw_capture = _raw_capture(
         _make_sensor(
@@ -194,6 +227,46 @@ def test_whole_run_spectra_are_deterministic_across_serial_and_parallel_executio
         "spectral-matrix:sensor-b",
         "spectral-summary:sensor-b",
     ]
+
+
+def test_whole_run_spectra_range_reader_matches_full_capture_without_full_range_reads() -> None:
+    raw_capture = _raw_capture(
+        _make_sensor(
+            client_id="sensor-a",
+            sample_rate_hz=8,
+            chunks=[
+                (_RUN_START_US, _sine_samples(total_samples=8)),
+                (_RUN_START_US + 1_000_000, _sine_samples(total_samples=8, phase_rad=0.1)),
+            ],
+            clock_sync=_verified_sync(),
+        )
+    )
+    read_sizes: list[int] = []
+
+    full_result = build_whole_run_spectral_artifact_bundle(
+        run_id="run-spectra",
+        metadata=_metadata(),
+        raw_capture=raw_capture,
+        max_workers=1,
+        chunk_window_count=2,
+        created_at="2025-01-01T00:00:00Z",
+    )
+    range_result = build_whole_run_spectral_artifact_bundle_from_ranges(
+        run_id="run-spectra",
+        metadata=_metadata(),
+        raw_capture_manifest=raw_capture.manifest,
+        raw_range_reader=_range_reader(raw_capture, read_sizes),
+        max_workers=1,
+        chunk_window_count=2,
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+    assert full_result.bundle is not None
+    assert range_result.bundle is not None
+    assert range_result.bundle.manifest == full_result.bundle.manifest
+    assert range_result.bundle.artifact_contents == full_result.bundle.artifact_contents
+    assert range_result.coverage_summary == full_result.coverage_summary
+    assert read_sizes == [8, 8, 8]
 
 
 def test_whole_run_spectra_align_sensor_windows_by_measurement_time() -> None:

--- a/apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py
@@ -4,7 +4,12 @@ from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
-from vibesensor.shared.types.raw_capture import RawCaptureManifest
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureManifest,
+    RawCaptureSensorClockSync,
+    RawCaptureSensorManifest,
+    RawCaptureSensorRange,
+)
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import (
     WholeRunArtifactFile,
@@ -76,6 +81,36 @@ def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
             high_rtt_sensor_count=0,
             coverage_confidence="unavailable",
         ),
+    )
+
+
+def _raw_capture_manifest_with_sensor(run_id: str) -> RawCaptureManifest:
+    return RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=(
+            RawCaptureSensorManifest(
+                client_id="sensor-a",
+                sample_rate_hz=800,
+                data_file="sensor-a.raw.i16le",
+                index_file="sensor-a.index.jsonl",
+                sample_count=2048,
+                chunk_count=1,
+                bytes_written=2048 * 3 * 2,
+                first_t0_us=1_000_000,
+                last_t0_us=1_000_000,
+                clock_sync=RawCaptureSensorClockSync(
+                    clock_domain="server_monotonic",
+                    proof_state="verified",
+                ),
+                declared_sample_rate_hz=800,
+                sample_rate_proof_state="observed_consistent",
+            ),
+        ),
+        total_samples=2048,
+        total_bytes=2048 * 3 * 2,
+        created_at="2025-01-01T00:00:00Z",
+        run_start_monotonic_us=1_000_000,
     )
 
 
@@ -191,6 +226,71 @@ def test_run_whole_run_pipeline_stages_reports_degraded_context_fallback() -> No
     assert statuses["PersistArtifactsStage"] == "ok"
     assert stored["run_id"] == "run-stage-pipeline"
     assert result.stored_artifact_manifest is not None
+
+
+def test_whole_run_spectral_stage_uses_manifest_and_bounded_range_reader() -> None:
+    raw_capture_manifest = _raw_capture_manifest_with_sensor("run-range-pipeline")
+    captured: dict[str, object] = {}
+
+    class FakeDB:
+        async def aload_raw_capture(self, _run_id):  # pragma: no cover - regression guard
+            raise AssertionError("whole-run spectra must not load full raw capture")
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            captured["range_read"] = (run_id, client_id, sample_start, sample_count)
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+
+    def artifact_builder(**kwargs):
+        captured["artifact_kwargs"] = kwargs
+        range_reader = kwargs["raw_range_reader"]
+        range_reader("sensor-a", sample_start=4, sample_count=8)
+        return _spectral_result(None)
+
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-range-pipeline",
+        metadata=_run_metadata("run-range-pipeline"),
+        language="en",
+        samples=_samples(),
+        total_summary_row_count=1,
+        stride=1,
+        raw_capture=None,
+        raw_capture_manifest=raw_capture_manifest,
+    )
+    run_input = run_build_post_analysis_input_stage(loaded).run_input
+    builders = resolve_whole_run_builders(
+        whole_run_artifact_builder=artifact_builder,
+        whole_run_context_builder=lambda **_kwargs: None,
+        whole_run_order_trace_builder=lambda **_kwargs: None,
+        whole_run_order_trace_summary_builder=lambda **_kwargs: None,
+        whole_run_order_family_summary_builder=lambda **_kwargs: None,
+        whole_run_spatial_coherence_builder=lambda **_kwargs: None,
+        whole_run_diagnosis_summary_builder=lambda **_kwargs: (),
+    )
+
+    result = run_whole_run_pipeline_stages(
+        db=FakeDB(),
+        loaded=loaded,
+        run_input=run_input,
+        builders=builders,
+    )
+
+    assert result.stage_results[0].stage_name == "BuildWholeRunSpectraStage"
+    assert result.stage_results[0].status == "ok"
+    artifact_kwargs = captured["artifact_kwargs"]
+    assert artifact_kwargs["raw_capture_manifest"] == raw_capture_manifest
+    assert "raw_capture" not in artifact_kwargs
+    assert captured["range_read"] == ("run-range-pipeline", "sensor-a", 4, 8)
 
 
 def test_run_persist_analysis_summary_stage_stores_summary() -> None:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from io import BytesIO
-from typing import cast
+from typing import Protocol, cast
 
 import numpy as np
 
@@ -16,8 +16,9 @@ from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
 from vibesensor.shared.fft_analysis import SpectralAnalysisComputer, float_list
 from vibesensor.shared.raw_capture_timeline import (
     RawSensorTimeline,
-    assemble_raw_window_samples,
+    RawTimelineChunk,
     build_raw_sensor_timeline,
+    raw_anchor_reason,
     resolve_raw_window_end_time,
 )
 from vibesensor.shared.structured_logging import log_extra
@@ -25,8 +26,9 @@ from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.raw_capture import (
     RawCaptureCoverageState,
     RawCaptureLossStats,
-    RawCaptureSensorData,
+    RawCaptureManifest,
     RawCaptureSensorManifest,
+    RawCaptureSensorRange,
     RawRunCapture,
 )
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -61,7 +63,10 @@ __all__ = [
     "WholeRunSpectralBuildResult",
     "WholeRunSpectralCoverageSummary",
     "WholeRunWindowSpectralSummary",
+    "RawCaptureRangeReader",
     "build_whole_run_spectral_artifact_bundle",
+    "build_whole_run_spectral_artifact_bundle_from_ranges",
+    "raw_capture_range_reader_from_capture",
     "whole_run_spectral_summaries_by_sensor",
     "whole_run_window_spectral_summaries_from_jsonl_bytes",
     "whole_run_window_spectral_summaries_to_jsonl_bytes",
@@ -85,11 +90,29 @@ class WholeRunSpectralBuildResult:
     window_plan: WholeRunWindowPlan | None = None
 
 
+class RawCaptureRangeReader(Protocol):
+    """Bounded raw-capture sample reader used by the whole-run spectral executor."""
+
+    def __call__(
+        self,
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None: ...
+
+
 @dataclass(frozen=True, slots=True)
-class _SpectralChunk:
-    sensor_data: RawCaptureSensorData
+class _SpectralSensor:
+    manifest: RawCaptureSensorManifest
     timeline: RawSensorTimeline
     loss_stats: RawCaptureLossStats
+
+
+@dataclass(frozen=True, slots=True)
+class _SpectralChunk:
+    sensor: _SpectralSensor
+    raw_range_reader: RawCaptureRangeReader
     chunk_index: int
     windows: tuple[WholeRunWindowDescriptor, ...]
 
@@ -115,44 +138,89 @@ def build_whole_run_spectral_artifact_bundle(
     """Compute deterministic time-aligned whole-run spectral artifacts from raw capture."""
 
     sensors = tuple(sorted(raw_capture.sensors, key=lambda sensor: sensor.manifest.client_id))
-    if not sensors:
-        coverage_summary = WholeRunSpectralCoverageSummary(
-            total_sensor_window_count=0,
-            full_sensor_window_count=0,
-            partial_sensor_window_count=0,
-            missing_sensor_window_count=0,
-            empty_sensor_window_count=0,
-            gap_count=0,
-            overlap_count=0,
-            dropped_chunk_count=0,
-            late_packet_chunk_count=0,
-            queue_overflow_chunk_count=0,
-            invalid_chunk_count=0,
-            write_error_chunk_count=0,
-            sample_rate_mismatch_sensor_count=0,
-            sample_rate_unverified_sensor_count=0,
-            unanchored_sensor_count=0,
-            legacy_sensor_count=0,
-            sync_unverified_sensor_count=0,
-            stale_sync_sensor_count=0,
-            high_rtt_sensor_count=0,
-            coverage_confidence="unavailable",
-            udp_ingest_queue_drop_count=0,
-        )
-        return WholeRunSpectralBuildResult(bundle=None, coverage_summary=coverage_summary)
-    timelines = {
-        sensor.manifest.client_id: build_raw_sensor_timeline(
-            raw_capture,
-            sensor_id=sensor.manifest.client_id,
+    spectral_sensors = tuple(
+        _SpectralSensor(
+            manifest=sensor.manifest,
+            timeline=build_raw_sensor_timeline(
+                raw_capture,
+                sensor_id=sensor.manifest.client_id,
+            ),
+            loss_stats=_sensor_loss_stats(
+                raw_capture.manifest,
+                sensor.manifest.client_id,
+            ),
         )
         for sensor in sensors
-    }
+    )
+    return _build_whole_run_spectral_artifact_bundle_with_ranges(
+        run_id=run_id,
+        metadata=metadata,
+        raw_capture_manifest=raw_capture.manifest,
+        sensors=spectral_sensors,
+        raw_range_reader=raw_capture_range_reader_from_capture(raw_capture),
+        max_workers=max_workers,
+        chunk_window_count=chunk_window_count,
+        created_at=created_at,
+    )
+
+
+def build_whole_run_spectral_artifact_bundle_from_ranges(
+    *,
+    run_id: str,
+    metadata: RunMetadata,
+    raw_capture_manifest: RawCaptureManifest,
+    raw_range_reader: RawCaptureRangeReader,
+    max_workers: int = DEFAULT_WHOLE_RUN_MAX_WORKERS,
+    chunk_window_count: int = _DEFAULT_CHUNK_WINDOW_COUNT,
+    created_at: str | None = None,
+) -> WholeRunSpectralBuildResult:
+    """Compute whole-run spectral artifacts from manifest metadata and bounded raw reads."""
+
+    sensors = tuple(
+        _SpectralSensor(
+            manifest=sensor,
+            timeline=_build_manifest_sensor_timeline(
+                raw_capture_manifest=raw_capture_manifest,
+                sensor=sensor,
+            ),
+            loss_stats=_sensor_loss_stats(raw_capture_manifest, sensor.client_id),
+        )
+        for sensor in sorted(raw_capture_manifest.sensors, key=lambda item: item.client_id)
+    )
+    return _build_whole_run_spectral_artifact_bundle_with_ranges(
+        run_id=run_id,
+        metadata=metadata,
+        raw_capture_manifest=raw_capture_manifest,
+        sensors=sensors,
+        raw_range_reader=raw_range_reader,
+        max_workers=max_workers,
+        chunk_window_count=chunk_window_count,
+        created_at=created_at,
+    )
+
+
+def _build_whole_run_spectral_artifact_bundle_with_ranges(
+    *,
+    run_id: str,
+    metadata: RunMetadata,
+    raw_capture_manifest: RawCaptureManifest,
+    sensors: Sequence[_SpectralSensor],
+    raw_range_reader: RawCaptureRangeReader,
+    max_workers: int,
+    chunk_window_count: int,
+    created_at: str | None,
+) -> WholeRunSpectralBuildResult:
+    sensors = tuple(sensors)
+    if not sensors:
+        coverage_summary = _empty_coverage_summary()
+        return WholeRunSpectralBuildResult(bundle=None, coverage_summary=coverage_summary)
+    timelines = {sensor.manifest.client_id: sensor.timeline for sensor in sensors}
     plan = _build_time_domain_window_plan(metadata=metadata, timelines=timelines)
     if plan is None or plan.total_window_count <= 0:
         coverage_summary = build_coverage_summary(
-            raw_capture=raw_capture,
+            raw_capture_manifest=raw_capture_manifest,
             plan=None,
-            sensors=sensors,
+            sensors=tuple(sensor.manifest for sensor in sensors),
             timelines=timelines,
             summaries_by_sensor={},
         )
@@ -162,9 +230,8 @@ def build_whole_run_spectral_artifact_bundle(
             window_plan=None,
         )
     chunks = _build_chunks(
-        raw_capture=raw_capture,
         sensors=sensors,
-        timelines=timelines,
+        raw_range_reader=raw_range_reader,
         plan=plan,
         chunk_window_count=chunk_window_count,
     )
@@ -178,9 +245,9 @@ def build_whole_run_spectral_artifact_bundle(
         for sensor_id, sensor_results in _chunk_results_by_sensor(chunk_results).items()
     }
     coverage_summary = build_coverage_summary(
-        raw_capture=raw_capture,
+        raw_capture_manifest=raw_capture_manifest,
         plan=plan,
-        sensors=sensors,
+        sensors=tuple(sensor.manifest for sensor in sensors),
         timelines=timelines,
         summaries_by_sensor=summaries_by_sensor,
     )
@@ -188,7 +255,7 @@ def build_whole_run_spectral_artifact_bundle(
         bundle=_build_artifact_bundle(
             run_id=run_id,
             plan=plan,
-            raw_capture=raw_capture,
+            raw_capture_manifest=raw_capture_manifest,
             sensors=tuple(sensor.manifest for sensor in sensors),
             chunk_results=chunk_results,
             created_at=created_at or utc_now_iso(),
@@ -253,6 +320,136 @@ def _build_time_domain_window_plan(
         coverage_sample_end=windows[-1].sample_end,
         windows=windows,
     )
+
+
+def _empty_coverage_summary() -> WholeRunSpectralCoverageSummary:
+    return WholeRunSpectralCoverageSummary(
+        total_sensor_window_count=0,
+        full_sensor_window_count=0,
+        partial_sensor_window_count=0,
+        missing_sensor_window_count=0,
+        empty_sensor_window_count=0,
+        gap_count=0,
+        overlap_count=0,
+        dropped_chunk_count=0,
+        late_packet_chunk_count=0,
+        queue_overflow_chunk_count=0,
+        invalid_chunk_count=0,
+        write_error_chunk_count=0,
+        sample_rate_mismatch_sensor_count=0,
+        sample_rate_unverified_sensor_count=0,
+        unanchored_sensor_count=0,
+        legacy_sensor_count=0,
+        sync_unverified_sensor_count=0,
+        stale_sync_sensor_count=0,
+        high_rtt_sensor_count=0,
+        coverage_confidence="unavailable",
+        udp_ingest_queue_drop_count=0,
+    )
+
+
+def _build_manifest_sensor_timeline(
+    *,
+    raw_capture_manifest: RawCaptureManifest,
+    sensor: RawCaptureSensorManifest,
+) -> RawSensorTimeline:
+    sample_rate_hz = int(sensor.sample_rate_hz or 0)
+    sample_period_us = 1_000_000.0 / float(sample_rate_hz) if sample_rate_hz > 0 else 0.0
+    chunks: tuple[RawTimelineChunk, ...] = ()
+    if sensor.first_t0_us is not None and sensor.sample_count > 0 and sample_period_us > 0.0:
+        chunks = (
+            RawTimelineChunk(
+                sample_start=0,
+                sample_end=max(0, int(sensor.sample_count)),
+                start_us=float(sensor.first_t0_us),
+                end_us=float(sensor.first_t0_us)
+                + (float(max(0, int(sensor.sample_count))) * sample_period_us),
+            ),
+        )
+    anchored = (
+        raw_capture_manifest.run_start_monotonic_us is not None
+        and sensor.clock_sync is not None
+        and sensor.clock_sync.verified
+    )
+    return RawSensorTimeline(
+        client_id=sensor.client_id,
+        sample_rate_hz=sample_rate_hz,
+        sample_period_us=sample_period_us,
+        chunks=chunks,
+        gap_intervals=(),
+        overlap_intervals=(),
+        run_start_monotonic_us=raw_capture_manifest.run_start_monotonic_us,
+        anchored=anchored,
+        anchor_reason=raw_anchor_reason(
+            run_start_monotonic_us=raw_capture_manifest.run_start_monotonic_us,
+            clock_sync=sensor.clock_sync,
+        ),
+        clock_sync=sensor.clock_sync,
+    )
+
+
+def _sensor_loss_stats(
+    raw_capture_manifest: RawCaptureManifest,
+    client_id: str,
+) -> RawCaptureLossStats:
+    sensor_loss = raw_capture_manifest.sensor_loss(client_id)
+    return sensor_loss.losses if sensor_loss is not None else RawCaptureLossStats()
+
+
+def raw_capture_range_reader_from_capture(raw_capture: RawRunCapture) -> RawCaptureRangeReader:
+    """Build a bounded range reader over an already materialized raw capture."""
+
+    sensors = {sensor.manifest.client_id: sensor for sensor in raw_capture.sensors}
+
+    def read_range(
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None:
+        sensor = sensors.get(client_id)
+        if sensor is None:
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+        requested_start = max(0, int(sample_start))
+        requested_count = max(0, int(sample_count))
+        requested_end = requested_start + requested_count
+        available_end = int(sensor.samples_i16.shape[0])
+        returned_start = min(requested_start, available_end)
+        returned_end = min(max(returned_start, requested_end), available_end)
+        samples = np.asarray(sensor.samples_i16[returned_start:returned_end], dtype=np.int16)
+        returned_count = int(samples.shape[0])
+        coverage_state: RawCaptureCoverageState
+        if returned_count <= 0:
+            coverage_state = "missing"
+            returned_sample_start: int | None = None
+        elif returned_start == requested_start and returned_count == requested_count:
+            coverage_state = "full"
+            returned_sample_start = returned_start
+        else:
+            coverage_state = "partial"
+            returned_sample_start = returned_start
+        chunks = tuple(
+            chunk
+            for chunk in sensor.chunks
+            if chunk.sample_start < requested_end
+            and (chunk.sample_start + chunk.sample_count) > requested_start
+        )
+        return RawCaptureSensorRange(
+            client_id=client_id,
+            requested_sample_start=sample_start,
+            requested_sample_count=sample_count,
+            coverage_state=coverage_state,
+            samples_i16=np.ascontiguousarray(samples, dtype=np.int16),
+            manifest=sensor.manifest,
+            returned_sample_start=returned_sample_start,
+            chunks=chunks,
+        )
+
+    return read_range
 
 
 def _timeline_first_window_end_t_s(
@@ -332,9 +529,8 @@ def _build_time_windows(
 
 def _build_chunks(
     *,
-    raw_capture: RawRunCapture,
-    sensors: Sequence[RawCaptureSensorData],
-    timelines: Mapping[str, RawSensorTimeline],
+    sensors: Sequence[_SpectralSensor],
+    raw_range_reader: RawCaptureRangeReader,
     plan: WholeRunWindowPlan,
     chunk_window_count: int,
 ) -> tuple[_SpectralChunk, ...]:
@@ -342,18 +538,14 @@ def _build_chunks(
     chunks: list[_SpectralChunk] = []
     for sensor_data in sensors:
         windows = plan.windows
-        timeline = timelines[sensor_data.manifest.client_id]
-        sensor_loss = raw_capture.manifest.sensor_loss(sensor_data.manifest.client_id)
-        loss_stats = sensor_loss.losses if sensor_loss is not None else RawCaptureLossStats()
         for chunk_index, start in enumerate(range(0, len(windows), normalized_chunk_size)):
             chunk_windows = windows[start : start + normalized_chunk_size]
             if not chunk_windows:
                 continue
             chunks.append(
                 _SpectralChunk(
-                    sensor_data=sensor_data,
-                    timeline=timeline,
-                    loss_stats=loss_stats,
+                    sensor=sensor_data,
+                    raw_range_reader=raw_range_reader,
                     chunk_index=chunk_index,
                     windows=chunk_windows,
                 )
@@ -428,7 +620,7 @@ def _execute_chunks(
                         extra=log_extra(
                             event="whole_run_spectral_chunk_failed",
                             run_id=metadata.run_id,
-                            sensor_id=chunk.sensor_data.manifest.client_id,
+                            sensor_id=chunk.sensor.manifest.client_id,
                             chunk_index=chunk.chunk_index,
                             chunk_position=chunk_position,
                             completed_chunks=completed_chunks,
@@ -473,7 +665,7 @@ def _process_chunk(
     chunk: _SpectralChunk,
     metadata: RunMetadata,
 ) -> _SpectralChunkResult:
-    sensor_manifest = chunk.sensor_data.manifest
+    sensor_manifest = chunk.sensor.manifest
     sample_rate_hz = int(sensor_manifest.sample_rate_hz or 0)
     fft_computer = _build_fft_computer(
         metadata=metadata,
@@ -484,13 +676,12 @@ def _process_chunk(
     summaries = tuple(
         _build_window_summary(
             window=window,
-            sensor_data=chunk.sensor_data,
-            timeline=chunk.timeline,
+            sensor=chunk.sensor,
+            raw_range_reader=chunk.raw_range_reader,
             spectrum_rows=spectrum_rows,
             row_index=row_index,
             metadata=metadata,
             sensor_manifest=sensor_manifest,
-            loss_stats=chunk.loss_stats,
             fft_computer=fft_computer,
         )
         for row_index, window in enumerate(chunk.windows)
@@ -507,15 +698,16 @@ def _process_chunk(
 def _build_window_summary(
     *,
     window: WholeRunWindowDescriptor,
-    sensor_data: RawCaptureSensorData,
-    timeline: RawSensorTimeline,
+    sensor: _SpectralSensor,
+    raw_range_reader: RawCaptureRangeReader,
     spectrum_rows: np.ndarray,
     row_index: int,
     metadata: RunMetadata,
     sensor_manifest: RawCaptureSensorManifest,
-    loss_stats: RawCaptureLossStats,
     fft_computer: SpectralAnalysisComputer,
 ) -> WholeRunWindowSpectralSummary:
+    timeline = sensor.timeline
+    loss_stats = sensor.loss_stats
     if int(sensor_manifest.sample_rate_hz or 0) <= 0:
         return _coverage_only_summary(
             window=window,
@@ -543,13 +735,39 @@ def _build_window_summary(
             coverage_reason=resolved.reason,
             loss_stats=loss_stats,
         )
-    samples_i16 = np.asarray(
-        assemble_raw_window_samples(
-            sensor_data=sensor_data,
-            segments=resolved.segments,
-        ),
-        dtype=np.int16,
+    returned_sample_start = resolved.segments[0].sample_start if resolved.segments else None
+    requested_sample_count = sum(
+        max(0, segment.sample_end - segment.sample_start) for segment in resolved.segments
     )
+    if returned_sample_start is None or requested_sample_count <= 0:
+        return _coverage_only_summary(
+            window=window,
+            coverage_state="missing",
+            coverage_reason="raw_window_unresolved",
+            loss_stats=loss_stats,
+        )
+    raw_range = raw_range_reader(
+        sensor_manifest.client_id,
+        sample_start=returned_sample_start,
+        sample_count=requested_sample_count,
+    )
+    if raw_range is None or raw_range.coverage_state == "missing":
+        return _coverage_only_summary(
+            window=window,
+            coverage_state="missing",
+            coverage_reason="raw_range_missing",
+            loss_stats=loss_stats,
+        )
+    if raw_range.coverage_state != "full":
+        return _coverage_only_summary(
+            window=window,
+            coverage_state="partial",
+            coverage_reason=f"raw_range_{raw_range.coverage_state}",
+            loss_stats=loss_stats,
+            returned_sample_start=raw_range.returned_sample_start,
+            returned_sample_count=raw_range.returned_sample_count,
+        )
+    samples_i16 = np.asarray(raw_range.samples_i16, dtype=np.int16)
     returned_sample_count = int(samples_i16.shape[0])
     if returned_sample_count != window.sample_count:
         return _coverage_only_summary(
@@ -557,9 +775,20 @@ def _build_window_summary(
             coverage_state="partial",
             coverage_reason="assembled_window_short",
             loss_stats=loss_stats,
-            returned_sample_start=(
-                resolved.segments[0].sample_start if resolved.segments else None
-            ),
+            returned_sample_start=raw_range.returned_sample_start,
+            returned_sample_count=returned_sample_count,
+        )
+    discontinuity_reason = _range_chunk_discontinuity_reason(
+        raw_range=raw_range,
+        sensor_manifest=sensor_manifest,
+    )
+    if discontinuity_reason is not None:
+        return _coverage_only_summary(
+            window=window,
+            coverage_state="partial",
+            coverage_reason=discontinuity_reason,
+            loss_stats=loss_stats,
+            returned_sample_start=raw_range.returned_sample_start,
             returned_sample_count=returned_sample_count,
         )
     spectrum_row, top_peaks, vibration_strength_db, peak_amp_g, floor_amp_g, strength_bucket = (
@@ -572,10 +801,6 @@ def _build_window_summary(
     )
     spectrum_rows[row_index, :] = spectrum_row
     dominant_freq_hz = top_peaks[0]["hz"] if top_peaks else None
-    returned_sample_start = resolved.segments[0].sample_start if resolved.segments else None
-    returned_sample_count = sum(
-        max(0, segment.sample_end - segment.sample_start) for segment in resolved.segments
-    )
     return WholeRunWindowSpectralSummary(
         window_index=window.window_index,
         coverage_state="full",
@@ -634,6 +859,31 @@ def _coverage_only_summary(
             server_queue_drop_count=_server_queue_drop_count(loss_stats),
         ),
     )
+
+
+def _range_chunk_discontinuity_reason(
+    *,
+    raw_range: RawCaptureSensorRange,
+    sensor_manifest: RawCaptureSensorManifest,
+) -> str | None:
+    sample_rate_hz = int(sensor_manifest.sample_rate_hz or 0)
+    if sample_rate_hz <= 0 or len(raw_range.chunks) < 2:
+        return None
+    sample_period_us = 1_000_000.0 / float(sample_rate_hz)
+    tolerance_us = max(1.0, sample_period_us * 0.75)
+    previous = None
+    for chunk in sorted(raw_range.chunks, key=lambda item: (item.t0_us, item.sample_start)):
+        if previous is not None:
+            expected_start_us = float(previous.t0_us) + (
+                float(previous.sample_count) * sample_period_us
+            )
+            delta_us = float(chunk.t0_us) - expected_start_us
+            if delta_us > tolerance_us:
+                return "window_crosses_gap"
+            if delta_us < -tolerance_us:
+                return "window_crosses_overlap"
+        previous = chunk
+    return None
 
 
 def _server_queue_drop_count(loss_stats: RawCaptureLossStats) -> int:
@@ -719,7 +969,7 @@ def _build_artifact_bundle(
     *,
     run_id: str,
     plan: WholeRunWindowPlan,
-    raw_capture: RawRunCapture,
+    raw_capture_manifest: RawCaptureManifest,
     sensors: Sequence[RawCaptureSensorManifest],
     chunk_results: Sequence[_SpectralChunkResult],
     created_at: str,
@@ -791,7 +1041,7 @@ def _build_artifact_bundle(
             "summary_storage_format": "jsonl",
         },
         source_raw_manifests=(
-            WholeRunSourceRawManifest.from_raw_capture_manifest(raw_capture.manifest),
+            WholeRunSourceRawManifest.from_raw_capture_manifest(raw_capture_manifest),
         ),
     )
     return WholeRunSpectralArtifactBundle(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
@@ -19,8 +19,8 @@ from vibesensor.shared.run_context_warning import (
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.shared.types.raw_capture import (
     RawCaptureCoverageState,
-    RawCaptureSensorData,
-    RawRunCapture,
+    RawCaptureManifest,
+    RawCaptureSensorManifest,
 )
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 from vibesensor.shared.window_quality import WindowQuality, clean_window_quality
@@ -166,9 +166,9 @@ class WholeRunSpectralCoverageSummary:
 
 def build_coverage_summary(
     *,
-    raw_capture: RawRunCapture,
+    raw_capture_manifest: RawCaptureManifest,
     plan: WholeRunWindowPlan | None,
-    sensors: Sequence[RawCaptureSensorData],
+    sensors: Sequence[RawCaptureSensorManifest],
     timelines: Mapping[str, RawSensorTimeline],
     summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
 ) -> WholeRunSpectralCoverageSummary:
@@ -182,7 +182,7 @@ def build_coverage_summary(
     limited_window_count = 0
     excluded_window_count = 0
     for sensor in sensors:
-        summaries = summaries_by_sensor.get(sensor.manifest.client_id, ())
+        summaries = summaries_by_sensor.get(sensor.client_id, ())
         if not summaries and plan is not None:
             total_sensor_window_count += plan.total_window_count
             missing_sensor_window_count += plan.total_window_count
@@ -210,11 +210,10 @@ def build_coverage_summary(
     sample_rate_mismatch_sensor_count = sum(
         1
         for sensor in sensors
-        if sensor.manifest.sample_rate_corrected
-        or sensor.manifest.sample_rate_proof_state == "timing_inconsistent"
+        if sensor.sample_rate_corrected or sensor.sample_rate_proof_state == "timing_inconsistent"
     )
     sample_rate_unverified_sensor_count = sum(
-        1 for sensor in sensors if sensor.manifest.sample_rate_unverified
+        1 for sensor in sensors if sensor.sample_rate_unverified
     )
     unanchored_sensor_count = sum(1 for timeline in timelines.values() if not timeline.anchored)
     legacy_sensor_count = sum(
@@ -233,18 +232,18 @@ def build_coverage_summary(
         for timeline in timelines.values()
         if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
     )
-    dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
-    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
+    dropped_chunk_count = raw_capture_manifest.total_dropped_chunk_count
+    late_packet_chunk_count = raw_capture_manifest.total_late_packet_chunk_count
     udp_ingest_queue_drop_count = _manifest_loss_count(
-        raw_capture,
+        raw_capture_manifest,
         "udp_ingest_queue_drop_count",
     )
     queue_overflow_chunk_count = _manifest_loss_count(
-        raw_capture,
+        raw_capture_manifest,
         "queue_overflow_chunk_count",
     )
-    invalid_chunk_count = _manifest_loss_count(raw_capture, "invalid_chunk_count")
-    write_error_chunk_count = _manifest_loss_count(raw_capture, "write_error_chunk_count")
+    invalid_chunk_count = _manifest_loss_count(raw_capture_manifest, "invalid_chunk_count")
+    write_error_chunk_count = _manifest_loss_count(raw_capture_manifest, "write_error_chunk_count")
     coverage_confidence = build_coverage_confidence(
         total_sensor_window_count=total_sensor_window_count,
         partial_sensor_window_count=partial_sensor_window_count,
@@ -310,13 +309,13 @@ def build_coverage_summary(
     )
 
 
-def _manifest_loss_count(raw_capture: RawRunCapture, field_name: str) -> int:
-    manifest_total = max(0, int(getattr(raw_capture.manifest.losses, field_name)))
+def _manifest_loss_count(raw_capture_manifest: RawCaptureManifest, field_name: str) -> int:
+    manifest_total = max(0, int(getattr(raw_capture_manifest.losses, field_name)))
     if manifest_total > 0:
         return manifest_total
     return sum(
         max(0, int(getattr(sensor_loss.losses, field_name)))
-        for sensor_loss in raw_capture.manifest.sensor_losses
+        for sensor_loss in raw_capture_manifest.sensor_losses
     )
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_raw_capture_policy.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_raw_capture_policy.py
@@ -8,7 +8,7 @@ from vibesensor.shared.raw_capture_quality import (
     RawCaptureLossPolicyAssessment,
     assess_raw_capture_loss_policy,
 )
-from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
 
 from .post_analysis_loader import LoadedPostAnalysisRun
 
@@ -28,11 +28,15 @@ class WholeRunRawCapturePolicy:
             self.loss_policy.reason if self.loss_policy.gate_whole_run else "missing_prerequisites"
         )
 
-    def spectra_prerequisites_met(self, raw_capture: RawRunCapture | None) -> bool:
-        return raw_capture is not None and self.whole_run_allowed
+    def spectra_prerequisites_met(self, *, raw_range_reader_available: bool) -> bool:
+        return self.manifest is not None and raw_range_reader_available and self.whole_run_allowed
 
-    def spectra_prerequisite_reason(self, raw_capture: RawRunCapture | None) -> str:
-        return "raw_capture_missing" if raw_capture is None else self.prerequisite_reason
+    def spectra_prerequisite_reason(self, *, raw_range_reader_available: bool) -> str:
+        if self.manifest is None:
+            return "raw_capture_manifest_missing"
+        if not raw_range_reader_available:
+            return "raw_capture_range_reader_missing"
+        return self.prerequisite_reason
 
     def context_prerequisites_met(self) -> bool:
         return self.manifest is not None and self.whole_run_allowed

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
@@ -28,9 +28,10 @@ from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
     build_whole_run_spatial_coherence_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    RawCaptureRangeReader,
     WholeRunSpectralArtifactBundle,
     WholeRunSpectralBuildResult,
-    build_whole_run_spectral_artifact_bundle,
+    build_whole_run_spectral_artifact_bundle_from_ranges,
 )
 from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
@@ -48,12 +49,14 @@ def build_whole_run_artifacts(
     *,
     run_id: str,
     metadata: RunMetadata,
-    raw_capture: RawRunCapture,
+    raw_capture_manifest: RawCaptureManifest,
+    raw_range_reader: RawCaptureRangeReader,
 ) -> WholeRunSpectralBuildResult:
-    return build_whole_run_spectral_artifact_bundle(
+    return build_whole_run_spectral_artifact_bundle_from_ranges(
         run_id=run_id,
         metadata=metadata,
-        raw_capture=raw_capture,
+        raw_capture_manifest=raw_capture_manifest,
+        raw_range_reader=raw_range_reader,
     )
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_pipeline.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_pipeline.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Protocol, cast
 
 import aiosqlite
 
 from vibesensor.domain import CarOrderReferenceStatus
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.json_types import JsonObject
-from vibesensor.shared.types.raw_capture import RawRunCapture
+from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawCaptureSensorRange
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
@@ -38,8 +38,10 @@ from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
     WholeRunSpatialCoherenceArtifactBundle,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    RawCaptureRangeReader,
     WholeRunSpectralArtifactBundle,
     WholeRunSpectralBuildResult,
+    raw_capture_range_reader_from_capture,
 )
 from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
@@ -80,7 +82,8 @@ class WholeRunArtifactBuilder(Protocol):
         *,
         run_id: str,
         metadata: RunMetadata,
-        raw_capture: RawRunCapture,
+        raw_capture_manifest: RawCaptureManifest,
+        raw_range_reader: RawCaptureRangeReader,
     ) -> WholeRunSpectralBuildResult: ...
 
 
@@ -416,12 +419,16 @@ class WholeRunPipelineRunner:
         )
 
     def _run_spectral_stage(self) -> None:
-        loaded = self.context.loaded
         raw_capture_policy = self.context.raw_capture_policy
+        raw_range_reader_available = self._raw_range_reader_available()
         self.state.spectral_result = self._record_stage(
             stage_name="BuildWholeRunSpectraStage",
-            prerequisites_met=raw_capture_policy.spectra_prerequisites_met(loaded.raw_capture),
-            prerequisite_reason=raw_capture_policy.spectra_prerequisite_reason(loaded.raw_capture),
+            prerequisites_met=raw_capture_policy.spectra_prerequisites_met(
+                raw_range_reader_available=raw_range_reader_available,
+            ),
+            prerequisite_reason=raw_capture_policy.spectra_prerequisite_reason(
+                raw_range_reader_available=raw_range_reader_available,
+            ),
             runner=self._build_spectral_stage,
         )
         if self.state.spectral_result is not None:
@@ -431,12 +438,13 @@ class WholeRunPipelineRunner:
         self,
     ) -> WholeRunStageExecution[WholeRunSpectralBuildResult | None]:
         loaded = self.context.loaded
-        raw_capture = loaded.raw_capture
-        assert raw_capture is not None
+        raw_capture_manifest = self.context.raw_capture_policy.manifest
+        assert raw_capture_manifest is not None
         result = self.context.builders.artifact_builder(
             run_id=loaded.run_id,
             metadata=loaded.metadata,
-            raw_capture=raw_capture,
+            raw_capture_manifest=raw_capture_manifest,
+            raw_range_reader=self._raw_range_reader(),
         )
         spectral_manifest = result.bundle.manifest if result.bundle is not None else None
         return _stage_execution(
@@ -448,6 +456,37 @@ class WholeRunPipelineRunner:
                 "coverage_confidence": result.coverage_summary.coverage_confidence,
             },
         )
+
+    def _raw_range_reader_available(self) -> bool:
+        if callable(getattr(self.context.db, "aload_raw_capture_sensor_range", None)):
+            return True
+        return self.context.loaded.raw_capture is not None
+
+    def _raw_range_reader(self) -> RawCaptureRangeReader:
+        loaded = self.context.loaded
+        if not callable(getattr(self.context.db, "aload_raw_capture_sensor_range", None)):
+            assert loaded.raw_capture is not None
+            return raw_capture_range_reader_from_capture(loaded.raw_capture)
+
+        def read_range(
+            client_id: str,
+            *,
+            sample_start: int,
+            sample_count: int,
+        ) -> RawCaptureSensorRange | None:
+            return cast(
+                RawCaptureSensorRange | None,
+                sync_run_persistence_call(
+                    self.context.db,
+                    "aload_raw_capture_sensor_range",
+                    loaded.run_id,
+                    client_id,
+                    sample_start=sample_start,
+                    sample_count=sample_count,
+                ),
+            )
+
+        return read_range
 
     def _run_context_stage(self) -> None:
         raw_capture_policy = self.context.raw_capture_policy

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -51,17 +51,15 @@ preserved.
 
 The connected full-run dense path is the `whole_run_*` sidecar pipeline wired by
 `use_cases/run/post_analysis_executor.py` through
-`use_cases/run/post_analysis_whole_run_builders.py`. It currently receives the
-full `RawRunCapture` loaded by `post_analysis_loader.py`, then builds and stores
-dense sidecar artifacts before compact report-facing summaries are persisted.
-The future streaming/range-read refactor should reuse the bounded range-read
-boundary in `post_run_raw_windows.py`, but that boundary is not the active
-executor input today.
+`use_cases/run/post_analysis_whole_run_builders.py`. Whole-run spectra now use
+`RawCaptureManifest` plus `RunPersistence.aload_raw_capture_sensor_range(...)`
+instead of receiving a full `RawRunCapture`; compact summary-row replay may still
+load full raw capture before compact report-facing summaries are persisted.
 
 Current whole-run sidecar stages:
 
 1. `use_cases/diagnostics/whole_run_spectra.py` computes deterministic
-   raw-window spectra from raw capture and emits `spectral-grid:*`,
+   raw-window spectra from bounded raw range reads and emits `spectral-grid:*`,
    `spectral-matrix:*`, and `spectral-summary:*` sidecars. The summaries carry
    window timing, coverage/quality, top peaks, and dB strength facts without
    forcing reports to read the dense matrices.
@@ -84,8 +82,8 @@ Current whole-run sidecar stages:
    summary through `RunPersistence.astore_analysis(...)`.
 
 The older `post_run_*` modules are compatibility/support/prototype components.
-`post_run_raw_windows.py` is the manifest-aware range-read access boundary for
-future streaming work; `post_run_stft.py`, `post_run_window_features.py`,
+`post_run_raw_windows.py` remains an alternate manifest-aware range-window
+iterator; `post_run_stft.py`, `post_run_window_features.py`,
 `post_run_vehicle_reference.py`, `post_run_order_bands.py`,
 `post_run_vibration_episodes.py`, and `post_run_dense_findings.py` preserve
 useful dense DTO and math seams, but the active sidecar pipeline is the
@@ -114,10 +112,10 @@ RunRecorder.stop_recording()            # use_cases/run/logger.py
             └─ _worker_loop()           # daemon thread, sequential queue
                  └─ _run_post_analysis(run_id)
                       ├─ load metadata + persisted summary rows via injected RunPersistence
-                      ├─ load full RawRunCapture when a raw-capture manifest exists
+                      ├─ load raw manifest; compact replay may load full RawRunCapture
                       ├─ build_post_analysis_input(...)
                       │    └─ raw_capture_replay.py rebuilds FFT-derived strength fields from raw windows when possible
-                      ├─ whole_run_* sidecar stages (spectra, context, orders, spatial coherence)
+                      ├─ whole_run_* sidecar stages (spectra use bounded raw ranges)
                       ├─ analysis_runner(...)
                       │    ← injected by RunRecorder
                       │      └─ RunAnalysis(metadata, samples, …).summarize()
@@ -177,14 +175,14 @@ summaries to the persisted analysis.
 | `_reference_resolution.py` | ~80 | Engine/tire/reference resolution helpers reused by order analysis |
 | `_sensor_locations.py` | ~80 | Stable sensor-location labels and connected-throughout-run detection |
 | `_run_loader.py` | ~20 | JSONL run loader used by analysis/report adapters |
-| `post_run_raw_windows.py` | ~300 | Compatibility/future-streaming manifest-aware raw waveform range reader and configurable overlapping-window iterator |
+| `post_run_raw_windows.py` | ~300 | Compatibility/support manifest-aware raw waveform range reader and configurable overlapping-window iterator |
 | `post_run_stft.py` | ~350 | Support/prototype in-memory dense STFT engine over range-read raw-window DTOs |
 | `post_run_window_features.py` | ~300 | Support/prototype window-level feature extraction over dense STFT frames |
 | `post_run_vehicle_reference.py` | ~350 | Support/prototype per-window vehicle speed/RPM/gear/final-drive reference normalization |
 | `post_run_order_bands.py` | ~400 | Support/prototype per-window wheel/driveshaft/engine order-band generation |
 | `post_run_vibration_episodes.py` | ~450 | Support/prototype deterministic grouping of dense window peaks into episodes |
 | `post_run_dense_findings.py` | ~500 | Support/prototype dense episode classification and domain-finding projection |
-| `whole_run_spectra.py` | ~900 | Active sidecar spectral executor over loaded raw capture; emits dense spectra and compact spectral summaries |
+| `whole_run_spectra.py` | ~900 | Active sidecar spectral executor over bounded raw range reads; emits dense spectra and compact spectral summaries |
 | `whole_run_context.py` | ~400 | Active sidecar context timeline and compact context intervals on the whole-run window grid |
 | `whole_run_spatial_coherence.py` | ~450 | Active candidate-level spatial evidence sidecars and compact spatial summaries |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |

--- a/docs/dataflows.md
+++ b/docs/dataflows.md
@@ -44,25 +44,24 @@ Deep dive: `docs/run_lifecycle.md`
 |------|-------------|
 | Source | Optional per-run raw capture written alongside an active recording |
 | Main path | `use_cases/run/raw_capture_writer.py` -> raw capture manifest/store -> `use_cases/run/post_analysis_loader.py` -> `use_cases/run/post_analysis_input.py` + `raw_capture_replay.py` + `post_analysis_whole_run_builders.py` |
-| Boundary | Raw capture is loaded through `RunPersistence`; compact replay and dense sidecar production stay inside the post-analysis pipeline |
+| Boundary | Raw capture is read through `RunPersistence`; compact replay and dense sidecar production stay inside the post-analysis pipeline |
 | Final consumer | Offline post-stop analysis: raw replay compatibility plus whole-run sidecar builders |
 | Data shape | Persisted and replayable raw artifacts, dense sidecar artifacts, and compact persisted summaries |
 
 Raw capture is not the report path and not the live UI path. Post-analysis may
 use raw replay when the manifest/store exists, or fall back to persisted summary
-rows when it does not. When raw capture is available, the current whole-run
-sidecar path builds spectra, context labels, order traces/summaries, family
+rows when it does not. When raw capture is available, whole-run spectra use
+bounded raw range reads, then the sidecar path builds context labels, order
+traces/summaries, family
 summaries, and spatial coherence through `post_analysis_whole_run_builders.py`
 and the `whole_run_*` diagnostics modules. Dense spectra/traces/matrices stay in
 `whole-run-artifacts/<run_id>/`; compact report-facing summaries and manifest
 metadata are appended to `analysis_json`.
 
-The compatibility/future-streaming raw window path is
-`use_cases/diagnostics/post_run_raw_windows.py`, which uses bounded raw range
-reads. The connected whole-run sidecar executor still receives a full
-`RawRunCapture` from `post_analysis_loader.py`, so future range-read work should
-replace that internal input without changing the history/report read side.
-Degraded or missing raw/whole-run state must propagate forward as
+`use_cases/diagnostics/post_run_raw_windows.py` remains a compatibility/support
+bounded raw range-window iterator. The connected whole-run spectral executor is
+`use_cases/diagnostics/whole_run_spectra.py`. Degraded or missing raw/whole-run
+state must propagate forward as
 lifecycle/artifact status and report context instead of triggering a second ad
 hoc recovery path in history or PDF code.
 

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -32,11 +32,9 @@ below.
 - `apps/server/vibesensor/use_cases/run/logger.py` finalizes a run and schedules
    `PostAnalysisWorker`.
 - `apps/server/vibesensor/use_cases/run/post_analysis_loader.py` loads persisted
-   samples for a run, but caps analysis input at `_MAX_POST_ANALYSIS_SAMPLES =
-   12_000` and applies event-preserving sampling when the summary row set is
-   longer. When a raw-capture manifest exists, the loader also asks persistence
-   for the full `RawRunCapture` via `aload_raw_capture(...)`; the current
-   connected whole-run sidecar path is not yet a pure range-streaming executor.
+   samples for a run, caps compact analysis input at `_MAX_POST_ANALYSIS_SAMPLES =
+   12_000`, and applies event-preserving sampling when needed. Compact summary
+   replay may still use a full `RawRunCapture`; whole-run spectra do not.
 - `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` uses raw capture
    only to rebuild FFT-derived metrics for those already-persisted summary rows.
 - `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` is the
@@ -64,15 +62,13 @@ below.
    `.raw.i16le` and `.index.jsonl` files via
    `apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py`.
 - Indexed raw range reads exist through
-  `RunPersistence.aload_raw_capture_sensor_range(...)` and are used by the
-  compatibility/prototype diagnostics boundary in
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py`.
+   `RunPersistence.aload_raw_capture_sensor_range(...)`.
 - The current connected dense sidecar path is owned by
   `apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py` and
   the `whole_run_*` diagnostics modules:
   - `whole_run_spectra.py` builds deterministic whole-run spectral sidecars from
-    `RawRunCapture`, emitting spectral grids/matrices plus per-window compact
-    spectral summaries.
+    `RawCaptureManifest` plus bounded raw range reads, emitting spectral
+    grids/matrices plus per-window compact spectral summaries.
   - `whole_run_context.py` labels the same window grid with speed/RPM/reference
     context and persists compact context intervals in `analysis_json`.
   - `orders/whole_run_traces.py` builds dense order trace points from
@@ -85,9 +81,9 @@ below.
     windows and compact spatial summaries.
 - `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py`
   persists dense sidecar artifacts under `data/whole-run-artifacts/{run_id}/`.
-- The older `post_run_*` modules remain useful support/prototype code for
-  bounded range-read experiments and legacy dense DTOs, but they are not the
-  currently connected sidecar pipeline in `execute_post_analysis()`.
+- The older `post_run_*` modules remain useful support/prototype code for legacy
+   dense DTOs and alternate bounded-window iteration, but they are not the
+   currently connected sidecar pipeline in `execute_post_analysis()`.
 
 ### Persisted analysis and reporting
 
@@ -106,16 +102,13 @@ The current architecture has raw capture, a canonical executor, dense sidecar
 persistence, whole-run spectra/context/order/spatial stages, and compact
 report-facing summaries. Remaining debt is narrower:
 
-1. **Future streaming/range-read refactor.** The compatibility
-   `post_run_raw_windows.py` path reads bounded raw ranges, but the connected
-   whole-run spectral stage currently receives a fully loaded `RawRunCapture`
-   from `post_analysis_loader.py`. Long-run memory pressure should be reduced by
-   wiring the sidecar executor to bounded range reads or an equivalent streaming
-   source.
-2. **Summary-era compatibility remains.** The compact `RunAnalysis` path over
+1. **Summary-era compatibility remains.** The compact `RunAnalysis` path over
    summary rows still builds the report-facing baseline. Whole-run summaries are
    projected into that persisted analysis, but legacy `Finding` narratives remain
    a fallback when fused whole-run diagnosis summaries are absent.
+2. **Compact raw replay still materializes raw capture.** Summary-row replay may
+   still use the optional full `RawRunCapture`; keep it separate from the
+   bounded range-read whole-run sidecar executor.
 3. **Dense sidecars are write-mostly.** History/report consumers intentionally
    read compact summaries and manifests. Sidecar readback is limited to explicit
    internal needs; adding new report surfaces should still project compact
@@ -131,7 +124,7 @@ diagnosis/report summaries.
 
 ```text
 raw capture manifest/files (#3065)
-  -> current RawRunCapture load (future streaming/range-read refactor)
+  -> bounded raw range reads for whole-run spectra
   -> deterministic window planner
   -> raw-window spectral executor
   -> context timeline + segment labels
@@ -147,8 +140,8 @@ raw capture manifest/files (#3065)
 | Layer | Owner area | Responsibility |
 |---|---|---|
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
-| Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
-| Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine, `post_run_window_features.py` owns the compact per-window feature reduction, and `post_run_vibration_episodes.py` owns deterministic episode grouping |
+| Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `whole_run_spectra.py` resolves each window to bounded raw range reads |
+| Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py`, `post_run_window_features.py`, and `post_run_vibration_episodes.py` remain support/prototype seams |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments; `post_run_vehicle_reference.py` owns the conservative vehicle-reference timeline for dense stages |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability; `post_run_order_bands.py` owns the pre-classification per-window expected band grid |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -13,11 +13,9 @@ one big state-machine class:
   artifact finalization for the active run.
 - `PostAnalysisWorker` owns the background queue and retry policy after a run
   stops.
-- `post_run_raw_windows.py` owns the compatibility/future-streaming raw artifact
-  window access boundary. It reads finalized raw sidecars by bounded ranges and
-  emits structured window warnings, but the current connected whole-run sidecar
-  executor still receives a full `RawRunCapture` loaded by
-  `post_analysis_loader.py`.
+- `whole_run_spectra.py` owns the connected bounded raw range-read sidecar
+  executor. `post_run_raw_windows.py` remains a compatibility/support window
+  iterator over finalized raw sidecars.
 - `CaptureReadinessTracker` owns the backend pre-record readiness checklist for
   idle/live states.
 - `RunRecorder` coordinates those helpers without re-owning their internals.
@@ -33,7 +31,7 @@ one big state-machine class:
 | `CaptureReadinessTracker` | `use_cases/run/capture_readiness.py` | Evaluate live-sensor readiness, reference freshness, steady-speed dwell, and recent integrity quiet windows for the idle recording gate. |
 | `RunRecorder` | `use_cases/run/logger.py` | Start/stop entrypoint and coordinator for lifecycle, persistence, and post-analysis. |
 | `PostAnalysisWorker` | `use_cases/run/post_analysis.py` | Non-evicting queue and single daemon thread for completed runs. |
-| `execute_post_analysis()` | `use_cases/run/post_analysis_executor.py` | Load metadata/samples/raw capture, build dense whole-run sidecars and compact persisted analysis, and store success or failure. |
+| `execute_post_analysis()` | `use_cases/run/post_analysis_executor.py` | Load metadata/samples/raw manifests, build dense whole-run sidecars and compact persisted analysis, and store success or failure. |
 
 ## Lifecycle phases
 
@@ -163,17 +161,13 @@ because there is nothing persistent to close.
   artifacts when raw capture is available, calls the injected compact analysis
   runner, appends compact whole-run summaries/metadata, and stores either
   analysis output or an analysis error record
-- the loaded post-stop input includes persisted summary rows and, when present,
-  a full raw-capture bundle loaded through `RunPersistence.aload_raw_capture()`;
-  the raw replay path rebuilds FFT-derived strength/peak fields for the compact
-  summary-row compatibility path and falls back to summary-only rows otherwise
+- the loaded post-stop input includes persisted summary rows and raw manifests;
+  compact raw replay may load a full raw-capture bundle, while whole-run spectra
+  read bounded ranges through `RunPersistence.aload_raw_capture_sensor_range()`
 - the current whole-run sidecar stages are spectra, context labels, order trace
   points, order trace summaries, order family summaries, spatial coherence, and
   artifact persistence; dense artifacts stay under `whole-run-artifacts/`, while
   `analysis_json` keeps compact report-facing summaries
-- future streaming/range-read refactor work should wire the connected whole-run
-  sidecar executor to bounded raw range reads instead of materializing the full
-  `RawRunCapture` for long runs
 
 The worker also exposes `PostAnalysisHealthSnapshot`, which is what the health
 surface uses for queue depth, active run ID, and the most recent completion
@@ -233,7 +227,7 @@ task/timeout helpers:
 | `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` | Load -> whole-run sidecars -> compact analysis -> store execution path. |
 | `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` | Raw-window replay for post-stop strength/peak rebuilding before diagnostics. |
 | `apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py` | Adapter between the executor and whole-run spectra/context/order/spatial sidecar builders. |
-| `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py` | Compatibility/future-streaming raw range-read window boundary. |
-| `apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py` | Current whole-run spectral sidecar builder over loaded raw capture. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py` | Compatibility/support raw range-read window boundary. |
+| `apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py` | Current whole-run spectral sidecar builder over bounded raw range reads. |
 | `apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py` | Current whole-run context labels and compact intervals. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_*.py` | Current whole-run order trace, scoring, and family-summary sidecar/summarization stages. |


### PR DESCRIPTION
## What changed
- Whole-run spectra now build from `RawCaptureManifest` plus bounded `aload_raw_capture_sensor_range(...)` reads.
- Added a range-reader protocol and kept an in-memory reader only for already-loaded captures and parity tests.
- Coverage summaries now project from raw manifests, not full capture objects.
- Updated docs that still described this as future work.

## Why
- The connected whole-run spectral sidecar path should not require materializing full raw sample buffers.
- Long runs need bounded window reads while preserving existing sidecar outputs.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py`
- related post-analysis pytest subset
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make plan-validation`

## Risks / edge cases
- Compact summary-row raw replay may still use a full `RawRunCapture`; this keeps scope separate from whole-run sidecars.
- Manifest-only planning cannot inspect every chunk up front, so per-window reads still check returned range chunks for timing gaps/overlaps.

Closes #3775