### PR TITLE
Add post-analysis execution stage runner

### DIFF
--- a/apps/server/tests/test_support/golden_replay.py
+++ b/apps/server/tests/test_support/golden_replay.py
@@ -30,7 +30,10 @@ from vibesensor.shared.types.raw_capture import (
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    execute_post_analysis,
+)
 from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
@@ -195,20 +198,24 @@ def execute_golden_replay_fixture(
     result = execute_post_analysis(
         run_id=run.run_id,
         db=cast(RunPersistence, recorder),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=run.metadata,
-            language=run.metadata.language or "en",
-            samples=list(run.samples),
-            total_summary_row_count=len(run.samples),
-            stride=1,
-            summary_duration_s=duration_s or fixture.duration_s,
-            context_samples=list(run.samples),
-            raw_capture=run.raw_capture,
-            raw_capture_manifest=run.raw_capture.manifest,
-        ),
-        analysis_runner=(
-            build_post_analysis_summary if analysis_runner is None else cast(Any, analysis_runner)
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=run.metadata,
+                language=run.metadata.language or "en",
+                samples=list(run.samples),
+                total_summary_row_count=len(run.samples),
+                stride=1,
+                summary_duration_s=duration_s or fixture.duration_s,
+                context_samples=list(run.samples),
+                raw_capture=run.raw_capture,
+                raw_capture_manifest=run.raw_capture.manifest,
+            ),
+            analysis_runner=(
+                build_post_analysis_summary
+                if analysis_runner is None
+                else cast(Any, analysis_runner)
+            ),
         ),
     )
     assert isinstance(result, PostAnalysisExecutionSuccess)

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -7,27 +7,13 @@ import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 from test_support.tracing import configured_trace_output, read_trace_output
 
-from vibesensor.domain import DrivingPhase
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
-from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
 from vibesensor.shared.types.run_schema import RunMetadata
-from vibesensor.shared.types.whole_run_analysis import (
-    WholeRunArtifactFile,
-    WholeRunArtifactManifest,
-    WholeRunContextInterval,
-    WholeRunContextWindowLabel,
-    WholeRunWindowPolicy,
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    execute_post_analysis,
 )
-from vibesensor.use_cases.diagnostics.whole_run_context import (
-    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
-    WholeRunContextArtifactBundle,
-)
-from vibesensor.use_cases.diagnostics.whole_run_spectra import (
-    WholeRunSpectralBuildResult,
-    WholeRunSpectralCoverageSummary,
-)
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
 from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
 from vibesensor.use_cases.run.post_analysis_loader import (
     EmptyPostAnalysisSamples,
@@ -61,36 +47,17 @@ def _samples() -> list:
     return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
 
 
-def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
-    return WholeRunSpectralBuildResult(
-        bundle=bundle,
-        coverage_summary=WholeRunSpectralCoverageSummary(
-            total_sensor_window_count=0,
-            full_sensor_window_count=0,
-            partial_sensor_window_count=0,
-            missing_sensor_window_count=0,
-            empty_sensor_window_count=0,
-            gap_count=0,
-            overlap_count=0,
-            dropped_chunk_count=0,
-            late_packet_chunk_count=0,
-            queue_overflow_chunk_count=0,
-            invalid_chunk_count=0,
-            write_error_chunk_count=0,
-            sample_rate_mismatch_sensor_count=0,
-            sample_rate_unverified_sensor_count=0,
-            unanchored_sensor_count=0,
-            legacy_sensor_count=0,
-            sync_unverified_sensor_count=0,
-            stale_sync_sensor_count=0,
-            high_rtt_sensor_count=0,
-            coverage_confidence="unavailable",
-        ),
+def _config(
+    *,
+    analysis_runner,
+    load_run,
+    defer_retryable_error_storage=False,
+):
+    return PostAnalysisExecutionConfig(
+        analysis_runner=analysis_runner,
+        load_run=load_run,
+        defer_retryable_error_storage=defer_retryable_error_storage,
     )
-
-
-def _empty_raw_capture(manifest: RawCaptureManifest) -> RawRunCapture:
-    return RawRunCapture(manifest=manifest, sensors=())
 
 
 def test_execute_post_analysis_success_stores_summary() -> None:
@@ -107,25 +74,27 @@ def test_execute_post_analysis_success_stores_summary() -> None:
     result = execute_post_analysis(
         run_id="run-ok",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id, language="nl"),
-            language="nl",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
-        ),
-        analysis_runner=lambda run: make_persisted_analysis(
-            {
-                "lang": run.language,
-                "row_count": len(run.samples),
-                "analysis_metadata": {
-                    "analyzed_sample_count": len(run.samples),
-                    "total_sample_count": run.total_summary_row_count,
-                    "sampling_method": "full",
-                },
-                "run_suitability": [],
-            }
+        config=_config(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id, language="nl"),
+                language="nl",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+            ),
+            analysis_runner=lambda run: make_persisted_analysis(
+                {
+                    "lang": run.language,
+                    "row_count": len(run.samples),
+                    "analysis_metadata": {
+                        "analyzed_sample_count": len(run.samples),
+                        "total_sample_count": run.total_summary_row_count,
+                        "sampling_method": "full",
+                    },
+                    "run_suitability": [],
+                }
+            ),
         ),
     )
 
@@ -146,15 +115,17 @@ def test_execute_post_analysis_exports_trace_span(tmp_path: Path) -> None:
         result = execute_post_analysis(
             run_id="run-trace",
             db=FakeDB(),
-            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-                run_id=run_id,
-                metadata=_run_metadata(run_id),
-                language="en",
-                samples=_samples(),
-                total_summary_row_count=1,
-                stride=1,
+            config=_config(
+                load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                    run_id=run_id,
+                    metadata=_run_metadata(run_id),
+                    language="en",
+                    samples=_samples(),
+                    total_summary_row_count=1,
+                    stride=1,
+                ),
+                analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
             ),
-            analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
         )
 
     assert isinstance(result, PostAnalysisExecutionSuccess)
