### PR TITLE
Split RunRecorder session and finalize services

### DIFF
--- a/apps/server/tests/use_cases/run/test_raw_capture_finalize_registry.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_finalize_registry.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+
+from vibesensor.use_cases.run.raw_capture_finalize_registry import RawCaptureFinalizeRegistry
+from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
+
+
+def test_raw_capture_finalize_registry_keeps_success_over_late_duplicate(
+    caplog,
+) -> None:
+    registry = RawCaptureFinalizeRegistry(logger=logging.getLogger("test.raw.finalize"))
+
+    with caplog.at_level(logging.WARNING, logger="test.raw.finalize"):
+        first = registry.record_result("run-1", RawCaptureFinalizeResult(status="completed"))
+        ignored = registry.record_late_result(
+            "run-1",
+            RawCaptureFinalizeResult(status="completed", error="late duplicate"),
+        )
+
+    assert first.status == "completed"
+    assert ignored is None
+    assert registry.finalize_for_run("run-1") == first
+    assert not caplog.records
+
+
+def test_raw_capture_finalize_registry_replaces_timeout_with_late_result() -> None:
+    registry = RawCaptureFinalizeRegistry(logger=logging.getLogger("test.raw.finalize"))
+
+    timeout = registry.record_result(
+        "run-2",
+        RawCaptureFinalizeResult(status="timeout", error="pending", queue_depth=2),
+    )
+    completed = registry.record_late_result(
+        "run-2",
+        RawCaptureFinalizeResult(status="completed", queue_depth=0),
+    )
+
+    assert timeout.status == "timeout"
+    assert completed is not None
+    assert completed.status == "completed"
+    assert registry.finalize_for_run("run-2") == completed

--- a/apps/server/tests/use_cases/run/test_recording_session.py
+++ b/apps/server/tests/use_cases/run/test_recording_session.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from vibesensor.shared.types.raw_capture import RawCaptureLossStats
+
+
+def test_recording_session_start_owns_context_snapshots_and_ingest_drop_baseline(
+    make_logger,
+) -> None:
+    recorder = make_logger()
+    active = recorder.registry.get("active")
+    assert active is not None
+    active.server_queue_drops = 2
+
+    snapshot = recorder._recording_session.start_new_run()
+    active.server_queue_drops = 5
+
+    assert recorder.processor.flush_calls == [("active", "recording run start")]
+    assert recorder._lifecycle.run_id == snapshot.run_id
+    assert recorder._recording_session.run_context_snapshot(snapshot.run_id).analysis_settings
+    assert recorder._recording_session.run_sensor_snapshots_for_run(snapshot.run_id)
+    assert recorder._recording_session.ingest_drop_losses() == {
+        "active": RawCaptureLossStats(udp_ingest_queue_drop_count=3),
+    }
+
+
+def test_recording_session_clear_stopped_run_drops_active_context(make_logger) -> None:
+    recorder = make_logger()
+    snapshot = recorder._recording_session.start_new_run()
+    assert recorder._recording_session.run_sensor_snapshots_for_run(snapshot.run_id)
+
+    recorder._recording_session.clear_stopped_run()
+
+    assert recorder._recording_session.run_sensor_snapshots_for_run(snapshot.run_id) == ()
+    assert recorder._recording_session.ingest_drop_losses() is None

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -7,7 +7,6 @@ import time
 from collections.abc import Mapping
 from threading import RLock
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import numpy as np
 from opentelemetry.trace import SpanKind
@@ -23,16 +22,12 @@ from vibesensor.shared.ports import (
     SpeedProvider,
 )
 from vibesensor.shared.structured_logging import log_extra
-from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.shared.types.raw_capture import (
     RawCaptureClockProofState,
-    RawCaptureLossStats,
-    RawCaptureManifest,
     RawCaptureSensorClockSync,
 )
