### PR TITLE
Refactor whole-run support summaries

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_support_summary.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_support_summary.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.types.whole_run_analysis import WholeRunContextWindowLabel
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTracePoint
+from vibesensor.use_cases.diagnostics.whole_run_support_summary import (
+    build_phase_support,
+    build_support_intervals,
+    has_speed_context_quality_reason,
+    has_timing_quality_reason,
+    mean_window_quality_score,
+    unique_quality_reason_window_count,
+    window_quality_state_counts,
+)
+
+
+def _label(
+    window_index: int,
+    *,
+    phase: DrivingPhase,
+    load_state: str = "steady",
+    speed_band: str = "medium",
+) -> WholeRunContextWindowLabel:
+    return WholeRunContextWindowLabel(
+        window_index=window_index,
+        segment_index=0,
+        phase=phase,
+        context_coverage="full",
+        speed_validity="measured",
+        rpm_validity="measured",
+        load_state=load_state,
+        speed_band=speed_band,
+    )
+
+
+def _point(
+    window_index: int,
+    *,
+    matched: bool = True,
+    peak_intensity_db: float = 20.0,
+    window_quality_score: float = 1.0,
+    window_quality_state: str = "usable",
+    window_quality_reasons: tuple[str, ...] = (),
+) -> OrderTracePoint:
+    return OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=window_index,
+        eligible=True,
+        matched=matched,
+        predicted_hz=10.0,
+        matched_hz=10.05 if matched else None,
+        relative_error=0.01 if matched else None,
+        peak_intensity_db=peak_intensity_db if matched else None,
+        vibration_strength_db=peak_intensity_db - 4.0 if matched else None,
+        ref_source="speed+tire",
+        window_quality_score=window_quality_score,
+        window_quality_state=window_quality_state,
+        window_quality_reasons=window_quality_reasons,
+    )
+
+
+def test_support_intervals_keep_eligible_gaps_and_rank_real_exemplar_index() -> None:
+    context_by_window = {
+        0: _label(0, phase=DrivingPhase.CRUISE, load_state="steady"),
+        1: _label(1, phase=DrivingPhase.CRUISE, load_state="steady"),
+        2: _label(2, phase=DrivingPhase.ACCELERATION, load_state="accel"),
+        4: _label(4, phase=DrivingPhase.CRUISE, load_state="steady"),
+        5: _label(5, phase=DrivingPhase.CRUISE, load_state="steady"),
+    }
+    matched_points_by_window = {
+        0: _point(0, peak_intensity_db=15.0),
+        2: _point(2, peak_intensity_db=30.0),
+        4: _point(4, peak_intensity_db=18.0),
+        5: _point(5, peak_intensity_db=18.0),
+    }
+
+    summary = build_support_intervals(
+        eligible_windows=(0, 1, 2, 4, 5),
+        matched_points_by_window=matched_points_by_window,
+        context_by_window=context_by_window,
+        context_rank_mode="weighted",
+        include_peak_intensity_in_rank=True,
+        missing_mean_error_rank=1.0,
+    )
+
+    assert [(row.start_window_index, row.end_window_index) for row in summary.intervals] == [
+        (0, 2),
+        (4, 5),
+    ]
+    assert summary.intervals[0].support_ratio == 2 / 3
+    assert summary.intervals[0].phase == "acceleration"
+    assert summary.exemplar_interval_index == 1
+
+
+def test_phase_support_counts_eligible_and_matched_windows_by_phase() -> None:
+    context_by_window = {
+        0: _label(0, phase=DrivingPhase.CRUISE),
+        1: _label(1, phase=DrivingPhase.CRUISE),
+        2: _label(2, phase=DrivingPhase.ACCELERATION),
+    }
+
+    rows = build_phase_support(
+        eligible_windows=(0, 1, 2),
+        matched_windows=(0, 2),
+        context_by_window=context_by_window,
+    )
+
+    assert [(row.phase, row.eligible_window_count, row.matched_window_count) for row in rows] == [
+        ("acceleration", 1, 1),
+        ("cruise", 2, 1),
+    ]
+    assert rows[1].support_ratio == 0.5
+
+
+def test_quality_summary_helpers_count_states_and_reason_windows_once() -> None:
+    points = (
+        _point(0, window_quality_score=1.0, window_quality_state="usable"),
+        _point(
+            1,
+            window_quality_score=0.5,
+            window_quality_state="limited",
+            window_quality_reasons=("timing_gap", "server_queue_drop"),
+        ),
+        _point(
+            1,
+            window_quality_score=0.25,
+            window_quality_state="excluded",
+            window_quality_reasons=("timing_gap",),
+        ),
+        _point(
+            2,
+            matched=False,
+            window_quality_score=0.0,
+            window_quality_state="excluded",
+            window_quality_reasons=("speed_stale",),
+        ),
+    )
+
+    counts = window_quality_state_counts(points)
+
+    assert counts.usable_window_count == 1
+    assert counts.limited_window_count == 1
+    assert counts.excluded_window_count == 2
+    assert mean_window_quality_score(points) == 0.4375
+    assert unique_quality_reason_window_count(points, "timing_gap") == 1
+    assert has_timing_quality_reason(points[1])
+    assert has_speed_context_quality_reason(points[3])

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -29,16 +29,12 @@ from vibesensor.use_cases.diagnostics.math_utils import (
     _stddev_or_none as _stddev,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
-    OrderTracePhaseSupport,
     OrderTracePoint,
     OrderTraceSummary,
-    OrderTraceSupportInterval,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     WholeRunOrderTraceSummaryArtifactBundle,
-    _dominant_context_value,
     _drift_score,
-    _has_speed_context_quality_reason,
     _lock_score,
     _longest_contiguous_match_run,
     _mounting_adjusted_lock_score,
@@ -49,13 +45,20 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WholeRunOrderTraceArtifactBundle,
 )