@@ -180,11 +151,13 @@ def test_execute_post_analysis_handles_missing_metadata() -> None:
     result = execute_post_analysis(
         run_id="run-missing",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: MissingPostAnalysisMetadata(
-            run_id=run_id,
-            error_message="Metadata not found or corrupt; cannot analyse",
+        config=_config(
+            load_run=lambda *, run_id, db: MissingPostAnalysisMetadata(
+                run_id=run_id,
+                error_message="Metadata not found or corrupt; cannot analyse",
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis({}),
         ),
-        analysis_runner=lambda _run: make_persisted_analysis({}),
     )
 
     assert isinstance(result, PostAnalysisExecutionMissingMetadata)
@@ -205,11 +178,13 @@ def test_execute_post_analysis_handles_no_samples() -> None:
     result = execute_post_analysis(
         run_id="run-empty",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: EmptyPostAnalysisSamples(
-            run_id=run_id,
-            error_message="No samples collected during run",
+        config=_config(
+            load_run=lambda *, run_id, db: EmptyPostAnalysisSamples(
+                run_id=run_id,
+                error_message="No samples collected during run",
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis({}),
         ),
-        analysis_runner=lambda _run: make_persisted_analysis({}),
     )
 
     assert isinstance(result, PostAnalysisExecutionNoSamples)
@@ -229,15 +204,17 @@ def test_execute_post_analysis_propagates_unexpected_analysis_failure() -> None:
         execute_post_analysis(
             run_id="run-fail",
             db=FakeDB(),
-            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-                run_id=run_id,
-                metadata=_run_metadata(run_id),
-                language="en",
-                samples=_samples(),
-                total_summary_row_count=1,
-                stride=1,
+            config=_config(
+                load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                    run_id=run_id,
+                    metadata=_run_metadata(run_id),
+                    language="en",
+                    samples=_samples(),
+                    total_summary_row_count=1,
+                    stride=1,
+                ),
+                analysis_runner=lambda _run: (_ for _ in ()).throw(RuntimeError("boom")),
             ),
-            analysis_runner=lambda _run: (_ for _ in ()).throw(RuntimeError("boom")),
         )
 
 
@@ -254,15 +231,17 @@ def test_execute_post_analysis_reports_persistence_failure() -> None:
     result = execute_post_analysis(
         run_id="run-store-fail",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
+        config=_config(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
         ),
-        analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
     )
 
     assert isinstance(result, PostAnalysisExecutionPersistenceFailure)
@@ -286,16 +265,18 @@ def test_execute_post_analysis_defers_retryable_persistence_failure() -> None:
     result = execute_post_analysis(
         run_id="run-retry",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
+        config=_config(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
+            defer_retryable_error_storage=True,
         ),
-        analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
-        defer_retryable_error_storage=True,
     )
 
     assert isinstance(result, PostAnalysisExecutionRetryableFailure)
@@ -317,9 +298,13 @@ def test_execute_post_analysis_defers_retryable_load_failure() -> None:
     result = execute_post_analysis(
         run_id="run-load-retry",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: (_ for _ in ()).throw(sqlite3.OperationalError("db busy")),
-        analysis_runner=lambda _run: make_persisted_analysis({}),
-        defer_retryable_error_storage=True,
+        config=_config(
+            load_run=lambda *, run_id, db: (_ for _ in ()).throw(
+                sqlite3.OperationalError("db busy")
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis({}),
+            defer_retryable_error_storage=True,
+        ),
     )
 
     assert isinstance(result, PostAnalysisExecutionRetryableFailure)
@@ -341,351 +326,23 @@ def test_execute_post_analysis_passes_canonical_typed_input_to_runner() -> None:
     result = execute_post_analysis(
         run_id="run-input",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id, language="nl"),
-            language="nl",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
+        config=_config(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id, language="nl"),
+                language="nl",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+            ),
+            analysis_runner=lambda run: _capture_run_input(captured, run),
         ),
-        analysis_runner=lambda run: _capture_run_input(captured, run),
     )
 
     assert isinstance(result, PostAnalysisExecutionSuccess)
     assert captured["run_input_type"] is PostAnalysisRunInput
     assert captured["context_run_id"] == "run-input"
     assert captured["sample_type"] == "SensorFrame"
-
-
-def test_execute_post_analysis_stores_whole_run_artifacts_and_appends_metadata() -> None:
-    stored: dict[str, object] = {}
-    raw_capture_manifest = RawCaptureManifest(
-        run_id="run-whole-run",
-        relative_dir="raw-runs/run-whole-run",
-        sensors=(),
-        total_samples=0,
-        total_bytes=0,
-        created_at="2025-01-01T00:00:00Z",
-    )
-    whole_run_manifest = WholeRunArtifactManifest(
-        run_id="run-whole-run",
-        relative_dir="whole-run-artifacts/run-whole-run",
-        window_policy=WholeRunWindowPolicy(
-            sample_rate_hz=800,
-            window_size_samples=2048,
-            stride_samples=200,
-            overlap_samples=1848,
-            feature_interval_s=0.25,
-        ),
-        total_window_count=3,
-        algorithm_versions={"whole_run_spectra": 1},
-        configuration={"spectrum_storage_format": "npy-f32"},
-        artifacts=(
-            WholeRunArtifactFile(
-                artifact_key="spectral-grid:sensor-a",
-                relative_path="spectra/sensor-a/freq.f32.npy",
-                file_format="npy-f32-vector",
-                record_count=10,
-                sensor_id="sensor-a",
-            ),
-            WholeRunArtifactFile(
-                artifact_key="spectral-summary:sensor-a",
-                relative_path="spectra/sensor-a/windows.jsonl",
-                file_format="jsonl",
-                record_count=3,
-                sensor_id="sensor-a",
-            ),
-        ),
-        created_at="2025-01-01T00:00:00Z",
-    )
-
-    class FakeDB:
-        async def astore_whole_run_artifacts(self, run_id, manifest, *, artifact_contents):
-            stored["whole_run_run_id"] = run_id
-            stored["whole_run_manifest"] = manifest
-            stored["whole_run_artifact_contents"] = artifact_contents
-            return manifest
-
-        async def astore_analysis(self, run_id, analysis):
-            stored["analysis_run_id"] = run_id
-            stored["analysis"] = analysis
-
-        async def astore_analysis_error(self, run_id, error):
-            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
-
-    result = execute_post_analysis(
-        run_id="run-whole-run",
-        db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
-            raw_capture=_empty_raw_capture(raw_capture_manifest),
-            raw_capture_manifest=raw_capture_manifest,
-        ),
-        whole_run_artifact_builder=lambda **_kwargs: _spectral_result(
-            type(
-                "Bundle",
-                (),
-                {
-                    "manifest": whole_run_manifest,
-                    "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
-                },
-            )()
-        ),
-        analysis_runner=lambda _run: make_persisted_analysis(
-            {
-                "analysis_metadata": {
-                    "analyzed_sample_count": 1,
-                    "total_sample_count": 1,
-                    "sampling_method": "full",
-                },
-                "run_suitability": [],
-            }
-        ),
-        whole_run_context_builder=lambda **_kwargs: None,
-    )
-
-    assert isinstance(result, PostAnalysisExecutionSuccess)
-    assert stored["whole_run_run_id"] == "run-whole-run"
-    assert stored["whole_run_manifest"] == whole_run_manifest
-    assert stored["analysis_run_id"] == "run-whole-run"
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifacts_available"] is True
-    assert stored["analysis"]["analysis_metadata"]["whole_run_window_count"] == 3
-    assert stored["analysis"]["analysis_metadata"]["whole_run_sensor_count"] == 1
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 2
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_artifact_manifest_path"]
-        == "whole-run-artifacts/run-whole-run/manifest.json"
-    )
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_artifact_generated_at"]
-        == "2025-01-01T00:00:00Z"
-    )
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifacts_status"] == "available"
-    assert stored["analysis"]["analysis_metadata"]["whole_run_algorithm_versions"] == {
-        "whole_run_spectra": 1,
-    }
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_configuration"] == {
-        "spectrum_storage_format": "npy-f32",
-    }
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_paths"] == {
-        "spectral-grid:sensor-a": "spectra/sensor-a/freq.f32.npy",
-        "spectral-summary:sensor-a": "spectra/sensor-a/windows.jsonl",
-    }
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_warnings"] == []
-
-
-def test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar() -> None:
-    stored: dict[str, object] = {}
-    raw_capture_manifest = RawCaptureManifest(
-        run_id="run-context",
-        relative_dir="raw-runs/run-context",
-        sensors=(),
-        total_samples=0,
-        total_bytes=0,
-        created_at="2025-01-01T00:00:00Z",
-    )
-    window_policy = WholeRunWindowPolicy(
-        sample_rate_hz=800,
-        window_size_samples=2048,
-        stride_samples=200,
-        overlap_samples=1848,
-        feature_interval_s=0.25,
-    )
-    spectral_manifest = WholeRunArtifactManifest(
-        run_id="run-context",
-        relative_dir="whole-run-artifacts/run-context",
-        window_policy=window_policy,
-        total_window_count=3,
-        artifacts=(
-            WholeRunArtifactFile(
-                artifact_key="spectral-summary:sensor-a",
-                relative_path="spectra/sensor-a/windows.jsonl",
-                file_format="jsonl",
-                record_count=3,
-                sensor_id="sensor-a",
-            ),
-        ),
-        created_at="2025-01-01T00:00:00Z",
-    )
-    context_bundle = WholeRunContextArtifactBundle(
-        manifest=WholeRunArtifactManifest(
-            run_id="run-context",
-            relative_dir="whole-run-artifacts/run-context",
-            window_policy=window_policy,
-            total_window_count=3,
-            artifacts=(
-                WholeRunArtifactFile(
-                    artifact_key=WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
-                    relative_path="context/window-labels.jsonl",
-                    file_format="jsonl",
-                    record_count=3,
-                ),
-            ),
-            created_at="2025-01-01T00:00:00Z",
-        ),
-        artifact_contents={
-            WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: b'{"window_index":0}\n',
-        },
-        labels=(
-            WholeRunContextWindowLabel(
-                window_index=0,
-                segment_index=0,
-                phase=DrivingPhase.IDLE,
-                context_coverage="full",
-                speed_validity="measured",
-                rpm_validity="measured",
-                load_state="idle",
-                speed_kmh=0.0,
-                speed_source="gps",
-                engine_rpm=800.0,
-                engine_rpm_source="obd2",
-            ),
-            WholeRunContextWindowLabel(
-                window_index=1,
-                segment_index=0,
-                phase=DrivingPhase.IDLE,
-                context_coverage="full",
-                speed_validity="measured",
-                rpm_validity="measured",
-                load_state="idle",
-                speed_kmh=0.0,
-                speed_source="gps",
-                engine_rpm=800.0,
-                engine_rpm_source="obd2",
-            ),
-            WholeRunContextWindowLabel(
-                window_index=2,
-                segment_index=0,
-                phase=DrivingPhase.IDLE,
-                context_coverage="full",
-                speed_validity="measured",
-                rpm_validity="measured",
-                load_state="idle",
-                speed_kmh=0.0,
-                speed_source="gps",
-                engine_rpm=800.0,
-                engine_rpm_source="obd2",
-            ),
-        ),
-        intervals=(
-            WholeRunContextInterval(
-                segment_index=0,
-                phase=DrivingPhase.IDLE,
-                load_state="idle",
-                start_window_index=0,
-                end_window_index=2,
-                start_t_s=0.0,
-                end_t_s=0.75,
-                speed_min_kmh=0.0,
-                speed_max_kmh=0.0,
-                speed_band="0-10",
-                full_context_window_count=3,
-                partial_context_window_count=0,
-                missing_context_window_count=0,
-            ),
-        ),
-    )
-
-    class FakeDB:
-        async def astore_whole_run_artifacts(self, run_id, manifest, *, artifact_contents):
-            stored["whole_run_run_id"] = run_id
-            stored["whole_run_manifest"] = manifest
-            stored["whole_run_artifact_contents"] = artifact_contents
-            return manifest
-
-        async def astore_analysis(self, run_id, analysis):
-            stored["analysis_run_id"] = run_id
-            stored["analysis"] = analysis
-
-        async def astore_analysis_error(self, run_id, error):
-            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
-
-    result = execute_post_analysis(
-        run_id="run-context",
-        db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
-            raw_capture=_empty_raw_capture(raw_capture_manifest),
-            raw_capture_manifest=raw_capture_manifest,
-        ),
-        whole_run_artifact_builder=lambda **_kwargs: _spectral_result(
-            type(
-                "Bundle",
-                (),
-                {
-                    "manifest": spectral_manifest,
-                    "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
-                },
-            )()
-        ),
-        whole_run_context_builder=lambda **_kwargs: context_bundle,
-        whole_run_order_trace_builder=lambda **_kwargs: None,
-        analysis_runner=lambda _run: make_persisted_analysis(
-            {
-                "analysis_metadata": {
-                    "analyzed_sample_count": 1,
-                    "total_sample_count": 1,
-                    "sampling_method": "full",
-                },
-                "run_suitability": [],
-            }
-        ),
-    )
-
-    assert isinstance(result, PostAnalysisExecutionSuccess)
-    merged_manifest = stored["whole_run_manifest"]
-    assert isinstance(merged_manifest, WholeRunArtifactManifest)
-    assert merged_manifest.artifact(WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY) is not None
-    assert merged_manifest.artifact("spectral-summary:sensor-a") is not None
-    assert stored["analysis"]["whole_run_context_intervals"] == [
-        {
-            "segment_index": 0,
-            "phase": "idle",
-            "load_state": "idle",
-            "start_window_index": 0,
-            "end_window_index": 2,
-            "start_t_s": 0.0,
-            "end_t_s": 0.75,
-            "speed_min_kmh": 0.0,
-            "speed_max_kmh": 0.0,
-            "speed_band": "0-10",
-            "full_context_window_count": 3,
-            "partial_context_window_count": 0,
-            "missing_context_window_count": 0,
-        }
-    ]
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_available"] is True
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_window_count"] == 3
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_interval_count"] == 1
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_full_window_count"] == 3
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_partial_window_count"] == 0
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_missing_window_count"] == 0
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_context_missing_speed_window_count"] == 0
-    )
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_context_missing_rpm_window_count"] == 0
-    )
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_context_stale_speed_window_count"] == 0
-    )
-    assert stored["analysis"]["analysis_metadata"]["whole_run_context_stale_rpm_window_count"] == 0
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_context_labels_artifact_key"]
-        == WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY
-    )
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 2
 
 
 def _capture_run_input(captured: dict[str, object], run: PostAnalysisRunInput):

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor_raw_capture_policy.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor_raw_capture_policy.py
@@ -10,7 +10,11 @@ from vibesensor.shared.types.raw_capture import (
     RawRunCapture,
 )
 from vibesensor.shared.types.run_schema import RunMetadata
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisWholeRunBuilderConfig,
+    execute_post_analysis,
+)
 from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