-from vibesensor.shared.types.run_schema import RunRawCaptureFinalize, RunSensorMetadata
-from vibesensor.shared.types.sensor_config import SensorConfigPayload
+from vibesensor.shared.types.run_schema import RunRawCaptureFinalize
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
 from vibesensor.use_cases.run.finalize_stages import (
@@ -49,15 +44,12 @@ from vibesensor.use_cases.run.persistence_writer import (
 )
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+from vibesensor.use_cases.run.raw_capture_finalize_registry import RawCaptureFinalizeRegistry
 from vibesensor.use_cases.run.raw_capture_writer import (
     RawCaptureFinalizeResult,
     RunRawCaptureWriter,
 )
-from vibesensor.use_cases.run.run_context import build_run_context_snapshot
-from vibesensor.use_cases.run.run_sensor_snapshot import (
-    build_run_sensor_snapshot,
-    capture_run_sensor_snapshots,
-)
+from vibesensor.use_cases.run.recording_session import RunRecordingSessionService
 from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator
 from vibesensor.use_cases.run.status_reporting import (
     RunRecorderStatusSnapshot,
@@ -71,6 +63,9 @@ if TYPE_CHECKING:
     from vibesensor.domain import RunContextSnapshot
     from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
     from vibesensor.shared.types.health_snapshot import RunRecorderHealthSnapshot
+    from vibesensor.shared.types.raw_capture import RawCaptureManifest
+    from vibesensor.shared.types.run_schema import RunSensorMetadata
+    from vibesensor.shared.types.sensor_config import SensorConfigPayload
     from vibesensor.use_cases.run.lifecycle_state import ActiveRunSnapshot
 
 LOGGER = logging.getLogger(__name__)
@@ -116,9 +111,6 @@ class RunRecorder:
         self._lock = RLock()
         self._history_db = history_db
         self._language_reader = language_reader
-        self._live_start_mono_s = time.monotonic()
-        self._active_run_context: RunContextSnapshot | None = None
-        self._run_sensor_snapshots: dict[str, RunSensorMetadata] = {}
         self._capture_readiness = CaptureReadinessTracker()
 
         self._lifecycle = RunLifecycleState(
@@ -158,15 +150,31 @@ class RunRecorder:
             ),
             late_finalize_callback=self._handle_late_raw_capture_finalize_result,
         )
+        self._raw_capture_finalize_registry = RawCaptureFinalizeRegistry(logger=LOGGER)
+        self._recording_session = RunRecordingSessionService(
+            lock=self._lock,
+            registry=self.registry,
+            processor=self.processor,
+            settings_reader=settings_reader,
+            sensor_metadata_reader=sensor_metadata_reader,
+            lifecycle=self._lifecycle,
+            persistence=self._persistence,
+            raw_capture=self._raw_capture,
+            analysis_settings_snapshot=self._analysis_settings_snapshot,
+            active_frames_total=lambda: _recorder_runtime.active_frames_total(self.registry),
+            monotonic=lambda: time.monotonic(),
+        )
 
         self._sample_flush = SampleFlushOrchestrator(
             registry=self.registry,
             gps_monitor=self.gps_monitor,
             processor=self.processor,
-            analysis_settings_snapshot=self._recording_analysis_settings_snapshot,
+            analysis_settings_snapshot=self._recording_session.recording_analysis_settings_snapshot,
             default_sample_rate_hz=self.default_sample_rate_hz,
             sensor_metadata_reader=sensor_metadata_reader,
-            run_sensor_presentation_resolver=self._resolve_run_sensor_presentation,
+            run_sensor_presentation_resolver=(
+                self._recording_session.resolve_run_sensor_presentation
+            ),
             lifecycle=self._lifecycle,
             persistence=self._persistence,
             active_frames_total=lambda: _recorder_runtime.active_frames_total(self.registry),
@@ -176,9 +184,6 @@ class RunRecorder:
 
         with self._lock:
             self._persistence.reset()
-        self._run_ingest_drop_baseline: dict[str, int] | None = None
-        self._finalized_raw_capture_manifests: dict[str, RawCaptureManifest] = {}
-        self._raw_capture_finalize_results: dict[str, RunRawCaptureFinalize] = {}
 
     @property
     def enabled(self) -> bool:
@@ -196,6 +201,10 @@ class RunRecorder:
     def _run_id(self) -> str | None:
         return self._lifecycle.run_id
 
+    @property
+    def _live_start_mono_s(self) -> float:
+        return self._recording_session.live_start_mono_s
+
     def _run_id_matches(self, run_id: str) -> bool:
         current = self._lifecycle.current_run
         return current is not None and current.run_id == run_id
@@ -204,47 +213,22 @@ class RunRecorder:
         return _recorder_runtime.analysis_settings_snapshot(self._settings_reader)
 
     def _raw_capture_manifest_for_run(self, run_id: str) -> RawCaptureManifest | None:
-        return self._finalized_raw_capture_manifests.get(run_id)
+        return self._raw_capture_finalize_registry.manifest_for_run(run_id)
 
     def _raw_capture_finalize_for_run(self, run_id: str) -> RunRawCaptureFinalize | None:
-        return self._raw_capture_finalize_results.get(run_id)
+        return self._raw_capture_finalize_registry.finalize_for_run(run_id)
 
     def _live_run_context_snapshot(self) -> RunContextSnapshot:
-        active_car_snapshot = (
-            self._settings_reader.active_car_snapshot()
-            if self._settings_reader is not None
-            else None
-        )
-        return build_run_context_snapshot(
-            analysis_settings_snapshot=self._analysis_settings_snapshot(),
-            active_car_snapshot=active_car_snapshot,
-        )
+        return self._recording_session.live_run_context_snapshot()
 
     def _run_context_snapshot(self, run_id: str | None = None) -> RunContextSnapshot:
-        with self._lock:
-            current_run = self._lifecycle.current_run
-            active_run_context = self._active_run_context
-            if (
-                active_run_context is not None
-                and current_run is not None
-                and current_run.is_recording
-                and (run_id is None or current_run.run_id == run_id)
-            ):
-                return active_run_context
-        return self._live_run_context_snapshot()
+        return self._recording_session.run_context_snapshot(run_id)
 
     def _recording_analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
-        return self._run_context_snapshot().analysis_settings
+        return self._recording_session.recording_analysis_settings_snapshot()
 
     def _run_sensor_snapshots_for_run(self, run_id: str) -> tuple[RunSensorMetadata, ...]:
-        with self._lock:
-            current_run = self._lifecycle.current_run
-            if current_run is None or current_run.run_id != run_id:
-                return tuple()
-            return tuple(
-                self._run_sensor_snapshots[client_id]
-                for client_id in sorted(self._run_sensor_snapshots)
-            )
+        return self._recording_session.run_sensor_snapshots_for_run(run_id)
 
     def _resolve_run_sensor_presentation(
         self,
@@ -256,52 +240,21 @@ class RunRecorder:
         firmware_version: str | None,
         sensors_by_mac: Mapping[str, SensorConfigPayload],
     ) -> tuple[str, str]:
-        with self._lock:
-            snapshot = self._run_sensor_snapshots.get(client_id)
-            if snapshot is None:
-                snapshot = build_run_sensor_snapshot(
-                    sensor_id=client_id,
-                    fallback_name=fallback_name,
-                    fallback_location_code=fallback_location_code,
-                    sample_rate_hz=sample_rate_hz,
-                    firmware_version=firmware_version,
-                    sensors_by_mac=sensors_by_mac,
-                )
-                self._run_sensor_snapshots[client_id] = snapshot
-            return snapshot.display_name, snapshot.location_code
+        return self._recording_session.resolve_run_sensor_presentation(
+            client_id=client_id,
+            fallback_name=fallback_name,
+            fallback_location_code=fallback_location_code,
+            sample_rate_hz=sample_rate_hz,
+            firmware_version=firmware_version,
+            sensors_by_mac=sensors_by_mac,
+        )
 
     def _session_snapshot(self) -> ActiveRunSnapshot | None:
         with self._lock:
             return self._lifecycle.snapshot()
 
     def _start_new_run_locked(self) -> ActiveRunSnapshot:
-        for client_id in self.registry.active_client_ids():
-            self.processor.flush_client_buffer(
-                client_id,
-                reason="recording run start",
-            )
-        run_context = self._live_run_context_snapshot()
-        snapshot = self._lifecycle.start_new_run(
-            run_id=uuid4().hex,
-            analysis_settings_snapshot=run_context.analysis_settings,
-            start_time_utc=utc_now_iso(),
-            start_mono_s=time.monotonic(),
-            current_total=_recorder_runtime.active_frames_total(self.registry),
-        )
-        self._active_run_context = run_context
-        self._run_sensor_snapshots = capture_run_sensor_snapshots(
-            client_ids=self.registry.active_client_ids(),
-            registry=self.registry,
-            sensor_metadata_reader=self._sensor_metadata_reader,
-        )
-        self._persistence.reset()
-        self._live_start_mono_s = snapshot.start_mono_s
-        self._raw_capture.start_run(
-            snapshot.run_id,
-            run_start_monotonic_us=int(round(snapshot.start_mono_s * 1_000_000.0)),
-        )
-        self._run_ingest_drop_baseline = _snapshot_server_queue_drops(self.registry)
-        return snapshot
+        return self._recording_session.start_new_run()
 
     def capture_raw_samples(
         self,
@@ -388,10 +341,7 @@ class RunRecorder:
             run_id=self._run_id,
             start_time_utc=self._lifecycle.start_time_utc,
             stop_reason=reason,
-            ingest_drop_losses=_udp_ingest_drop_sensor_losses(
-                self.registry,
-                baseline=self._run_ingest_drop_baseline,
-            ),
+            ingest_drop_losses=self._recording_session.ingest_drop_losses(),
             sample_flush=self._sample_flush,
             persistence=self._persistence,
             raw_capture=self._raw_capture,
@@ -509,10 +459,8 @@ class RunRecorder:
                             finalize_result.persistence_snapshot.dropped_sample_count,
                         )
                     self._lifecycle.stop()
-                    self._active_run_context = None
-                    self._run_sensor_snapshots = {}
                     self._persistence.reset()
-                    self._run_ingest_drop_baseline = None
+                    self._recording_session.clear_stopped_run()
                     result = self.status()
             except Exception as exc:
                 mark_span_error(span, exc)
@@ -565,25 +513,7 @@ class RunRecorder:
         run_id: str,
         result: RawCaptureFinalizeResult,
     ) -> None:
-        self._raw_capture_finalize_results[run_id] = RunRawCaptureFinalize(
-            status=result.status,
-            queue_depth=result.queue_depth,
-            error_summary=result.error,
-        )
-        if result.manifest is not None:
-            self._finalized_raw_capture_manifests[run_id] = result.manifest
-        if result.completed or result.status == "not_configured":
-            return
-        LOGGER.warning(
-            "raw_capture_finalize_degraded",
-            extra=log_extra(
-                event="raw_capture_finalize_degraded",
-                run_id=run_id,
-                raw_capture_finalize_status=result.status,
-                raw_capture_queue_depth=result.queue_depth,
-                raw_capture_error=result.error,
-            ),
-        )
+        self._raw_capture_finalize_registry.record_result(run_id, result)
 
     def _handle_late_raw_capture_finalize_result(
         self,
@@ -591,11 +521,9 @@ class RunRecorder:
         result: RawCaptureFinalizeResult,
     ) -> None:
         with self._lock:
-            previous = self._raw_capture_finalize_results.get(run_id)
-            if previous is not None and previous.status != "timeout":
+            finalized = self._raw_capture_finalize_registry.record_late_result(run_id, result)
+            if finalized is None:
                 return
-            self._record_raw_capture_finalize_result(run_id, result)
-            finalized = self._raw_capture_finalize_results[run_id]
         if not self._persistence.update_raw_capture_finalize(run_id, finalized):
             LOGGER.warning(
                 "late_raw_capture_finalize_metadata_update_failed",
@@ -682,40 +610,3 @@ def _raw_capture_clock_proof_state(
 def _int_attr(value: object, name: str) -> int | None:
     raw_value = getattr(value, name, None)
     return int(raw_value) if isinstance(raw_value, int) else None
-
-
-def _snapshot_server_queue_drops(registry: ClientTracker) -> dict[str, int]:
-    client_ids: set[str] = set()
-    client_snapshots = getattr(registry, "client_snapshots", None)
-    if callable(client_snapshots):
-        for client_snapshot in client_snapshots():
-            client_id = str(getattr(client_snapshot, "client_id", "") or "").strip()
-            if client_id:
-                client_ids.add(client_id)
-    else:
-        client_ids.update(str(client_id) for client_id in registry.active_client_ids())
-    queue_drop_snapshot: dict[str, int] = {}
-    for client_id in sorted(client_ids):
-        record = registry.get(client_id)
-        if record is None:
-            continue
-        queue_drop_snapshot[client_id] = _int_attr(record, "server_queue_drops") or 0
-    return queue_drop_snapshot
-
-
-def _udp_ingest_drop_sensor_losses(
-    registry: ClientTracker,
-    *,
-    baseline: dict[str, int] | None,
-) -> dict[str, RawCaptureLossStats] | None:
-    current = _snapshot_server_queue_drops(registry)
-    client_ids = set(current) | set(baseline or {})
-    if not client_ids:
-        return None
-    losses: dict[str, RawCaptureLossStats] = {}
-    for client_id in sorted(client_ids):
-        delta = max(0, current.get(client_id, 0) - (baseline or {}).get(client_id, 0))
-        if delta <= 0:
-            continue
-        losses[client_id] = RawCaptureLossStats(udp_ingest_queue_drop_count=delta)
-    return losses or None

--- a/apps/server/vibesensor/use_cases/run/raw_capture_finalize_registry.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_finalize_registry.py
@@ -1,0 +1,64 @@
+"""Raw-capture finalization bookkeeping for recording runs."""
+
+from __future__ import annotations
+
+import logging
+
+from vibesensor.shared.structured_logging import log_extra
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
+from vibesensor.shared.types.run_schema import RunRawCaptureFinalize
+from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
+
+__all__ = ["RawCaptureFinalizeRegistry"]
+
+
+class RawCaptureFinalizeRegistry:
+    """Store raw-capture finalize results and manifests by run."""
+
+    def __init__(self, *, logger: logging.Logger) -> None:
+        self._logger = logger
+        self._manifests: dict[str, RawCaptureManifest] = {}
+        self._results: dict[str, RunRawCaptureFinalize] = {}
+
+    def manifest_for_run(self, run_id: str) -> RawCaptureManifest | None:
+        return self._manifests.get(run_id)
+
+    def finalize_for_run(self, run_id: str) -> RunRawCaptureFinalize | None:
+        return self._results.get(run_id)
+
+    def record_result(
+        self,
+        run_id: str,
+        result: RawCaptureFinalizeResult,
+    ) -> RunRawCaptureFinalize:
+        finalized = RunRawCaptureFinalize(
+            status=result.status,
+            queue_depth=result.queue_depth,
+            error_summary=result.error,
+        )
+        self._results[run_id] = finalized
+        if result.manifest is not None:
+            self._manifests[run_id] = result.manifest
+        if result.completed or result.status == "not_configured":
+            return finalized
+        self._logger.warning(
+            "raw_capture_finalize_degraded",
+            extra=log_extra(
+                event="raw_capture_finalize_degraded",
+                run_id=run_id,
+                raw_capture_finalize_status=result.status,
+                raw_capture_queue_depth=result.queue_depth,
+                raw_capture_error=result.error,
+            ),
+        )
+        return finalized
+
+    def record_late_result(
+        self,
+        run_id: str,
+        result: RawCaptureFinalizeResult,
+    ) -> RunRawCaptureFinalize | None:
+        previous = self._results.get(run_id)
+        if previous is not None and previous.status != "timeout":
+            return None
+        return self.record_result(run_id, result)

--- a/apps/server/vibesensor/use_cases/run/recording_session.py
+++ b/apps/server/vibesensor/use_cases/run/recording_session.py
@@ -1,0 +1,215 @@
+"""Active recording session state and startup coordination."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from threading import RLock
+from uuid import uuid4
+
+from vibesensor.domain import RunContextSnapshot
+from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
+from vibesensor.shared.ports import (
+    ClientTracker,
+    SensorMetadataReader,
+    SettingsReader,
+    SignalSource,
+)
+from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.raw_capture import RawCaptureLossStats
+from vibesensor.shared.types.run_schema import RunSensorMetadata
+from vibesensor.shared.types.sensor_config import SensorConfigPayload
+from vibesensor.use_cases.run.lifecycle_state import ActiveRunSnapshot, RunLifecycleState
+from vibesensor.use_cases.run.persistence_writer import RunPersistenceWriter
+from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
+from vibesensor.use_cases.run.run_context import build_run_context_snapshot
+from vibesensor.use_cases.run.run_sensor_snapshot import (
+    build_run_sensor_snapshot,
+    capture_run_sensor_snapshots,
+)
+
+__all__ = ["RunRecordingSessionService", "snapshot_server_queue_drops"]
+
+
+class RunRecordingSessionService:
+    """Own active-run context, sensor snapshots, and run-start side effects."""
+
+    def __init__(
+        self,
+        *,
+        lock: RLock,
+        registry: ClientTracker,
+        processor: SignalSource,
+        settings_reader: SettingsReader | None,
+        sensor_metadata_reader: SensorMetadataReader | None,
+        lifecycle: RunLifecycleState,
+        persistence: RunPersistenceWriter,
+        raw_capture: RunRawCaptureWriter,
+        analysis_settings_snapshot: Callable[[], AnalysisSettingsSnapshot],
+        active_frames_total: Callable[[], int],
+        monotonic: Callable[[], float],
+        uuid_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._lock = lock
+        self._registry = registry
+        self._processor = processor
+        self._settings_reader = settings_reader
+        self._sensor_metadata_reader = sensor_metadata_reader
+        self._lifecycle = lifecycle
+        self._persistence = persistence
+        self._raw_capture = raw_capture
+        self._analysis_settings_snapshot = analysis_settings_snapshot
+        self._active_frames_total = active_frames_total
+        self._monotonic = monotonic
+        self._uuid_factory = uuid_factory or (lambda: uuid4().hex)
+        self._live_start_mono_s = monotonic()
+        self._active_run_context: RunContextSnapshot | None = None
+        self._run_sensor_snapshots: dict[str, RunSensorMetadata] = {}
+        self._run_ingest_drop_baseline: dict[str, int] | None = None
+
+    @property
+    def live_start_mono_s(self) -> float:
+        return self._live_start_mono_s
+
+    def live_run_context_snapshot(self) -> RunContextSnapshot:
+        active_car_snapshot = (
+            self._settings_reader.active_car_snapshot()
+            if self._settings_reader is not None
+            else None
+        )
+        return build_run_context_snapshot(
+            analysis_settings_snapshot=self._analysis_settings_snapshot(),
+            active_car_snapshot=active_car_snapshot,
+        )
+
+    def run_context_snapshot(self, run_id: str | None = None) -> RunContextSnapshot:
+        with self._lock:
+            current_run = self._lifecycle.current_run
+            active_run_context = self._active_run_context
+            if (
+                active_run_context is not None
+                and current_run is not None
+                and current_run.is_recording
+                and (run_id is None or current_run.run_id == run_id)
+            ):
+                return active_run_context
+        return self.live_run_context_snapshot()
+
+    def recording_analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
+        return self.run_context_snapshot().analysis_settings
+
+    def run_sensor_snapshots_for_run(self, run_id: str) -> tuple[RunSensorMetadata, ...]:
+        with self._lock:
+            current_run = self._lifecycle.current_run
+            if current_run is None or current_run.run_id != run_id:
+                return tuple()
+            return tuple(
+                self._run_sensor_snapshots[client_id]
+                for client_id in sorted(self._run_sensor_snapshots)
+            )
+
+    def resolve_run_sensor_presentation(
+        self,
+        *,
+        client_id: str,
+        fallback_name: str,
+        fallback_location_code: str,
+        sample_rate_hz: int | None,
+        firmware_version: str | None,
+        sensors_by_mac: Mapping[str, SensorConfigPayload],
+    ) -> tuple[str, str]:
+        with self._lock:
+            snapshot = self._run_sensor_snapshots.get(client_id)
+            if snapshot is None:
+                snapshot = build_run_sensor_snapshot(
+                    sensor_id=client_id,
+                    fallback_name=fallback_name,
+                    fallback_location_code=fallback_location_code,
+                    sample_rate_hz=sample_rate_hz,
+                    firmware_version=firmware_version,
+                    sensors_by_mac=sensors_by_mac,
+                )
+                self._run_sensor_snapshots[client_id] = snapshot
+            return snapshot.display_name, snapshot.location_code
+
+    def start_new_run(self) -> ActiveRunSnapshot:
+        for client_id in self._registry.active_client_ids():
+            self._processor.flush_client_buffer(
+                client_id,
+                reason="recording run start",
+            )
+        run_context = self.live_run_context_snapshot()
+        start_mono_s = self._monotonic()
+        snapshot = self._lifecycle.start_new_run(
+            run_id=self._uuid_factory(),
+            analysis_settings_snapshot=run_context.analysis_settings,
+            start_time_utc=utc_now_iso(),
+            start_mono_s=start_mono_s,
+            current_total=self._active_frames_total(),
+        )
+        self._active_run_context = run_context
+        self._run_sensor_snapshots = capture_run_sensor_snapshots(
+            client_ids=self._registry.active_client_ids(),
+            registry=self._registry,
+            sensor_metadata_reader=self._sensor_metadata_reader,
+        )
+        self._persistence.reset()
+        self._live_start_mono_s = snapshot.start_mono_s
+        self._raw_capture.start_run(
+            snapshot.run_id,
+            run_start_monotonic_us=int(round(snapshot.start_mono_s * 1_000_000.0)),
+        )
+        self._run_ingest_drop_baseline = snapshot_server_queue_drops(self._registry)
+        return snapshot
+
+    def ingest_drop_losses(self) -> dict[str, RawCaptureLossStats] | None:
+        return udp_ingest_drop_sensor_losses(
+            self._registry,
+            baseline=self._run_ingest_drop_baseline,
+        )
+
+    def clear_stopped_run(self) -> None:
+        self._active_run_context = None
+        self._run_sensor_snapshots = {}
+        self._run_ingest_drop_baseline = None
+
+
+def snapshot_server_queue_drops(registry: ClientTracker) -> dict[str, int]:
+    client_ids: set[str] = set()
+    client_snapshots = getattr(registry, "client_snapshots", None)
+    if callable(client_snapshots):
+        for client_snapshot in client_snapshots():
+            client_id = str(getattr(client_snapshot, "client_id", "") or "").strip()
+            if client_id:
+                client_ids.add(client_id)
+    else:
+        client_ids.update(str(client_id) for client_id in registry.active_client_ids())
+    queue_drop_snapshot: dict[str, int] = {}
+    for client_id in sorted(client_ids):
+        record = registry.get(client_id)
+        if record is None:
+            continue
+        queue_drop_snapshot[client_id] = _int_attr(record, "server_queue_drops") or 0
+    return queue_drop_snapshot
+
+
+def udp_ingest_drop_sensor_losses(
+    registry: ClientTracker,
+    *,
+    baseline: dict[str, int] | None,
+) -> dict[str, RawCaptureLossStats] | None:
+    current = snapshot_server_queue_drops(registry)
+    client_ids = set(current) | set(baseline or {})
+    if not client_ids:
+        return None
+    losses: dict[str, RawCaptureLossStats] = {}
+    for client_id in sorted(client_ids):
+        delta = max(0, current.get(client_id, 0) - (baseline or {}).get(client_id, 0))
+        if delta <= 0:
+            continue
+        losses[client_id] = RawCaptureLossStats(udp_ingest_queue_drop_count=delta)
+    return losses or None
+
+
+def _int_attr(value: object, name: str) -> int | None:
+    raw_value = getattr(value, name, None)
+    return int(raw_value) if isinstance(raw_value, int) else None

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -11,6 +11,10 @@ one big state-machine class:
   finalization.
 - `RunRawCaptureWriter` owns the recorder-side raw UDP chunk handoff and
   artifact finalization for the active run.
+- `RunRecordingSessionService` owns active-run context snapshots, sensor
+  snapshots, run-start side effects, and ingest-drop baselines.
+- `RawCaptureFinalizeRegistry` owns raw-capture finalize manifests/results and
+  late-finalize replacement rules.
 - `PostAnalysisWorker` owns the background queue and retry policy after a run
   stops.
 - `whole_run_spectra.py` owns the connected bounded raw range-read sidecar
@@ -28,6 +32,8 @@ one big state-machine class:
 | `SampleFlushOrchestrator` | `use_cases/run/sample_flush.py` | Build `SensorFrame` rows, refresh recent metrics, and decide when to flush or auto-stop. |
 | `RunPersistenceWriter` | `use_cases/run/persistence_writer.py` | Create the persisted run, append sample rows with retries, and finalize the run metadata. |
 | `RunRawCaptureWriter` | `use_cases/run/raw_capture_writer.py` | Buffer raw UDP chunks for the active run and finalize the raw artifact manifest into history. |
+| `RunRecordingSessionService` | `use_cases/run/recording_session.py` | Active run context/sensor snapshots, start-run side effects, and ingest-drop baseline accounting. |
+| `RawCaptureFinalizeRegistry` | `use_cases/run/raw_capture_finalize_registry.py` | Raw-capture finalize result/manifest bookkeeping and late timeout replacement. |
 | `CaptureReadinessTracker` | `use_cases/run/capture_readiness.py` | Evaluate live-sensor readiness, reference freshness, steady-speed dwell, and recent integrity quiet windows for the idle recording gate. |
 | `RunRecorder` | `use_cases/run/logger.py` | Start/stop entrypoint and coordinator for lifecycle, persistence, and post-analysis. |
 | `PostAnalysisWorker` | `use_cases/run/post_analysis.py` | Non-evicting queue and single daemon thread for completed runs. |
@@ -222,6 +228,8 @@ task/timeout helpers:
 | `apps/server/vibesensor/use_cases/run/sample_flush.py` | Flush decisions, live metric refresh, and sample-row building. |
 | `apps/server/vibesensor/use_cases/run/persistence_writer.py` | History-run creation, append retries, counters, and finalize flow. |
 | `apps/server/vibesensor/use_cases/run/raw_capture_writer.py` | Recorder-side raw chunk queue and raw manifest finalization. |
+| `apps/server/vibesensor/use_cases/run/recording_session.py` | Active run context/sensor snapshots, run-start side effects, and ingest-drop baselines. |
+| `apps/server/vibesensor/use_cases/run/raw_capture_finalize_registry.py` | Raw-capture finalize result/manifest bookkeeping and late timeout replacement. |
 | `apps/server/vibesensor/use_cases/run/logger.py` | Public recording start/stop entrypoint. |
 | `apps/server/vibesensor/use_cases/run/post_analysis.py` | Queue, worker-thread, retry, and health behavior. |
 | `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` | Load -> whole-run sidecars -> compact analysis -> store execution path. |


### PR DESCRIPTION
## What changed
- Added `RunRecordingSessionService` for active run context, sensor snapshots, start-run side effects, and ingest-drop baselines.
- Added `RawCaptureFinalizeRegistry` for raw-capture finalize manifests/results and late-timeout replacement.
- Kept `RunRecorder` as the public coordinator and updated lifecycle ownership docs.

## Why
`RunRecorder` was owning too many recording concerns directly. This splits stable seams without changing start, stop, finalize, or post-analysis behavior.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/test_recording_session.py apps/server/tests/use_cases/run/test_raw_capture_finalize_registry.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/use_cases/run/test_finalize_stages.py apps/server/tests/use_cases/run/test_post_analysis_summary_raw_capture_finalize.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make plan-validation`

## Risks / edge cases
- Lifecycle lock boundaries remain in `RunRecorder`; service calls are wired through the same start/stop/finalize paths.
- `_live_start_mono_s` stays exposed as a delegated compatibility property for runtime helpers.

Closes #3776