+from vibesensor.use_cases.diagnostics.whole_run_support_summary import (
+    build_phase_support,
+    build_support_intervals,
+    dominant_context_value,
+    has_speed_context_quality_reason,
+    has_timing_quality_reason,
+    mean_window_quality_score,
+    unique_quality_reason_window_count,
+    window_quality_state_counts,
+)
 
 WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY = "order-family-summaries"
 _WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_PATH = "orders/family-summaries.jsonl"
 _FAMILY_ORDER = ("wheel", "driveshaft", "engine")
-_TIMING_QUALITY_REASONS = frozenset(
-    {"timing_gap", "late_packet_loss", "server_queue_drop", "sensor_reset"}
-)
 
 __all__ = [
     "WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY",
@@ -206,12 +209,7 @@ def _family_summary(
     ]
     mean_relative_error = _mean(relative_errors)
     relative_error_stddev = _stddev(relative_errors)
-    quality_scores = [
-        point.window_quality_score
-        for point in matched_points
-        if point.window_quality_score is not None
-    ]
-    mean_quality_score = _mean(quality_scores)
+    mean_quality_score = mean_window_quality_score(matched_points)
     quality_counts = _family_quality_counts(
         points=points,
         matched_points=matched_points,
@@ -249,14 +247,18 @@ def _family_summary(
             quality_counts.matched_speed_context_limited_window_count
         ),
     )
-    support_intervals, exemplar_interval_index = _support_intervals(
+    support_interval_summary = build_support_intervals(
         eligible_windows=eligible_windows,
-        selected_matches_by_window=selected_matches_by_window,
+        matched_points_by_window=selected_matches_by_window,
         context_by_window=context_by_window,
+        context_rank_mode="weighted",
+        include_peak_intensity_in_rank=True,
+        missing_mean_error_rank=1.0,
     )
-    phase_support = _phase_support_rows(
+    support_intervals = support_interval_summary.intervals
+    phase_support = build_phase_support(
         eligible_windows=eligible_windows,
-        selected_matches_by_window=selected_matches_by_window,
+        matched_windows=selected_matches_by_window,
         context_by_window=context_by_window,
     )
     stable_frequency_min_hz = _min_or_none(
@@ -283,12 +285,12 @@ def _family_summary(
             if point.strongest_location
         )
     )
-    dominant_phase = _dominant_context_value(
+    dominant_phase = dominant_context_value(
         points=matched_points,
         context_by_window=context_by_window,
         attribute_name="phase",
     )
-    dominant_speed_band = _dominant_context_value(
+    dominant_speed_band = dominant_context_value(
         points=matched_points,
         context_by_window=context_by_window,
         attribute_name="speed_band",
@@ -327,7 +329,7 @@ def _family_summary(
         harmonic_summaries=harmonic_summaries,
         stable_frequency_min_hz=stable_frequency_min_hz,
         stable_frequency_max_hz=stable_frequency_max_hz,
-        exemplar_interval_index=exemplar_interval_index,
+        exemplar_interval_index=support_interval_summary.exemplar_interval_index,
         dominant_phase=dominant_phase,
         dominant_speed_band=dominant_speed_band,
         strongest_location=strongest_location,
@@ -347,49 +349,47 @@ def _family_quality_counts(
     matched_points: Sequence[OrderTracePoint],
     candidate_summaries: Sequence[OrderTraceSummary],
 ) -> _FamilyQualityCounts:
-    return _FamilyQualityCounts(
-        usable_window_count=sum(
-            1 for point in matched_points if point.window_quality_state == "usable"
-        ),
-        limited_window_count=sum(
-            1 for point in matched_points if point.window_quality_state == "limited"
-        ),
+    matched_state_counts = window_quality_state_counts(
+        matched_points,
         excluded_window_count=sum(summary.excluded_window_count for summary in candidate_summaries),
-        shock_transient_window_count=_unique_reason_window_count(points, "shock_transient"),
-        sensor_clipping_window_count=_unique_reason_window_count(points, "sensor_clipping"),
-        sensor_mounting_artifact_window_count=_unique_reason_window_count(
+    )
+    return _FamilyQualityCounts(
+        usable_window_count=matched_state_counts.usable_window_count,
+        limited_window_count=matched_state_counts.limited_window_count,
+        excluded_window_count=matched_state_counts.excluded_window_count,
+        shock_transient_window_count=unique_quality_reason_window_count(
+            points,
+            "shock_transient",
+        ),
+        sensor_clipping_window_count=unique_quality_reason_window_count(
+            points,
+            "sensor_clipping",
+        ),
+        sensor_mounting_artifact_window_count=unique_quality_reason_window_count(
             points,
             "mounting_artifact",
         ),
-        matched_mounting_artifact_window_count=_unique_reason_window_count(
+        matched_mounting_artifact_window_count=unique_quality_reason_window_count(
             matched_points,
             "mounting_artifact",
         ),
         sensor_timing_integrity_window_count=len(
-            {point.window_index for point in points if _has_timing_quality_reason(point)}
+            {point.window_index for point in points if has_timing_quality_reason(point)}
         ),
         matched_timing_integrity_window_count=len(
-            {point.window_index for point in matched_points if _has_timing_quality_reason(point)}
+            {point.window_index for point in matched_points if has_timing_quality_reason(point)}
         ),
         speed_context_limited_window_count=len(
-            {point.window_index for point in points if _has_speed_context_quality_reason(point)}
+            {point.window_index for point in points if has_speed_context_quality_reason(point)}
         ),
         matched_speed_context_limited_window_count=len(
             {
                 point.window_index
                 for point in matched_points
-                if _has_speed_context_quality_reason(point)
+                if has_speed_context_quality_reason(point)
             }
         ),
     )
-
-
-def _unique_reason_window_count(points: Sequence[OrderTracePoint], reason: str) -> int:
-    return len({point.window_index for point in points if reason in point.window_quality_reasons})
-
-
-def _has_timing_quality_reason(point: OrderTracePoint) -> bool:
-    return any(reason in _TIMING_QUALITY_REASONS for reason in point.window_quality_reasons)
 
 
 def _selected_family_matches_by_window(
@@ -410,157 +410,6 @@ def _selected_family_matches_by_window(
             reverse=True,
         )[0]
     return selected
-
-
-def _support_intervals(
-    *,
-    eligible_windows: Sequence[int],
-    selected_matches_by_window: Mapping[int, OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-) -> tuple[tuple[OrderTraceSupportInterval, ...], int | None]:
-    intervals: list[OrderTraceSupportInterval] = []
-    interval_ranks: list[tuple[int, float, float, float, int]] = []
-    current_start: int | None = None
-    current_windows: list[int] = []
-    matched_points: list[OrderTracePoint] = []
-    previous_window: int | None = None
-    for window_index in eligible_windows:
-        if previous_window is None or window_index == previous_window + 1:
-            if current_start is None:
-                current_start = window_index
-            current_windows.append(window_index)
-            point = selected_matches_by_window.get(window_index)
-            if point is not None:
-                matched_points.append(point)
-        else:
-            _append_interval(
-                intervals=intervals,
-                interval_ranks=interval_ranks,
-                interval_index=len(intervals),
-                start_window=current_start,
-                eligible_windows=current_windows,
-                matched_points=matched_points,
-                context_by_window=context_by_window,
-            )
-            current_start = window_index
-            current_windows = [window_index]
-            matched_points = []
-            point = selected_matches_by_window.get(window_index)
-            if point is not None:
-                matched_points.append(point)
-        previous_window = window_index
-    _append_interval(
-        intervals=intervals,
-        interval_ranks=interval_ranks,
-        interval_index=len(intervals),
-        start_window=current_start,
-        eligible_windows=current_windows,
-        matched_points=matched_points,
-        context_by_window=context_by_window,
-    )
-    exemplar_interval_index: int | None = None
-    if interval_ranks:
-        exemplar_interval_index = max(interval_ranks)[-1]
-    return tuple(intervals), exemplar_interval_index
-
-
-def _append_interval(
-    *,
-    intervals: list[OrderTraceSupportInterval],
-    interval_ranks: list[tuple[int, float, float, float, int]],
-    interval_index: int,
-    start_window: int | None,
-    eligible_windows: Sequence[int],
-    matched_points: Sequence[OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-) -> None:
-    if start_window is None or not eligible_windows or not matched_points:
-        return
-    end_window = eligible_windows[-1]
-    support_ratio = _ratio(len(matched_points), len(eligible_windows))
-    mean_relative_error = _mean(
-        point.relative_error for point in matched_points if point.relative_error is not None
-    )
-    interval = OrderTraceSupportInterval(
-        interval_index=interval_index,
-        start_window_index=start_window,
-        end_window_index=end_window,
-        matched_window_count=len(matched_points),
-        support_ratio=support_ratio,
-        phase=_dominant_context_value(
-            points=matched_points,
-            context_by_window=context_by_window,
-            attribute_name="phase",
-        ),
-        load_state=_dominant_load_state(matched_points, context_by_window),
-        speed_band=_dominant_context_value(
-            points=matched_points,
-            context_by_window=context_by_window,
-            attribute_name="speed_band",
-        ),
-        mean_relative_error=mean_relative_error,
-    )
-    intervals.append(interval)
-    interval_ranks.append(
-        (
-            len(matched_points),
-            support_ratio,
-            _max_or_none(
-                point.peak_intensity_db
-                for point in matched_points
-                if point.peak_intensity_db is not None
-            )
-            or 0.0,
-            -(mean_relative_error or 1.0),
-            -interval_index,
-        )
-    )
-
-
-def _phase_support_rows(
-    *,
-    eligible_windows: Sequence[int],
-    selected_matches_by_window: Mapping[int, OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-) -> tuple[OrderTracePhaseSupport, ...]:
-    eligible_by_phase: dict[str, int] = defaultdict(int)
-    matched_by_phase: dict[str, int] = defaultdict(int)
-    for window_index in eligible_windows:
-        label = context_by_window.get(window_index)
-        if label is None:
-            continue
-        phase = label.phase.value
-        eligible_by_phase[phase] += 1
-        if window_index in selected_matches_by_window:
-            matched_by_phase[phase] += 1
-    ordered_phases = sorted(eligible_by_phase)
-    return tuple(
-        OrderTracePhaseSupport(
-            phase=phase,
-            eligible_window_count=eligible_by_phase[phase],
-            matched_window_count=matched_by_phase.get(phase, 0),
-            support_ratio=_ratio(matched_by_phase.get(phase, 0), eligible_by_phase[phase]),
-        )
-        for phase in ordered_phases
-    )
-
-
-def _dominant_load_state(
-    points: Sequence[OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-) -> str | None:
-    ranked_values: list[tuple[str, float]] = []
-    for point in points:
-        label = context_by_window.get(point.window_index)
-        if label is None or not label.load_state:
-            continue
-        ranked_values.append(
-            (
-                label.load_state,
-                point.peak_intensity_db if point.peak_intensity_db is not None else 0.0,
-            )
-        )
-    return dominant_weighted_value(values=ranked_values)
 
 
 def _point_rank(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -39,13 +39,21 @@ from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
 from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderHarmonicEvidenceSummary,
-    OrderTracePhaseSupport,
     OrderTracePoint,
     OrderTraceSummary,
-    OrderTraceSupportInterval,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_support_summary import (
+    build_phase_support,
+    build_support_intervals,
+    dominant_context_value,
+    has_speed_context_quality_reason,
+    has_timing_quality_reason,
+    mean_window_quality_score,
+    unique_quality_reason_window_count,
+    window_quality_state_counts,
 )
 
 WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY = "order-trace-summaries"
@@ -57,19 +65,6 @@ _LOCK_SCORE_ERROR_WEIGHT = 0.15
 _LOCK_SCORE_DRIFT_WEIGHT = 0.10
 _RELATIVE_ERROR_DENOMINATOR = 0.25
 _RELATIVE_ERROR_DRIFT_TOLERANCE = 0.08
-_TIMING_QUALITY_REASONS = frozenset(
-    {"timing_gap", "late_packet_loss", "server_queue_drop", "sensor_reset"}
-)
-_SPEED_CONTEXT_QUALITY_REASONS = frozenset(
-    {
-        "speed_unavailable",
-        "speed_low",
-        "speed_stale",
-        "speed_unstable",
-        "speed_assumed",
-    }
-)
-
 __all__ = [
     "WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY",
     "WholeRunOrderTraceSummaryArtifactBundle",
@@ -198,43 +193,42 @@ def _summarize_hypothesis_trace(
     ]
     mean_relative_error = _mean(relative_errors)
     relative_error_stddev = _stddev(relative_errors)
-    quality_scores = [
-        point.window_quality_score for point in points if point.window_quality_score is not None
-    ]
-    mean_quality_score = _mean(quality_scores)
-    usable_window_count = sum(1 for point in points if point.window_quality_state == "usable")
-    limited_window_count = sum(1 for point in points if point.window_quality_state == "limited")
-    excluded_window_count = sum(1 for point in points if point.window_quality_state == "excluded")
-    shock_transient_window_count = sum(
-        1 for point in points if "shock_transient" in point.window_quality_reasons
-    )
-    sensor_clipping_window_count = sum(
-        1 for point in points if "sensor_clipping" in point.window_quality_reasons
-    )
-    sensor_mounting_artifact_window_count = sum(
-        1 for point in points if "mounting_artifact" in point.window_quality_reasons
+    mean_quality_score = mean_window_quality_score(points)
+    quality_state_counts = window_quality_state_counts(points)
+    usable_window_count = quality_state_counts.usable_window_count
+    limited_window_count = quality_state_counts.limited_window_count
+    excluded_window_count = quality_state_counts.excluded_window_count
+    shock_transient_window_count = unique_quality_reason_window_count(points, "shock_transient")
+    sensor_clipping_window_count = unique_quality_reason_window_count(points, "sensor_clipping")
+    sensor_mounting_artifact_window_count = unique_quality_reason_window_count(
+        points,
+        "mounting_artifact",
     )
     matched_mounting_artifact_window_count = sum(
         1 for point in matched_points if "mounting_artifact" in point.window_quality_reasons
     )
     sensor_timing_integrity_window_count = sum(
-        1 for point in points if _has_timing_quality_reason(point)
+        1 for point in points if has_timing_quality_reason(point)
     )
     matched_timing_integrity_window_count = sum(
-        1 for point in matched_points if _has_timing_quality_reason(point)
+        1 for point in matched_points if has_timing_quality_reason(point)
     )
     speed_context_limited_window_count = sum(
-        1 for point in points if _has_speed_context_quality_reason(point)
+        1 for point in points if has_speed_context_quality_reason(point)
     )
     matched_speed_context_limited_window_count = sum(
-        1 for point in matched_points if _has_speed_context_quality_reason(point)
+        1 for point in matched_points if has_speed_context_quality_reason(point)
     )
-    support_intervals = _support_intervals(
-        matched_points=matched_points,
+    support_interval_summary = build_support_intervals(
+        eligible_windows=tuple(point.window_index for point in matched_points),
+        matched_points_by_window={point.window_index: point for point in matched_points},
         context_by_window=context_by_window,
+        context_rank_mode="count",
     )
-    phase_support = _phase_support(
-        eligible_points=eligible_points,
+    support_intervals = support_interval_summary.intervals
+    phase_support = build_phase_support(
+        eligible_windows=tuple(point.window_index for point in eligible_points),
+        matched_windows=(point.window_index for point in matched_points),
         context_by_window=context_by_window,
     )
     drift_score = _drift_score(
@@ -289,12 +283,12 @@ def _summarize_hypothesis_trace(
             if point.strongest_location
         )
     )
-    dominant_phase = _dominant_context_value(
+    dominant_phase = dominant_context_value(
         points=matched_points,
         context_by_window=context_by_window,
         attribute_name="phase",
     )
-    dominant_speed_band = _dominant_context_value(
+    dominant_speed_band = dominant_context_value(
         points=matched_points,
         context_by_window=context_by_window,
         attribute_name="speed_band",
@@ -343,7 +337,7 @@ def _summarize_hypothesis_trace(
         harmonic_summaries=(harmonic_summary,),
         stable_frequency_min_hz=stable_frequency_min_hz,
         stable_frequency_max_hz=stable_frequency_max_hz,
-        exemplar_interval_index=_exemplar_interval_index(support_intervals),
+        exemplar_interval_index=support_interval_summary.exemplar_interval_index,
         dominant_phase=dominant_phase,
         dominant_speed_band=dominant_speed_band,
         strongest_location=strongest_location,
@@ -435,14 +429,6 @@ def _speed_context_adjusted_lock_score(
     return min(lock_score, 0.75)
 
 
-def _has_timing_quality_reason(point: OrderTracePoint) -> bool:
-    return any(reason in _TIMING_QUALITY_REASONS for reason in point.window_quality_reasons)
-
-
-def _has_speed_context_quality_reason(point: OrderTracePoint) -> bool:
-    return any(reason in _SPEED_CONTEXT_QUALITY_REASONS for reason in point.window_quality_reasons)
-
-
 def _relative_error_score(*, mean_relative_error: float | None, path_compliance: float) -> float:
     if mean_relative_error is None:
         return 0.0
@@ -469,144 +455,6 @@ def _longest_contiguous_match_run(points: Sequence[OrderTracePoint]) -> int:
         previous_window_index = point.window_index
         longest = max(longest, current)
     return longest
-
-
-def _support_intervals(
-    *,
-    matched_points: Sequence[OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-) -> tuple[OrderTraceSupportInterval, ...]:
-    if not matched_points:
-        return ()
-    sorted_points = sorted(matched_points, key=lambda point: point.window_index)
-    grouped_points: list[list[OrderTracePoint]] = []
-    current_group: list[OrderTracePoint] = []
-    previous_window_index: int | None = None
-    for point in sorted_points:
-        if previous_window_index is None or point.window_index == previous_window_index + 1:
-            current_group.append(point)
-        else:
-            grouped_points.append(current_group)
-            current_group = [point]
-        previous_window_index = point.window_index
-    if current_group:
-        grouped_points.append(current_group)
-
-    return tuple(
-        OrderTraceSupportInterval(
-            interval_index=index,
-            start_window_index=group[0].window_index,
-            end_window_index=group[-1].window_index,
-            matched_window_count=len(group),
-            support_ratio=_ratio(
-                len(group),
-                group[-1].window_index - group[0].window_index + 1,
-            ),
-            phase=_dominant_context_for_points(
-                points=group,
-                context_by_window=context_by_window,
-                attribute_name="phase",
-            ),
-            load_state=_dominant_context_for_points(
-                points=group,
-                context_by_window=context_by_window,
-                attribute_name="load_state",
-            ),
-            speed_band=_dominant_context_for_points(
-                points=group,
-                context_by_window=context_by_window,
-                attribute_name="speed_band",
-            ),
-            mean_relative_error=_mean(
-                point.relative_error for point in group if point.relative_error is not None
-            ),
-        )
-        for index, group in enumerate(grouped_points)
-    )
-
-
-def _phase_support(
-    *,
-    eligible_points: Sequence[OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-) -> tuple[OrderTracePhaseSupport, ...]:
-    points_by_phase: dict[str, list[OrderTracePoint]] = {}
-    for point in eligible_points:
-        label = context_by_window.get(point.window_index)
-        if label is None:
-            continue
-        points_by_phase.setdefault(label.phase.value, []).append(point)
-    return tuple(
-        OrderTracePhaseSupport(
-            phase=phase,
-            eligible_window_count=len(points),
-            matched_window_count=sum(1 for point in points if point.matched),
-            support_ratio=_ratio(
-                sum(1 for point in points if point.matched),
-                len(points),
-            ),
-        )
-        for phase, points in sorted(points_by_phase.items())
-    )
-
-
-def _dominant_context_for_points(
-    *,
-    points: Sequence[OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-    attribute_name: str,
-) -> str | None:
-    counts: dict[str, int] = {}
-    for point in points:
-        label = context_by_window.get(point.window_index)
-        if label is None:
-            continue
-        raw_value = getattr(label, attribute_name)
-        value = raw_value.value if hasattr(raw_value, "value") else raw_value
-        if not isinstance(value, str) or not value:
-            continue
-        counts[value] = counts.get(value, 0) + 1
-    if not counts:
-        return None
-    return max(counts.items(), key=lambda item: (item[1], item[0]))[0]
-
-
-def _exemplar_interval_index(
-    intervals: Sequence[OrderTraceSupportInterval],
-) -> int | None:
-    if not intervals:
-        return None
-    exemplar = max(
-        intervals,
-        key=lambda interval: (
-            interval.matched_window_count,
-            interval.support_ratio,
-            -(interval.mean_relative_error or 0.0),
-            -interval.interval_index,
-        ),
-    )
-    return exemplar.interval_index
-
-
-def _dominant_context_value(
-    *,
-    points: Sequence[OrderTracePoint],
-    context_by_window: Mapping[int, WholeRunContextWindowLabel],
-    attribute_name: str,
-) -> str | None:
-    ranked_values: list[tuple[str, float]] = []
-    for point in points:
-        label = context_by_window.get(point.window_index)
-        if label is None:
-            continue
-        raw_value = getattr(label, attribute_name)
-        value = raw_value.value if hasattr(raw_value, "value") else raw_value
-        if not isinstance(value, str) or not value:
-            continue
-        ranked_values.append(
-            (value, point.peak_intensity_db if point.peak_intensity_db is not None else 0.0)
-        )
-    return _dominant_value(values=ranked_values)
 
 
 def _dominant_value(*, values: Iterable[tuple[str, float]]) -> str | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_support_summary.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_support_summary.py
@@ -1,0 +1,349 @@
+"""Shared compact support-summary helpers for whole-run diagnostics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from vibesensor.shared.types.whole_run_analysis import WholeRunContextWindowLabel
+from vibesensor.use_cases.diagnostics._ranking_utils import dominant_weighted_value
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _mean_or_none as _mean,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _ratio_or_zero as _ratio,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
+    OrderTracePhaseSupport,
+    OrderTraceSupportInterval,
+)
+
+TIMING_QUALITY_REASONS = frozenset(
+    {"timing_gap", "late_packet_loss", "server_queue_drop", "sensor_reset"}
+)
+SPEED_CONTEXT_QUALITY_REASONS = frozenset(
+    {
+        "speed_unavailable",
+        "speed_low",
+        "speed_stale",
+        "speed_unstable",
+        "speed_assumed",
+    }
+)
+
+type ContextRankMode = Literal["count", "weighted"]
+
+
+class WholeRunSupportPoint(Protocol):
+    @property
+    def window_index(self) -> int: ...
+
+    @property
+    def matched(self) -> bool: ...
+
+    @property
+    def relative_error(self) -> float | None: ...
+
+    @property
+    def peak_intensity_db(self) -> float | None: ...
+
+    @property
+    def window_quality_score(self) -> float | None: ...
+
+    @property
+    def window_quality_state(self) -> str | None: ...
+
+    @property
+    def window_quality_reasons(self) -> tuple[str, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WindowQualityStateCounts:
+    usable_window_count: int
+    limited_window_count: int
+    excluded_window_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class SupportIntervalSummary:
+    intervals: tuple[OrderTraceSupportInterval, ...]
+    exemplar_interval_index: int | None
+
+
+def mean_window_quality_score(points: Iterable[WholeRunSupportPoint]) -> float | None:
+    return _mean(
+        point.window_quality_score for point in points if point.window_quality_score is not None
+    )
+
+
+def window_quality_state_counts(
+    points: Iterable[WholeRunSupportPoint],
+    *,
+    excluded_window_count: int | None = None,
+) -> WindowQualityStateCounts:
+    usable_window_count = 0
+    limited_window_count = 0
+    computed_excluded_window_count = 0
+    for point in points:
+        if point.window_quality_state == "usable":
+            usable_window_count += 1
+        elif point.window_quality_state == "limited":
+            limited_window_count += 1
+        elif point.window_quality_state == "excluded":
+            computed_excluded_window_count += 1
+    return WindowQualityStateCounts(
+        usable_window_count=usable_window_count,
+        limited_window_count=limited_window_count,
+        excluded_window_count=(
+            computed_excluded_window_count
+            if excluded_window_count is None
+            else excluded_window_count
+        ),
+    )
+
+
+def unique_quality_reason_window_count(
+    points: Iterable[WholeRunSupportPoint],
+    reason: str,
+) -> int:
+    return len({point.window_index for point in points if reason in point.window_quality_reasons})
+
+
+def has_timing_quality_reason(point: WholeRunSupportPoint) -> bool:
+    return has_any_quality_reason(point, TIMING_QUALITY_REASONS)
+
+
+def has_speed_context_quality_reason(point: WholeRunSupportPoint) -> bool:
+    return has_any_quality_reason(point, SPEED_CONTEXT_QUALITY_REASONS)
+
+
+def has_any_quality_reason(
+    point: WholeRunSupportPoint,
+    reasons: frozenset[str],
+) -> bool:
+    return any(reason in reasons for reason in point.window_quality_reasons)
+
+
+def build_support_intervals(
+    *,
+    eligible_windows: Sequence[int],
+    matched_points_by_window: Mapping[int, WholeRunSupportPoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+    context_rank_mode: ContextRankMode,
+    include_peak_intensity_in_rank: bool = False,
+    missing_mean_error_rank: float = 0.0,
+) -> SupportIntervalSummary:
+    intervals: list[OrderTraceSupportInterval] = []
+    interval_ranks: list[tuple[tuple[float, ...], int]] = []
+    current_start: int | None = None
+    current_windows: list[int] = []
+    matched_points: list[WholeRunSupportPoint] = []
+    previous_window: int | None = None
+    for window_index in sorted(eligible_windows):
+        if previous_window is None or window_index == previous_window + 1:
+            if current_start is None:
+                current_start = window_index
+            current_windows.append(window_index)
+            point = matched_points_by_window.get(window_index)
+            if point is not None:
+                matched_points.append(point)
+        else:
+            _append_interval(
+                intervals=intervals,
+                interval_ranks=interval_ranks,
+                interval_index=len(intervals),
+                start_window=current_start,
+                eligible_windows=current_windows,
+                matched_points=matched_points,
+                context_by_window=context_by_window,
+                context_rank_mode=context_rank_mode,
+                include_peak_intensity_in_rank=include_peak_intensity_in_rank,
+                missing_mean_error_rank=missing_mean_error_rank,
+            )
+            current_start = window_index
+            current_windows = [window_index]
+            matched_points = []
+            point = matched_points_by_window.get(window_index)
+            if point is not None:
+                matched_points.append(point)
+        previous_window = window_index
+    _append_interval(
+        intervals=intervals,
+        interval_ranks=interval_ranks,
+        interval_index=len(intervals),
+        start_window=current_start,
+        eligible_windows=current_windows,
+        matched_points=matched_points,
+        context_by_window=context_by_window,
+        context_rank_mode=context_rank_mode,
+        include_peak_intensity_in_rank=include_peak_intensity_in_rank,
+        missing_mean_error_rank=missing_mean_error_rank,
+    )
+    return SupportIntervalSummary(
+        intervals=tuple(intervals),
+        exemplar_interval_index=max(interval_ranks)[1] if interval_ranks else None,
+    )
+
+
+def build_phase_support(
+    *,
+    eligible_windows: Sequence[int],
+    matched_windows: Iterable[int],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+) -> tuple[OrderTracePhaseSupport, ...]:
+    matched_window_set = set(matched_windows)
+    eligible_by_phase: dict[str, int] = defaultdict(int)
+    matched_by_phase: dict[str, int] = defaultdict(int)
+    for window_index in sorted(eligible_windows):
+        label = context_by_window.get(window_index)
+        if label is None:
+            continue
+        phase = label.phase.value
+        eligible_by_phase[phase] += 1
+        if window_index in matched_window_set:
+            matched_by_phase[phase] += 1
+    return tuple(
+        OrderTracePhaseSupport(
+            phase=phase,
+            eligible_window_count=eligible_by_phase[phase],
+            matched_window_count=matched_by_phase.get(phase, 0),
+            support_ratio=_ratio(matched_by_phase.get(phase, 0), eligible_by_phase[phase]),
+        )
+        for phase in sorted(eligible_by_phase)
+    )
+
+
+def dominant_context_value(
+    *,
+    points: Sequence[WholeRunSupportPoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+    attribute_name: str,
+) -> str | None:
+    ranked_values: list[tuple[str, float]] = []
+    for point in points:
+        value = _context_value(
+            point=point,
+            context_by_window=context_by_window,
+            attribute_name=attribute_name,
+        )
+        if value is None:
+            continue
+        ranked_values.append(
+            (value, point.peak_intensity_db if point.peak_intensity_db is not None else 0.0)
+        )
+    return dominant_weighted_value(values=ranked_values)
+
+
+def _append_interval(
+    *,
+    intervals: list[OrderTraceSupportInterval],
+    interval_ranks: list[tuple[tuple[float, ...], int]],
+    interval_index: int,
+    start_window: int | None,
+    eligible_windows: Sequence[int],
+    matched_points: Sequence[WholeRunSupportPoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+    context_rank_mode: ContextRankMode,
+    include_peak_intensity_in_rank: bool,
+    missing_mean_error_rank: float,
+) -> None:
+    if start_window is None or not eligible_windows or not matched_points:
+        return
+    end_window = eligible_windows[-1]
+    support_ratio = _ratio(len(matched_points), len(eligible_windows))
+    mean_relative_error = _mean(
+        point.relative_error for point in matched_points if point.relative_error is not None
+    )
+    interval = OrderTraceSupportInterval(
+        interval_index=interval_index,
+        start_window_index=start_window,
+        end_window_index=end_window,
+        matched_window_count=len(matched_points),
+        support_ratio=support_ratio,
+        phase=_interval_context_value(
+            points=matched_points,
+            context_by_window=context_by_window,
+            attribute_name="phase",
+            rank_mode=context_rank_mode,
+        ),
+        load_state=_interval_context_value(
+            points=matched_points,
+            context_by_window=context_by_window,
+            attribute_name="load_state",
+            rank_mode=context_rank_mode,
+        ),
+        speed_band=_interval_context_value(
+            points=matched_points,
+            context_by_window=context_by_window,
+            attribute_name="speed_band",
+            rank_mode=context_rank_mode,
+        ),
+        mean_relative_error=mean_relative_error,
+    )
+    intervals.append(interval)
+    rank: tuple[float, ...]
+    if include_peak_intensity_in_rank:
+        rank = (
+            float(len(matched_points)),
+            support_ratio,
+            _max_peak_intensity(matched_points),
+            -(mean_relative_error or missing_mean_error_rank),
+            float(-interval_index),
+        )
+    else:
+        rank = (
+            float(len(matched_points)),
+            support_ratio,
+            -(mean_relative_error or missing_mean_error_rank),
+            float(-interval_index),
+        )
+    interval_ranks.append((rank, interval_index))
+
+
+def _interval_context_value(
+    *,
+    points: Sequence[WholeRunSupportPoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+    attribute_name: str,
+    rank_mode: ContextRankMode,
+) -> str | None:
+    if rank_mode == "weighted":
+        return dominant_context_value(
+            points=points,
+            context_by_window=context_by_window,
+            attribute_name=attribute_name,
+        )
+    counts: dict[str, int] = {}
+    for point in points:
+        value = _context_value(
+            point=point,
+            context_by_window=context_by_window,
+            attribute_name=attribute_name,
+        )
+        if value is None:
+            continue
+        counts[value] = counts.get(value, 0) + 1
+    if not counts:
+        return None
+    return max(counts.items(), key=lambda item: (item[1], item[0]))[0]
+
+
+def _context_value(
+    *,
+    point: WholeRunSupportPoint,
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+    attribute_name: str,
+) -> str | None:
+    label = context_by_window.get(point.window_index)
+    if label is None:
+        return None
+    raw_value = getattr(label, attribute_name)
+    value = raw_value.value if hasattr(raw_value, "value") else raw_value
+    return value if isinstance(value, str) and value else None
+
+
+def _max_peak_intensity(points: Sequence[WholeRunSupportPoint]) -> float:
+    values = [point.peak_intensity_db for point in points if point.peak_intensity_db is not None]
+    return max(values) if values else 0.0

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -77,8 +77,10 @@ below.
     `spectral-summary:*` sidecars and context labels.
   - `orders/whole_run_scoring.py` collapses dense traces into compact lock and
     stability summaries.
+  - `whole_run_support_summary.py` owns shared support intervals, phase support,
+    dominant context, and quality-reason rollup helpers.
   - `orders/whole_run_family_summaries.py` rolls scored harmonic traces up to
-    family-level support intervals and phase summaries.
+    family-level summaries.
   - `whole_run_spatial_coherence.py` builds candidate-level spatial evidence
     windows and compact spatial summaries.
 - `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py`
@@ -271,9 +273,8 @@ whole-run traces stay aligned with the current live/sample order model.
 The current scoring owner is
 `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py`. It
 derives deterministic per-candidate `OrderTraceSummary` rows from the dense
-trace points, keeps `support_intervals` and `phase_support` empty until the
-later summarization issue lands, and already projects the compact stability
-fields that later ranking and persistence work need:
+trace points and projects compact stability fields that ranking and persistence
+need:
 
 - `reference_coverage_ratio`
 - `contiguous_support_ratio`
@@ -290,6 +291,12 @@ It consumes the dense trace points plus the per-candidate scored summaries from
 - per-phase `phase_support`
 - `stable_frequency_min_hz` / `stable_frequency_max_hz`
 - `exemplar_interval_index`
+
+Generic support interval, phase support, dominant context, and quality-reason
+rollup primitives live in
+`apps/server/vibesensor/use_cases/diagnostics/whole_run_support_summary.py` so
+candidate and family summaries share one summarization path while order-specific
+lock scoring stays in `orders/whole_run_scoring.py`.
 
 Those family summaries now feed a ranked persisted
 `whole_run_order_summaries` payload in `PersistedAnalysis`, while the dense


### PR DESCRIPTION
Fixes #3778

## What changed
- Added `whole_run_support_summary.py` for shared support intervals, phase support, dominant context, and window-quality rollups.
- Rewired harmonic order scoring and family summaries to use the shared primitives.
- Added focused helper tests and updated the whole-run design owner map.

## Why
- The same compact summary logic lived in separate order-scoring and family-summary paths.
- Generic summarization now has one owner; drivetrain/order scoring stays in `orders/whole_run_scoring.py`.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_support_summary.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make plan-validation`

## Risks / tradeoffs
- No threshold tuning.
- No DTO shape changes intended.
- Helper still returns order summary DTO rows because current consumers are order summaries.