@@ -87,18 +91,22 @@ def test_execute_post_analysis_skips_whole_run_artifacts_for_fatal_raw_capture_l
     result = execute_post_analysis(
         run_id="run-loss-gated",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id, language="en"),
-            language="en",
-            samples=_samples(),
-            raw_capture=RawRunCapture(manifest=manifest, sensors=()),
-            total_summary_row_count=1,
-            stride=1,
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id, language="en"),
+                language="en",
+                samples=_samples(),
+                raw_capture=RawRunCapture(manifest=manifest, sensors=()),
+                total_summary_row_count=1,
+                stride=1,
+            ),
+            analysis_runner=analysis_runner,
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=artifact_builder,
+                context_builder=context_builder,
+            ),
         ),
-        analysis_runner=analysis_runner,
-        whole_run_artifact_builder=artifact_builder,
-        whole_run_context_builder=context_builder,
     )
 
     assert isinstance(result, PostAnalysisExecutionSuccess)

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_metadata.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_metadata.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextInterval,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+    WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunSpectralBuildResult,
+    WholeRunSpectralCoverageSummary,
+)
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisWholeRunBuilderConfig,
+    execute_post_analysis,
+)
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
+
+
+def _run_metadata(run_id: str) -> RunMetadata:
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "language": "en",
+        }
+    )
+
+
+def _samples() -> list:
+    return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
+
+
+def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
+    return WholeRunSpectralBuildResult(
+        bundle=bundle,
+        coverage_summary=WholeRunSpectralCoverageSummary(
+            total_sensor_window_count=0,
+            full_sensor_window_count=0,
+            partial_sensor_window_count=0,
+            missing_sensor_window_count=0,
+            empty_sensor_window_count=0,
+            gap_count=0,
+            overlap_count=0,
+            dropped_chunk_count=0,
+            late_packet_chunk_count=0,
+            queue_overflow_chunk_count=0,
+            invalid_chunk_count=0,
+            write_error_chunk_count=0,
+            sample_rate_mismatch_sensor_count=0,
+            sample_rate_unverified_sensor_count=0,
+            unanchored_sensor_count=0,
+            legacy_sensor_count=0,
+            sync_unverified_sensor_count=0,
+            stale_sync_sensor_count=0,
+            high_rtt_sensor_count=0,
+            coverage_confidence="unavailable",
+        ),
+    )
+
+
+def _empty_raw_capture(manifest: RawCaptureManifest) -> RawRunCapture:
+    return RawRunCapture(manifest=manifest, sensors=())
+
+
+def test_execute_post_analysis_stores_whole_run_artifacts_and_appends_metadata() -> None:
+    stored: dict[str, object] = {}
+    raw_capture_manifest = RawCaptureManifest(
+        run_id="run-whole-run",
+        relative_dir="raw-runs/run-whole-run",
+        sensors=(),
+        total_samples=0,
+        total_bytes=0,
+        created_at="2025-01-01T00:00:00Z",
+    )
+    whole_run_manifest = WholeRunArtifactManifest(
+        run_id="run-whole-run",
+        relative_dir="whole-run-artifacts/run-whole-run",
+        window_policy=WholeRunWindowPolicy(
+            sample_rate_hz=800,
+            window_size_samples=2048,
+            stride_samples=200,
+            overlap_samples=1848,
+            feature_interval_s=0.25,
+        ),
+        total_window_count=3,
+        algorithm_versions={"whole_run_spectra": 1},
+        configuration={"spectrum_storage_format": "npy-f32"},
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-grid:sensor-a",
+                relative_path="spectra/sensor-a/freq.f32.npy",
+                file_format="npy-f32-vector",
+                record_count=10,
+                sensor_id="sensor-a",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-a",
+                relative_path="spectra/sensor-a/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-a",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+    class FakeDB:
+        async def astore_whole_run_artifacts(self, run_id, manifest, *, artifact_contents):
+            stored["whole_run_run_id"] = run_id
+            stored["whole_run_manifest"] = manifest
+            stored["whole_run_artifact_contents"] = artifact_contents
+            return manifest
+
+        async def astore_analysis(self, run_id, analysis):
+            stored["analysis_run_id"] = run_id
+            stored["analysis"] = analysis
+
+        async def astore_analysis_error(self, run_id, error):
+            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
+
+    result = execute_post_analysis(
+        run_id="run-whole-run",
+        db=FakeDB(),
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+                raw_capture=_empty_raw_capture(raw_capture_manifest),
+                raw_capture_manifest=raw_capture_manifest,
+            ),
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=lambda **_kwargs: _spectral_result(
+                    type(
+                        "Bundle",
+                        (),
+                        {
+                            "manifest": whole_run_manifest,
+                            "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
+                        },
+                    )()
+                ),
+                context_builder=lambda **_kwargs: None,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis(
+                {
+                    "analysis_metadata": {
+                        "analyzed_sample_count": 1,
+                        "total_sample_count": 1,
+                        "sampling_method": "full",
+                    },
+                    "run_suitability": [],
+                }
+            ),
+        ),
+    )
+
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    assert stored["whole_run_run_id"] == "run-whole-run"
+    assert stored["whole_run_manifest"] == whole_run_manifest
+    assert stored["analysis_run_id"] == "run-whole-run"
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifacts_available"] is True
+    assert stored["analysis"]["analysis_metadata"]["whole_run_window_count"] == 3
+    assert stored["analysis"]["analysis_metadata"]["whole_run_sensor_count"] == 1
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 2
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_artifact_manifest_path"]
+        == "whole-run-artifacts/run-whole-run/manifest.json"
+    )
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_artifact_generated_at"]
+        == "2025-01-01T00:00:00Z"
+    )
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifacts_status"] == "available"
+    assert stored["analysis"]["analysis_metadata"]["whole_run_algorithm_versions"] == {
+        "whole_run_spectra": 1,
+    }
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_configuration"] == {
+        "spectrum_storage_format": "npy-f32",
+    }
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_paths"] == {
+        "spectral-grid:sensor-a": "spectra/sensor-a/freq.f32.npy",
+        "spectral-summary:sensor-a": "spectra/sensor-a/windows.jsonl",
+    }
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_warnings"] == []
+
+
+def test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar() -> None:
+    stored: dict[str, object] = {}
+    raw_capture_manifest = RawCaptureManifest(
+        run_id="run-context",
+        relative_dir="raw-runs/run-context",
+        sensors=(),
+        total_samples=0,
+        total_bytes=0,
+        created_at="2025-01-01T00:00:00Z",
+    )
+    window_policy = WholeRunWindowPolicy(
+        sample_rate_hz=800,
+        window_size_samples=2048,
+        stride_samples=200,
+        overlap_samples=1848,
+        feature_interval_s=0.25,
+    )
+    spectral_manifest = WholeRunArtifactManifest(
+        run_id="run-context",
+        relative_dir="whole-run-artifacts/run-context",
+        window_policy=window_policy,
+        total_window_count=3,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-a",
+                relative_path="spectra/sensor-a/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-a",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+    context_bundle = WholeRunContextArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-context",
+            relative_dir="whole-run-artifacts/run-context",
+            window_policy=window_policy,
+            total_window_count=3,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+                    relative_path="context/window-labels.jsonl",
+                    file_format="jsonl",
+                    record_count=3,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={
+            WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: b'{"window_index":0}\n',
+        },
+        labels=(
+            WholeRunContextWindowLabel(
+                window_index=0,
+                segment_index=0,
+                phase=DrivingPhase.IDLE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="idle",
+                speed_kmh=0.0,
+                speed_source="gps",
+                engine_rpm=800.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=1,
+                segment_index=0,
+                phase=DrivingPhase.IDLE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="idle",
+                speed_kmh=0.0,
+                speed_source="gps",
+                engine_rpm=800.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=2,
+                segment_index=0,
+                phase=DrivingPhase.IDLE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="idle",
+                speed_kmh=0.0,
+                speed_source="gps",
+                engine_rpm=800.0,
+                engine_rpm_source="obd2",
+            ),
+        ),
+        intervals=(
+            WholeRunContextInterval(
+                segment_index=0,
+                phase=DrivingPhase.IDLE,
+                load_state="idle",
+                start_window_index=0,
+                end_window_index=2,
+                start_t_s=0.0,
+                end_t_s=0.75,
+                speed_min_kmh=0.0,
+                speed_max_kmh=0.0,
+                speed_band="0-10",
+                full_context_window_count=3,
+                partial_context_window_count=0,
+                missing_context_window_count=0,
+            ),
+        ),
+    )
+
+    class FakeDB:
+        async def astore_whole_run_artifacts(self, run_id, manifest, *, artifact_contents):
+            stored["whole_run_run_id"] = run_id
+            stored["whole_run_manifest"] = manifest
+            stored["whole_run_artifact_contents"] = artifact_contents
+            return manifest
+
+        async def astore_analysis(self, run_id, analysis):
+            stored["analysis_run_id"] = run_id
+            stored["analysis"] = analysis
+
+        async def astore_analysis_error(self, run_id, error):
+            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
+
+    result = execute_post_analysis(
+        run_id="run-context",
+        db=FakeDB(),
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+                raw_capture=_empty_raw_capture(raw_capture_manifest),
+                raw_capture_manifest=raw_capture_manifest,
+            ),
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=lambda **_kwargs: _spectral_result(
+                    type(
+                        "Bundle",
+                        (),
+                        {
+                            "manifest": spectral_manifest,
+                            "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
+                        },
+                    )()
+                ),
+                context_builder=lambda **_kwargs: context_bundle,
+                order_trace_builder=lambda **_kwargs: None,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis(
+                {
+                    "analysis_metadata": {
+                        "analyzed_sample_count": 1,
+                        "total_sample_count": 1,
+                        "sampling_method": "full",
+                    },
+                    "run_suitability": [],
+                }
+            ),
+        ),
+    )
+
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    merged_manifest = stored["whole_run_manifest"]
+    assert isinstance(merged_manifest, WholeRunArtifactManifest)
+    assert merged_manifest.artifact(WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY) is not None
+    assert merged_manifest.artifact("spectral-summary:sensor-a") is not None
+    assert stored["analysis"]["whole_run_context_intervals"] == [
+        {
+            "segment_index": 0,
+            "phase": "idle",
+            "load_state": "idle",
+            "start_window_index": 0,
+            "end_window_index": 2,
+            "start_t_s": 0.0,
+            "end_t_s": 0.75,
+            "speed_min_kmh": 0.0,
+            "speed_max_kmh": 0.0,
+            "speed_band": "0-10",
+            "full_context_window_count": 3,
+            "partial_context_window_count": 0,
+            "missing_context_window_count": 0,
+        }
+    ]
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_available"] is True
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_window_count"] == 3
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_interval_count"] == 1
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_full_window_count"] == 3
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_partial_window_count"] == 0
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_missing_window_count"] == 0
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_missing_speed_window_count"] == 0
+    )
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_missing_rpm_window_count"] == 0
+    )
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_stale_speed_window_count"] == 0
+    )
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_stale_rpm_window_count"] == 0
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_labels_artifact_key"]
+        == WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY
+    )
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 2

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py
@@ -15,7 +15,11 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralBuildResult,
     WholeRunSpectralCoverageSummary,
 )
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisWholeRunBuilderConfig,
+    execute_post_analysis,
+)
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
 
@@ -60,80 +64,86 @@ def test_execute_post_analysis_appends_whole_run_alignment_warning_and_metadata(
     result = execute_post_analysis(
         run_id="run-whole-run-warning",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
-            raw_capture=RawRunCapture(manifest=raw_capture_manifest, sensors=()),
-            raw_capture_manifest=raw_capture_manifest,
-        ),
-        whole_run_artifact_builder=lambda **_kwargs: WholeRunSpectralBuildResult(
-            bundle=None,
-            coverage_summary=WholeRunSpectralCoverageSummary(
-                total_sensor_window_count=4,
-                full_sensor_window_count=2,
-                partial_sensor_window_count=1,
-                missing_sensor_window_count=1,
-                empty_sensor_window_count=0,
-                gap_count=1,
-                overlap_count=0,
-                dropped_chunk_count=2,
-                late_packet_chunk_count=1,
-                queue_overflow_chunk_count=2,
-                invalid_chunk_count=0,
-                write_error_chunk_count=0,
-                sample_rate_mismatch_sensor_count=1,
-                sample_rate_unverified_sensor_count=2,
-                unanchored_sensor_count=1,
-                legacy_sensor_count=0,
-                sync_unverified_sensor_count=1,
-                stale_sync_sensor_count=1,
-                high_rtt_sensor_count=0,
-                coverage_confidence="partial",
-                warnings=(
-                    RunContextWarning(
-                        code=WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
-                        severity="warn",
-                        applies_to="whole_run",
-                        title=i18n_ref("RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_TITLE"),
-                        detail=i18n_ref(
-                            "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_DETAIL",
-                            partial="1",
-                            missing="1",
-                            gaps="1",
-                            overlaps="0",
-                            dropped="2",
-                            late="1",
-                            udp_ingest="0",
-                            queue_overflow="2",
-                            invalid="0",
-                            write_errors="0",
-                            mismatches="1",
-                            unverified_rates="2",
-                            legacy="0",
-                            unanchored="1",
-                            sync_unverified="1",
-                            missing_sync="0",
-                            stale="1",
-                            high_rtt="0",
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+                raw_capture=RawRunCapture(manifest=raw_capture_manifest, sensors=()),
+                raw_capture_manifest=raw_capture_manifest,
+            ),
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=lambda **_kwargs: WholeRunSpectralBuildResult(
+                    bundle=None,
+                    coverage_summary=WholeRunSpectralCoverageSummary(
+                        total_sensor_window_count=4,
+                        full_sensor_window_count=2,
+                        partial_sensor_window_count=1,
+                        missing_sensor_window_count=1,
+                        empty_sensor_window_count=0,
+                        gap_count=1,
+                        overlap_count=0,
+                        dropped_chunk_count=2,
+                        late_packet_chunk_count=1,
+                        queue_overflow_chunk_count=2,
+                        invalid_chunk_count=0,
+                        write_error_chunk_count=0,
+                        sample_rate_mismatch_sensor_count=1,
+                        sample_rate_unverified_sensor_count=2,
+                        unanchored_sensor_count=1,
+                        legacy_sensor_count=0,
+                        sync_unverified_sensor_count=1,
+                        stale_sync_sensor_count=1,
+                        high_rtt_sensor_count=0,
+                        coverage_confidence="partial",
+                        warnings=(
+                            RunContextWarning(
+                                code=WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
+                                severity="warn",
+                                applies_to="whole_run",
+                                title=i18n_ref(
+                                    "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_TITLE"
+                                ),
+                                detail=i18n_ref(
+                                    "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_DETAIL",
+                                    partial="1",
+                                    missing="1",
+                                    gaps="1",
+                                    overlaps="0",
+                                    dropped="2",
+                                    late="1",
+                                    udp_ingest="0",
+                                    queue_overflow="2",
+                                    invalid="0",
+                                    write_errors="0",
+                                    mismatches="1",
+                                    unverified_rates="2",
+                                    legacy="0",
+                                    unanchored="1",
+                                    sync_unverified="1",
+                                    missing_sync="0",
+                                    stale="1",
+                                    high_rtt="0",
+                                ),
+                            ),
                         ),
                     ),
                 ),
+                context_builder=lambda **_kwargs: None,
             ),
-        ),
-        whole_run_context_builder=lambda **_kwargs: None,
-        analysis_runner=lambda _run: make_persisted_analysis(
-            {
-                "analysis_metadata": {
-                    "analyzed_sample_count": 1,
-                    "total_sample_count": 1,
-                    "sampling_method": "full",
-                },
-                "run_suitability": [],
-            }
+            analysis_runner=lambda _run: make_persisted_analysis(
+                {
+                    "analysis_metadata": {
+                        "analyzed_sample_count": 1,
+                        "total_sample_count": 1,
+                        "sampling_method": "full",
+                    },
+                    "run_suitability": [],
+                }
+            ),
         ),
     )
 

--- a/apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py
@@ -25,6 +25,8 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralCoverageSummary,
 )
 from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisExecutionRunner,
     resolve_whole_run_builders,
     run_build_post_analysis_input_stage,
     run_load_run_stage,
@@ -111,6 +113,25 @@ def _raw_capture_manifest_with_sensor(run_id: str) -> RawCaptureManifest:
         total_bytes=2048 * 3 * 2,
         created_at="2025-01-01T00:00:00Z",
         run_start_monotonic_us=1_000_000,
+    )
+
+
+def test_post_analysis_execution_runner_stage_order_is_explicit() -> None:
+    runner = PostAnalysisExecutionRunner(
+        run_id="run-stage-order",
+        db=object(),
+        config=PostAnalysisExecutionConfig(
+            analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
+        ),
+        analysis_start=0.0,
+    )
+
+    assert runner.stage_names == (
+        "LoadRunStage",
+        "BuildPostAnalysisInputStage",
+        "WholeRunPipelineStages",
+        "BuildReportFactsStage",
+        "PersistAnalysisSummaryStage",
     )
 
 

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py
@@ -46,7 +46,11 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralBuildResult,
     WholeRunSpectralCoverageSummary,
 )
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisWholeRunBuilderConfig,
+    execute_post_analysis,
+)
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
 
@@ -405,43 +409,47 @@ def test_execute_post_analysis_persists_whole_run_diagnosis_summaries() -> None:
                 ),
             },
         )(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id="run-diagnosis-ranking",
-            metadata=_run_metadata("run-diagnosis-ranking"),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
-            context_samples=_samples(),
-            raw_capture=_empty_raw_capture(raw_capture_manifest),
-            raw_capture_manifest=raw_capture_manifest,
-        ),
-        whole_run_artifact_builder=lambda **_kwargs: _spectral_result(
-            type(
-                "Bundle",
-                (),
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id="run-diagnosis-ranking",
+                metadata=_run_metadata("run-diagnosis-ranking"),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+                context_samples=_samples(),
+                raw_capture=_empty_raw_capture(raw_capture_manifest),
+                raw_capture_manifest=raw_capture_manifest,
+            ),
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=lambda **_kwargs: _spectral_result(
+                    type(
+                        "Bundle",
+                        (),
+                        {
+                            "manifest": spectral_manifest,
+                            "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
+                        },
+                    )()
+                ),
+                context_builder=lambda **_kwargs: context_bundle,
+                order_trace_builder=lambda **_kwargs: order_trace_bundle,
+                order_trace_summary_builder=lambda **_kwargs: order_trace_summary_bundle,
+                order_family_summary_builder=lambda **_kwargs: order_family_bundle,
+                spatial_coherence_builder=lambda **_kwargs: spatial_bundle,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis(
                 {
-                    "manifest": spectral_manifest,
-                    "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
-                },
-            )()
-        ),
-        whole_run_context_builder=lambda **_kwargs: context_bundle,
-        whole_run_order_trace_builder=lambda **_kwargs: order_trace_bundle,
-        whole_run_order_trace_summary_builder=lambda **_kwargs: order_trace_summary_bundle,
-        whole_run_order_family_summary_builder=lambda **_kwargs: order_family_bundle,
-        whole_run_spatial_coherence_builder=lambda **_kwargs: spatial_bundle,
-        analysis_runner=lambda _run: make_persisted_analysis(
-            {
-                "analysis_metadata": {
-                    "analyzed_sample_count": 1,
-                    "total_sample_count": 1,
-                    "sampling_method": "full",
-                    "raw_backed_sample_count": 48,
-                    "raw_capture_mode": "raw_backed",
-                },
-                "run_suitability": [],
-            }
+                    "analysis_metadata": {
+                        "analyzed_sample_count": 1,
+                        "total_sample_count": 1,
+                        "sampling_method": "full",
+                        "raw_backed_sample_count": 48,
+                        "raw_capture_mode": "raw_backed",
+                    },
+                    "run_suitability": [],
+                }
+            ),
         ),
     )
 

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py
@@ -31,7 +31,11 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralBuildResult,
     WholeRunSpectralCoverageSummary,
 )
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisWholeRunBuilderConfig,
+    execute_post_analysis,
+)
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
 
@@ -239,38 +243,42 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
     result = execute_post_analysis(
         run_id="run-order-traces",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=1,
-            stride=1,
-            raw_capture=_empty_raw_capture(raw_capture_manifest),
-            raw_capture_manifest=raw_capture_manifest,
-        ),
-        whole_run_artifact_builder=lambda **_kwargs: _spectral_result(
-            type(
-                "Bundle",
-                (),
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=1,
+                stride=1,
+                raw_capture=_empty_raw_capture(raw_capture_manifest),
+                raw_capture_manifest=raw_capture_manifest,
+            ),
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=lambda **_kwargs: _spectral_result(
+                    type(
+                        "Bundle",
+                        (),
+                        {
+                            "manifest": spectral_manifest,
+                            "artifact_contents": {"spectral-summary:sensor-a": b"{}\n{}\n"},
+                        },
+                    )()
+                ),
+                context_builder=lambda **_kwargs: context_bundle,
+                order_trace_builder=lambda **_kwargs: order_trace_bundle,
+                spatial_coherence_builder=lambda **_kwargs: None,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis(
                 {
-                    "manifest": spectral_manifest,
-                    "artifact_contents": {"spectral-summary:sensor-a": b"{}\n{}\n"},
-                },
-            )()
-        ),
-        whole_run_context_builder=lambda **_kwargs: context_bundle,
-        whole_run_order_trace_builder=lambda **_kwargs: order_trace_bundle,
-        whole_run_spatial_coherence_builder=lambda **_kwargs: None,
-        analysis_runner=lambda _run: make_persisted_analysis(
-            {
-                "analysis_metadata": {
-                    "analyzed_sample_count": 1,
-                    "total_sample_count": 1,
-                    "sampling_method": "full",
-                },
-                "run_suitability": [],
-            }
+                    "analysis_metadata": {
+                        "analyzed_sample_count": 1,
+                        "total_sample_count": 1,
+                        "sampling_method": "full",
+                    },
+                    "run_suitability": [],
+                }
+            ),
         ),
     )
 

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
@@ -28,7 +28,11 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralBuildResult,
     WholeRunSpectralCoverageSummary,
 )
-from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionConfig,
+    PostAnalysisWholeRunBuilderConfig,
+    execute_post_analysis,
+)
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
 
@@ -247,56 +251,64 @@ def test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_
     result = execute_post_analysis(
         run_id="run-spatial-coherence",
         db=FakeDB(),
-        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
-            run_id=run_id,
-            metadata=_run_metadata(run_id),
-            language="en",
-            samples=_samples(),
-            total_summary_row_count=2,
-            stride=1,
-            raw_capture=_empty_raw_capture(raw_capture_manifest),
-            raw_capture_manifest=raw_capture_manifest,
-        ),
-        whole_run_artifact_builder=lambda **_kwargs: _spectral_result(
-            type(
-                "Bundle",
-                (),
+        config=PostAnalysisExecutionConfig(
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_summary_row_count=2,
+                stride=1,
+                raw_capture=_empty_raw_capture(raw_capture_manifest),
+                raw_capture_manifest=raw_capture_manifest,
+            ),
+            whole_run_builders=PostAnalysisWholeRunBuilderConfig(
+                artifact_builder=lambda **_kwargs: _spectral_result(
+                    type(
+                        "Bundle",
+                        (),
+                        {
+                            "manifest": spectral_manifest,
+                            "artifact_contents": {
+                                "spectral-summary:sensor-front": (
+                                    b'{"window_index":0,"coverage_state":"full",'
+                                    b'"returned_sample_start":0,"returned_sample_count":256,'
+                                    b'"top_peaks":[{"hz":5.0,"amp":0.2,'
+                                    b'"vibration_strength_db":31.0}]}\n'
+                                    b'{"window_index":1,"coverage_state":"full",'
+                                    b'"returned_sample_start":200,"returned_sample_count":256,'
+                                    b'"top_peaks":[{"hz":6.0,"amp":0.2,'
+                                    b'"vibration_strength_db":31.0}]}\n'
+                                ),
+                                "spectral-summary:sensor-rear": (
+                                    b'{"window_index":0,"coverage_state":"full",'
+                                    b'"returned_sample_start":0,"returned_sample_count":256,'
+                                    b'"top_peaks":[{"hz":5.05,"amp":0.15,'
+                                    b'"vibration_strength_db":29.0}]}\n'
+                                    b'{"window_index":1,"coverage_state":"full",'
+                                    b'"returned_sample_start":200,"returned_sample_count":256,'
+                                    b'"top_peaks":[{"hz":6.05,"amp":0.15,'
+                                    b'"vibration_strength_db":29.0}]}\n'
+                                ),
+                            },
+                        },
+                    )()
+                ),
+                context_builder=lambda **_kwargs: context_bundle,
+                order_trace_builder=lambda **_kwargs: order_trace_bundle,
+                order_trace_summary_builder=lambda **_kwargs: None,
+                order_family_summary_builder=lambda **_kwargs: None,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis(
                 {
-                    "manifest": spectral_manifest,
-                    "artifact_contents": {
-                        "spectral-summary:sensor-front": (
-                            b'{"window_index":0,"coverage_state":"full","returned_sample_start":0,'
-                            b'"returned_sample_count":256,"top_peaks":[{"hz":5.0,"amp":0.2,'
-                            b'"vibration_strength_db":31.0}]}\n'
-                            b'{"window_index":1,"coverage_state":"full","returned_sample_start":200,'
-                            b'"returned_sample_count":256,"top_peaks":[{"hz":6.0,"amp":0.2,'
-                            b'"vibration_strength_db":31.0}]}\n'
-                        ),
-                        "spectral-summary:sensor-rear": (
-                            b'{"window_index":0,"coverage_state":"full","returned_sample_start":0,'
-                            b'"returned_sample_count":256,"top_peaks":[{"hz":5.05,"amp":0.15,'
-                            b'"vibration_strength_db":29.0}]}\n'
-                            b'{"window_index":1,"coverage_state":"full","returned_sample_start":200,'
-                            b'"returned_sample_count":256,"top_peaks":[{"hz":6.05,"amp":0.15,'
-                            b'"vibration_strength_db":29.0}]}\n'
-                        ),
+                    "analysis_metadata": {
+                        "analyzed_sample_count": 2,
+                        "total_sample_count": 2,
+                        "sampling_method": "full",
                     },
-                },
-            )()
-        ),
-        whole_run_context_builder=lambda **_kwargs: context_bundle,
-        whole_run_order_trace_builder=lambda **_kwargs: order_trace_bundle,
-        whole_run_order_trace_summary_builder=lambda **_kwargs: None,
-        whole_run_order_family_summary_builder=lambda **_kwargs: None,
-        analysis_runner=lambda _run: make_persisted_analysis(
-            {
-                "analysis_metadata": {
-                    "analyzed_sample_count": 2,
-                    "total_sample_count": 2,
-                    "sampling_method": "full",
-                },
-                "run_suitability": [],
-            }
+                    "run_suitability": [],
+                }
+            ),
         ),
     )
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis.py
@@ -19,6 +19,7 @@ from threading import Event, RLock, Thread
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.use_cases.run.post_analysis_executor import (
     PostAnalysisAttemptResult,
+    PostAnalysisExecutionConfig,
     PostAnalysisRunner,
     execute_post_analysis,
 )
@@ -241,8 +242,10 @@ class PostAnalysisWorker:
             result: PostAnalysisAttemptResult = execute_post_analysis(
                 run_id=run_id,
                 db=db,
-                analysis_runner=self._analysis_runner,
-                defer_retryable_error_storage=defer_retryable_error_storage,
+                config=PostAnalysisExecutionConfig(
+                    analysis_runner=self._analysis_runner,
+                    defer_retryable_error_storage=defer_retryable_error_storage,
+                ),
             )
             if isinstance(result, PostAnalysisExecutionRetryableFailure):
                 delay_s = _RETRY_DELAYS_S[retry_index]

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from typing import Protocol
 
 import aiosqlite
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import Span, SpanKind
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.structured_logging import log_extra
@@ -45,6 +45,7 @@ from vibesensor.use_cases.run.post_analysis_stage_runner import (
     warning_codes,
 )
 from vibesensor.use_cases.run.post_analysis_whole_run_pipeline import (
+    ResolvedWholeRunBuilders,
     WholeRunArtifactBuilder,
     WholeRunContextBuilder,
     WholeRunDiagnosisSummaryBuilder,
@@ -119,6 +120,58 @@ class PostAnalysisInputStageOutput:
     stage_result: PostAnalysisStageResult
 
 
+@dataclass(frozen=True, slots=True)
+class PostAnalysisWholeRunBuilderConfig:
+    artifact_builder: WholeRunArtifactBuilder | None = None
+    context_builder: WholeRunContextBuilder | None = None
+    order_trace_builder: WholeRunOrderTraceBuilder | None = None
+    order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None = None
+    order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None = None
+    spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None = None
+    diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder | None = None
+
+    def resolve(self) -> ResolvedWholeRunBuilders:
+        return resolve_whole_run_builders(
+            whole_run_artifact_builder=self.artifact_builder,
+            whole_run_context_builder=self.context_builder,
+            whole_run_order_trace_builder=self.order_trace_builder,
+            whole_run_order_trace_summary_builder=self.order_trace_summary_builder,
+            whole_run_order_family_summary_builder=self.order_family_summary_builder,
+            whole_run_spatial_coherence_builder=self.spatial_coherence_builder,
+            whole_run_diagnosis_summary_builder=self.diagnosis_summary_builder,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisExecutionConfig:
+    analysis_runner: PostAnalysisRunner
+    load_run: PostAnalysisLoader = load_post_analysis_run
+    whole_run_builders: PostAnalysisWholeRunBuilderConfig = field(
+        default_factory=PostAnalysisWholeRunBuilderConfig
+    )
+    defer_retryable_error_storage: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisStageOutcome:
+    stage_results: tuple[PostAnalysisStageResult, ...]
+    terminal_result: PostAnalysisAttemptResult | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisStageDefinition:
+    stage_name: str
+    run: Callable[[], PostAnalysisStageOutcome]
+
+
+@dataclass(slots=True)
+class PostAnalysisExecutionState:
+    loaded: LoadedPostAnalysisRun | None = None
+    run_input: PostAnalysisRunInput | None = None
+    whole_run_output: WholeRunPipelineStageOutput | None = None
+    summary: PersistedAnalysis | None = None
+
+
 def _log_stage_result(run_id: str, stage_result: PostAnalysisStageResult) -> None:
     if stage_result.status == "ok":
         return
@@ -139,6 +192,174 @@ def _log_stage_result(run_id: str, stage_result: PostAnalysisStageResult) -> Non
             diagnostic_context=stage_result.diagnostic_context,
         ),
     )
+
+
+class PostAnalysisExecutionRunner:
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        db: RunPersistence,
+        config: PostAnalysisExecutionConfig,
+        analysis_start: float,
+    ) -> None:
+        self.run_id = run_id
+        self.db = db
+        self.config = config
+        self.analysis_start = analysis_start
+        self.resolved_builders = config.whole_run_builders.resolve()
+        self.state = PostAnalysisExecutionState()
+
+    @property
+    def stage_names(self) -> tuple[str, ...]:
+        return tuple(stage.stage_name for stage in self._stage_definitions())
+
+    def run(self, span: Span) -> PostAnalysisAttemptResult:
+        for stage in self._stage_definitions():
+            try:
+                outcome = stage.run()
+            except PostAnalysisStageFailure as stage_failure:
+                return self._handle_stage_failure(span, stage_failure)
+            for stage_result in outcome.stage_results:
+                _log_stage_result(self.run_id, stage_result)
+            if outcome.terminal_result is not None:
+                self._record_terminal_span_attributes(span, outcome.stage_results)
+                return outcome.terminal_result
+        return self._success(span)
+
+    def _stage_definitions(self) -> tuple[PostAnalysisStageDefinition, ...]:
+        return (
+            PostAnalysisStageDefinition("LoadRunStage", self._run_load_stage),
+            PostAnalysisStageDefinition(
+                "BuildPostAnalysisInputStage",
+                self._run_input_stage,
+            ),
+            PostAnalysisStageDefinition("WholeRunPipelineStages", self._run_whole_run_stages),
+            PostAnalysisStageDefinition("BuildReportFactsStage", self._run_report_facts_stage),
+            PostAnalysisStageDefinition(
+                "PersistAnalysisSummaryStage",
+                self._run_persist_summary_stage,
+            ),
+        )
+
+    def _run_load_stage(self) -> PostAnalysisStageOutcome:
+        load_stage = run_load_run_stage(
+            run_id=self.run_id,
+            db=self.db,
+            load_run=self.config.load_run,
+            analysis_start=self.analysis_start,
+            defer_retryable_error_storage=self.config.defer_retryable_error_storage,
+        )
+        if load_stage.loaded is not None:
+            self.state.loaded = load_stage.loaded
+        return PostAnalysisStageOutcome(
+            stage_results=(load_stage.stage_result,),
+            terminal_result=load_stage.terminal_result,
+        )
+
+    def _run_input_stage(self) -> PostAnalysisStageOutcome:
+        loaded = self.state.loaded
+        assert loaded is not None
+        input_stage = run_build_post_analysis_input_stage(loaded)
+        self.state.run_input = input_stage.run_input
+        return PostAnalysisStageOutcome(stage_results=(input_stage.stage_result,))
+
+    def _run_whole_run_stages(self) -> PostAnalysisStageOutcome:
+        loaded = self.state.loaded
+        run_input = self.state.run_input
+        assert loaded is not None
+        assert run_input is not None
+        whole_run_output = run_whole_run_pipeline_stages(
+            db=self.db,
+            loaded=loaded,
+            run_input=run_input,
+            builders=self.resolved_builders,
+        )
+        self.state.whole_run_output = whole_run_output
+        return PostAnalysisStageOutcome(stage_results=whole_run_output.stage_results)
+
+    def _run_report_facts_stage(self) -> PostAnalysisStageOutcome:
+        run_input = self.state.run_input
+        whole_run_output = self.state.whole_run_output
+        assert run_input is not None
+        assert whole_run_output is not None
+        summary, report_facts_stage = run_build_report_facts_stage(
+            run_input=run_input,
+            analysis_runner=self.config.analysis_runner,
+            whole_run_output=whole_run_output,
+            diagnosis_summary_builder=self.resolved_builders.diagnosis_summary_builder,
+        )
+        self.state.summary = summary
+        return PostAnalysisStageOutcome(stage_results=(report_facts_stage,))
+
+    def _run_persist_summary_stage(self) -> PostAnalysisStageOutcome:
+        loaded = self.state.loaded
+        summary = self.state.summary
+        assert loaded is not None
+        assert summary is not None
+        persist_summary_stage = run_persist_analysis_summary_stage(
+            db=self.db,
+            run_id=loaded.run_id,
+            summary=summary,
+        )
+        return PostAnalysisStageOutcome(stage_results=(persist_summary_stage,))
+
+    def _record_terminal_span_attributes(
+        self,
+        span: Span,
+        stage_results: tuple[PostAnalysisStageResult, ...],
+    ) -> None:
+        if not stage_results:
+            return
+        failure_kind = stage_results[-1].diagnostic_context.get("failure_kind")
+        if failure_kind in {"missing_metadata", "no_samples"}:
+            span.set_attribute("vibesensor.failure_kind", failure_kind)
+
+    def _handle_stage_failure(
+        self,
+        span: Span,
+        stage_failure: PostAnalysisStageFailure,
+    ) -> PostAnalysisAttemptResult:
+        mark_span_error(span, stage_failure.cause)
+        span.set_attribute("vibesensor.failed_stage", stage_failure.stage_result.stage_name)
+        _log_stage_result(self.run_id, stage_failure.stage_result)
+        exc = stage_failure.cause
+        if self.config.defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
+            return _retryable_failure_result(
+                run_id=self.run_id,
+                analysis_start=self.analysis_start,
+                exc=exc,
+                stage_name=stage_failure.stage_result.stage_name,
+            )
+        return _persistence_failure_result(
+            run_id=self.run_id,
+            analysis_start=self.analysis_start,
+            exc=exc,
+            db=self.db,
+            stage_name=stage_failure.stage_result.stage_name,
+        )
+
+    def _success(self, span: Span) -> PostAnalysisExecutionSuccess:
+        loaded = self.state.loaded
+        run_input = self.state.run_input
+        assert loaded is not None
+        assert run_input is not None
+        duration_s = time.monotonic() - self.analysis_start
+        span.set_attribute("vibesensor.sample_count", len(run_input.samples))
+        span.set_attribute("vibesensor.duration_s", round(duration_s, 3))
+        LOGGER.info(
+            "Analysis completed for run %s: %d samples in %.2fs",
+            loaded.run_id,
+            len(run_input.samples),
+            duration_s,
+            extra=log_extra(
+                event="post_analysis_completed",
+                run_id=loaded.run_id,
+                sample_count=len(run_input.samples),
+                duration_s=round(duration_s, 3),
+            ),
+        )
+        return PostAnalysisExecutionSuccess(run_id=loaded.run_id)
 
 
 def run_load_run_stage(
@@ -409,27 +630,9 @@ def execute_post_analysis(
     *,
     run_id: str,
     db: RunPersistence,
-    analysis_runner: PostAnalysisRunner,
-    load_run: PostAnalysisLoader = load_post_analysis_run,
-    whole_run_artifact_builder: WholeRunArtifactBuilder | None = None,
-    whole_run_context_builder: WholeRunContextBuilder | None = None,
-    whole_run_order_trace_builder: WholeRunOrderTraceBuilder | None = None,
-    whole_run_order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None = None,
-    whole_run_order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None = None,
-    whole_run_spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None = None,
-    whole_run_diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder | None = None,
-    defer_retryable_error_storage: bool = False,
+    config: PostAnalysisExecutionConfig,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
-    resolved_builders = resolve_whole_run_builders(
-        whole_run_artifact_builder=whole_run_artifact_builder,
-        whole_run_context_builder=whole_run_context_builder,
-        whole_run_order_trace_builder=whole_run_order_trace_builder,
-        whole_run_order_trace_summary_builder=whole_run_order_trace_summary_builder,
-        whole_run_order_family_summary_builder=whole_run_order_family_summary_builder,
-        whole_run_spatial_coherence_builder=whole_run_spatial_coherence_builder,
-        whole_run_diagnosis_summary_builder=whole_run_diagnosis_summary_builder,
-    )
     with start_span(
         __name__,
         "run.post_analysis.execute",
@@ -441,87 +644,13 @@ def execute_post_analysis(
             run_id,
             extra=log_extra(event="post_analysis_started", run_id=run_id),
         )
-        load_stage = run_load_run_stage(
+        runner = PostAnalysisExecutionRunner(
             run_id=run_id,
             db=db,
-            load_run=load_run,
+            config=config,
             analysis_start=analysis_start,
-            defer_retryable_error_storage=defer_retryable_error_storage,
         )
-        _log_stage_result(run_id, load_stage.stage_result)
-        if load_stage.terminal_result is not None:
-            if load_stage.stage_result.diagnostic_context.get("failure_kind") == "missing_metadata":
-                span.set_attribute("vibesensor.failure_kind", "missing_metadata")
-            if load_stage.stage_result.diagnostic_context.get("failure_kind") == "no_samples":
-                span.set_attribute("vibesensor.failure_kind", "no_samples")
-            return load_stage.terminal_result
-
-        loaded = load_stage.loaded
-        assert loaded is not None
-        try:
-            input_stage = run_build_post_analysis_input_stage(loaded)
-            _log_stage_result(loaded.run_id, input_stage.stage_result)
-
-            whole_run_stage = run_whole_run_pipeline_stages(
-                db=db,
-                loaded=loaded,
-                run_input=input_stage.run_input,
-                builders=resolved_builders,
-            )
-            for stage_result in whole_run_stage.stage_results:
-                _log_stage_result(loaded.run_id, stage_result)
-
-            run_input = input_stage.run_input
-            span.set_attribute("vibesensor.sample_count", len(run_input.samples))
-            summary, report_facts_stage = run_build_report_facts_stage(
-                run_input=run_input,
-                analysis_runner=analysis_runner,
-                whole_run_output=whole_run_stage,
-                diagnosis_summary_builder=resolved_builders.diagnosis_summary_builder,
-            )
-            _log_stage_result(loaded.run_id, report_facts_stage)
-
-            persist_summary_stage = run_persist_analysis_summary_stage(
-                db=db,
-                run_id=loaded.run_id,
-                summary=summary,
-            )
-            _log_stage_result(loaded.run_id, persist_summary_stage)
-        except PostAnalysisStageFailure as stage_failure:
-            mark_span_error(span, stage_failure.cause)
-            span.set_attribute("vibesensor.failed_stage", stage_failure.stage_result.stage_name)
-            _log_stage_result(loaded.run_id, stage_failure.stage_result)
-            exc = stage_failure.cause
-            if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
-                return _retryable_failure_result(
-                    run_id=loaded.run_id,
-                    analysis_start=analysis_start,
-                    exc=exc,
-                    stage_name=stage_failure.stage_result.stage_name,
-                )
-            return _persistence_failure_result(
-                run_id=loaded.run_id,
-                analysis_start=analysis_start,
-                exc=exc,
-                db=db,
-                stage_name=stage_failure.stage_result.stage_name,
-            )
-
-        duration_s = time.monotonic() - analysis_start
-        span.set_attribute("vibesensor.duration_s", round(duration_s, 3))
-        LOGGER.info(
-            "Analysis completed for run %s: %d samples in %.2fs",
-            loaded.run_id,
-            len(run_input.samples),
-            duration_s,
-            extra=log_extra(
-                event="post_analysis_completed",
-                run_id=loaded.run_id,
-                sample_count=len(run_input.samples),
-                duration_s=round(duration_s, 3),
-            ),
-        )
-        return PostAnalysisExecutionSuccess(run_id=loaded.run_id)
+        return runner.run(span)
 
 
 def _store_load_error(

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -38,7 +38,9 @@ below.
 - `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` uses raw capture
    only to rebuild FFT-derived metrics for those already-persisted summary rows.
 - `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` is the
-   canonical offline executor. It runs a structured stage pipeline:
+   canonical offline executor. `PostAnalysisExecutionRunner` owns the
+   declarative top-level stage order, using `PostAnalysisExecutionConfig` for
+   loader/runner/builder dependencies:
   `LoadRunStage`, `BuildPostAnalysisInputStage`,
   `BuildWholeRunSpectraStage`, `BuildWholeRunContextStage`,
   `BuildOrderTraceStage`, `BuildOrderTraceSummaryStage`,

--- a/tools/dev/maintainability_allowlist.yml
+++ b/tools/dev/maintainability_allowlist.yml
@@ -15,7 +15,7 @@ functions:
     max_lines: 281
     reason: Contract sync and UI validation entrypoint guards now live in their own concern module; keep together for workflow/config drift reporting.
   apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py::test_execute_post_analysis_persists_whole_run_diagnosis_summaries:
-    max_lines: 353
+    max_lines: 357
     reason: End-to-end whole-run diagnosis persistence scenario kept together to preserve setup/assertion context.
   apps/server/tests_e2e/test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys:
     max_lines: 263
@@ -24,14 +24,11 @@ functions:
     max_lines: 234
     reason: Raw-capture replay assembly retained until sample-building phases are separated.
   apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py::test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metadata:
-    max_lines: 230
+    max_lines: 234
     reason: Whole-run order trace persistence scenario kept together to preserve fixture chronology.
   apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py::test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_metadata:
-    max_lines: 225
+    max_lines: 233
     reason: Whole-run spatial coherence persistence scenario kept together to preserve setup/assertion context.
   apps/server/tests/integration/test_ingest_backpressure_metrics.py::test_ingest_metrics_hold_ci_budget_under_sensor_load:
     max_lines: 220
     reason: Integration load scenario intentionally keeps timing, ingest, and metric assertions in one flow.
-  apps/server/tests/use_cases/run/test_post_analysis_executor.py::test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar:
-    max_lines: 206
-    reason: Post-analysis context summary persistence scenario kept together to preserve setup/assertion context.

--- a/tools/dev/maintainability_allowlist.yml
+++ b/tools/dev/maintainability_allowlist.yml
@@ -29,6 +29,9 @@ functions:
   apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py::test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_metadata:
     max_lines: 233
     reason: Whole-run spatial coherence persistence scenario kept together to preserve setup/assertion context.
+  apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_metadata.py::test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar:
+    max_lines: 210
+    reason: Post-analysis context summary persistence scenario kept together to preserve setup/assertion context after moving out of the oversized executor test module.
   apps/server/tests/integration/test_ingest_backpressure_metrics.py::test_ingest_metrics_hold_ci_budget_under_sensor_load:
     max_lines: 220
     reason: Integration load scenario intentionally keeps timing, ingest, and metric assertions in one flow.


### PR DESCRIPTION
## What changed
- Added `PostAnalysisExecutionRunner` to own top-level post-analysis stage order, state transitions, terminal load results, and stage failure handling.
- Added `PostAnalysisExecutionConfig` and `PostAnalysisWholeRunBuilderConfig` so optional loader/runner/builder dependencies are configured as metadata instead of a wide executor signature.
- Updated `PostAnalysisWorker`, golden replay support, and executor tests to use the config path.
- Split whole-run metadata executor coverage out of the oversized executor test file and updated the whole-run design doc.

## Why
`execute_post_analysis()` manually sequenced stages and listed every optional builder as a parameter. The new runner makes the order inspectable and keeps failure/status behavior in one owner.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_metadata.py apps/server/tests/use_cases/run/test_post_analysis_executor_raw_capture_policy.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make docs-lint`
- `make plan-validation`

## Risks / edge cases
- Existing load terminal results, retryable persistence deferral, stage failure persistence, span attributes, and persisted summary contracts are preserved.
- The whole-run sub-pipeline still owns its own internal stage order; this change only replaces the top-level executor orchestration.

Closes #3777