### PR TITLE
Refactor report analysis metadata boundary

### DIFF
--- a/apps/server/tests/shared/boundaries/test_report_analysis_metadata.py
+++ b/apps/server/tests/shared/boundaries/test_report_analysis_metadata.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.reporting.analysis_metadata import (
+    REPORT_ANALYSIS_METADATA_STABLE_KEYS,
+    report_analysis_metadata_from_payload,
+)
+
+
+def test_report_analysis_metadata_decodes_stable_persisted_keys() -> None:
+    metadata = report_analysis_metadata_from_payload(
+        {
+            "analysis_metadata": {
+                "raw_backed_sample_count": "12",
+                "raw_capture_available": False,
+                "raw_capture_finalize_status": "timeout",
+                "raw_capture_mode": "partial_raw_backed",
+                "whole_run_context_available": True,
+                "whole_run_context_window_count": 8,
+                "whole_run_context_missing_speed_window_count": 2,
+                "whole_run_order_family_summaries_available": True,
+                "whole_run_order_family_summary_count": 3,
+            }
+        }
+    )
+
+    assert metadata.present is True
+    assert metadata.raw_backed_sample_count == 12
+    assert metadata.raw_capture_available is False
+    assert metadata.raw_capture_finalize_status == "timeout"
+    assert metadata.data_basis == "partial_raw_backed"
+    assert metadata.whole_run_context_available is True
+    assert metadata.whole_run_context.window_count == 8
+    assert metadata.whole_run_context.missing_speed_window_count == 2
+    assert metadata.whole_run_order_family_summary_count == 3
+
+
+def test_report_analysis_metadata_documents_external_stable_keys() -> None:
+    assert "raw_capture_mode" in REPORT_ANALYSIS_METADATA_STABLE_KEYS
+    assert "raw_backed_sample_count" in REPORT_ANALYSIS_METADATA_STABLE_KEYS
+    assert "whole_run_context_available" in REPORT_ANALYSIS_METADATA_STABLE_KEYS
+    assert "whole_run_order_family_summaries_available" in REPORT_ANALYSIS_METADATA_STABLE_KEYS

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -321,6 +321,24 @@ def test_prepare_report_facts_projects_whole_run_context_facts_from_persisted_an
     assert [warning.code for warning in facts.decision.warnings] == ["whole_run_context_incomplete"]
 
 
+def test_prepare_report_facts_projects_typed_analysis_metadata_into_evidence() -> None:
+    summary = _summary()
+    summary["analysis_metadata"] = {
+        "raw_backed_sample_count": 9,
+        "raw_capture_mode": "partial_raw_backed",
+        "whole_run_artifacts_available": True,
+    }
+
+    facts = _prepare_facts(summary)
+
+    assert facts.evidence.data_basis == "partial_raw_backed"
+    assert facts.evidence.raw_backed_sample_count == 9
+    assert facts.fallback_reasons == ("whole_run_evidence_incomplete",)
+    assert facts.whole_run_diagnosis_summaries[0].fallback_reason == (
+        "whole_run_evidence_incomplete"
+    )
+
+
 def test_build_report_document_builds_workflow_document_sections() -> None:
     summary = _summary()
     document = _prepare_document(summary)

--- a/apps/server/vibesensor/adapters/history/projection.py
+++ b/apps/server/vibesensor/adapters/history/projection.py
@@ -10,6 +10,9 @@ from vibesensor.shared.boundaries.analysis_payloads import (
     project_analysis_summary,
     project_persisted_analysis,
 )
+from vibesensor.shared.boundaries.reporting.analysis_metadata import (
+    report_analysis_metadata_from_mapping,
+)
 from vibesensor.shared.boundaries.reporting.fallback_reasons import (
     REPORT_FALLBACK_REASONS_METADATA_KEY,
     dedupe_report_fallback_reasons,
@@ -147,7 +150,7 @@ def _apply_projected_analysis_fallback_reasons(payload: JsonObject) -> None:
         return
     normalized = report_summary_from_mapping(payload)
     reasons = derive_report_fallback_reasons(
-        analysis_metadata,
+        report_analysis_metadata_from_mapping(analysis_metadata),
         has_whole_run_context_intervals=bool(normalized.whole_run_context_intervals),
         has_whole_run_order_summaries=bool(normalized.whole_run_order_summaries),
         has_whole_run_spatial_summaries=bool(normalized.whole_run_spatial_summaries),
@@ -178,7 +181,7 @@ def _history_run_fallback_reasons(run: StoredHistoryRun) -> tuple[str, ...]:
             normalized = report_summary_from_mapping(payload)
             reasons.extend(
                 derive_report_fallback_reasons(
-                    analysis_metadata,
+                    report_analysis_metadata_from_mapping(analysis_metadata),
                     has_whole_run_context_intervals=bool(normalized.whole_run_context_intervals),
                     has_whole_run_order_summaries=bool(normalized.whole_run_order_summaries),
                     has_whole_run_spatial_summaries=bool(normalized.whole_run_spatial_summaries),

--- a/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
@@ -2,6 +2,11 @@
 
 # Summary normalization and projectable-payload gates.
 # Fact projections and prepared fact groups.
+from .analysis_metadata import (
+    REPORT_ANALYSIS_METADATA_STABLE_KEYS,
+    ReportAnalysisMetadata,
+    report_analysis_metadata_from_mapping,
+)
 from .confidence_facts import ReportConfidenceFacts, build_report_confidence_facts
 from .decision_facts import ReportDecisionFacts, build_report_decision_facts
 from .facts import (
@@ -53,8 +58,10 @@ __all__ = [
     "PreparedReportFindings",
     "PreparedReportInput",
     "PrimaryReportFacts",
+    "REPORT_ANALYSIS_METADATA_STABLE_KEYS",
     "REPORT_FALLBACK_REASONS_METADATA_KEY",
     "REPORT_FALLBACK_REASON_VALUES",
+    "ReportAnalysisMetadata",
     "ReportConfidenceFacts",
     "ReportContextFacts",
     "ReportCoverageSummary",
@@ -73,6 +80,7 @@ __all__ = [
     "prepare_persisted_report_input",
     "prepare_report_facts",
     "prepare_report_input",
+    "report_analysis_metadata_from_mapping",
     "report_summary_from_mapping",
     "require_projectable_report_payload",
     "resolve_primary_report_facts",

--- a/apps/server/vibesensor/shared/boundaries/reporting/analysis_metadata.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/analysis_metadata.py
@@ -1,0 +1,242 @@
+"""Typed report-facing view of persisted analysis metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+
+__all__ = [
+    "REPORT_ANALYSIS_METADATA_STABLE_KEYS",
+    "ReportAnalysisMetadata",
+    "ReportWholeRunContextMetadata",
+    "report_analysis_metadata_from_mapping",
+    "report_analysis_metadata_from_payload",
+]
+
+REPORT_ANALYSIS_METADATA_STABLE_KEYS = frozenset(
+    {
+        "raw_backed_sample_count",
+        "raw_capture_available",
+        "raw_capture_finalize_status",
+        "raw_capture_loss_policy_gate_whole_run",
+        "raw_capture_loss_policy_severity",
+        "raw_capture_mode",
+        "whole_run_artifacts_available",
+        "whole_run_context_assumed_speed_window_count",
+        "whole_run_context_available",
+        "whole_run_context_full_window_count",
+        "whole_run_context_interval_count",
+        "whole_run_context_low_speed_window_count",
+        "whole_run_context_missing_rpm_window_count",
+        "whole_run_context_missing_speed_window_count",
+        "whole_run_context_missing_window_count",
+        "whole_run_context_partial_window_count",
+        "whole_run_context_stale_rpm_window_count",
+        "whole_run_context_stale_speed_window_count",
+        "whole_run_context_unstable_speed_window_count",
+        "whole_run_context_window_count",
+        "whole_run_diagnosis_summaries_available",
+        "whole_run_diagnosis_summary_count",
+        "whole_run_order_family_summaries_available",
+        "whole_run_order_family_summary_count",
+        "whole_run_spatial_coherence_available",
+        "whole_run_spatial_coherence_summary_count",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReportWholeRunContextMetadata:
+    """Typed counts for stable whole-run context metadata keys."""
+
+    window_count: int | None
+    interval_count: int | None
+    full_window_count: int | None
+    partial_window_count: int | None
+    missing_window_count: int | None
+    missing_speed_window_count: int | None
+    missing_rpm_window_count: int | None
+    stale_speed_window_count: int | None
+    stale_rpm_window_count: int | None
+    low_speed_window_count: int | None
+    unstable_speed_window_count: int | None
+    assumed_speed_window_count: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReportAnalysisMetadata:
+    """Typed report boundary object for stable persisted analysis metadata keys."""
+
+    present: bool
+    raw_backed_sample_count: int
+    raw_capture_available: bool | None
+    raw_capture_finalize_status: str | None
+    raw_capture_loss_policy_severity: str | None
+    raw_capture_loss_policy_gate_whole_run: bool
+    raw_capture_mode: str | None
+    whole_run_artifacts_available: bool
+    whole_run_context_available: bool
+    whole_run_order_family_summaries_available: bool
+    whole_run_spatial_coherence_available: bool
+    whole_run_diagnosis_summaries_available: bool
+    whole_run_diagnosis_summary_count: int
+    whole_run_order_family_summary_count: int
+    whole_run_spatial_coherence_summary_count: int
+    whole_run_context: ReportWholeRunContextMetadata
+
+    @property
+    def data_basis(self) -> str:
+        if self.raw_capture_mode in {"raw_backed", "partial_raw_backed", "summary_only"}:
+            return self.raw_capture_mode
+        return "raw_backed" if self.raw_backed_sample_count > 0 else "summary_only"
+
+    @property
+    def has_fatal_raw_capture_loss(self) -> bool:
+        return (
+            self.raw_capture_loss_policy_severity == "fatal"
+            or self.raw_capture_loss_policy_gate_whole_run
+        )
+
+    @property
+    def is_summary_only_capture(self) -> bool:
+        return self.raw_capture_mode == "summary_only" or (
+            self.raw_capture_mode is None and self.raw_backed_sample_count <= 0
+        )
+
+    @property
+    def is_summary_only_context_fallback(self) -> bool:
+        if self.raw_capture_mode == "summary_only":
+            return True
+        if self.raw_capture_mode == "raw_backed":
+            return False
+        return self.raw_backed_sample_count <= 0
+
+    def has_partial_whole_run_inputs(
+        self,
+        *,
+        has_whole_run_context_intervals: bool,
+        has_whole_run_order_summaries: bool,
+        has_whole_run_spatial_summaries: bool,
+    ) -> bool:
+        return bool(
+            has_whole_run_context_intervals
+            or has_whole_run_order_summaries
+            or has_whole_run_spatial_summaries
+            or self.whole_run_artifacts_available
+            or self.whole_run_context_available
+            or self.whole_run_order_family_summaries_available
+            or self.whole_run_spatial_coherence_available
+        )
+
+
+def report_analysis_metadata_from_payload(
+    payload: Mapping[str, object],
+) -> ReportAnalysisMetadata:
+    raw_metadata = payload.get("analysis_metadata")
+    raw = raw_metadata if isinstance(raw_metadata, Mapping) else None
+    return report_analysis_metadata_from_mapping(raw)
+
+
+def report_analysis_metadata_from_mapping(
+    raw: Mapping[str, object] | None,
+) -> ReportAnalysisMetadata:
+    return ReportAnalysisMetadata(
+        present=raw is not None,
+        raw_backed_sample_count=_count(raw, "raw_backed_sample_count"),
+        raw_capture_available=_optional_bool(raw, "raw_capture_available"),
+        raw_capture_finalize_status=_text(raw, "raw_capture_finalize_status"),
+        raw_capture_loss_policy_severity=_text(raw, "raw_capture_loss_policy_severity"),
+        raw_capture_loss_policy_gate_whole_run=_flag(
+            raw,
+            "raw_capture_loss_policy_gate_whole_run",
+        ),
+        raw_capture_mode=_text(raw, "raw_capture_mode"),
+        whole_run_artifacts_available=_flag(raw, "whole_run_artifacts_available"),
+        whole_run_context_available=_flag(raw, "whole_run_context_available"),
+        whole_run_order_family_summaries_available=_flag(
+            raw,
+            "whole_run_order_family_summaries_available",
+        ),
+        whole_run_spatial_coherence_available=_flag(
+            raw,
+            "whole_run_spatial_coherence_available",
+        ),
+        whole_run_diagnosis_summaries_available=_flag(
+            raw,
+            "whole_run_diagnosis_summaries_available",
+        ),
+        whole_run_diagnosis_summary_count=_count(raw, "whole_run_diagnosis_summary_count"),
+        whole_run_order_family_summary_count=_count(
+            raw,
+            "whole_run_order_family_summary_count",
+        ),
+        whole_run_spatial_coherence_summary_count=_count(
+            raw,
+            "whole_run_spatial_coherence_summary_count",
+        ),
+        whole_run_context=ReportWholeRunContextMetadata(
+            window_count=_optional_count(raw, "whole_run_context_window_count"),
+            interval_count=_optional_count(raw, "whole_run_context_interval_count"),
+            full_window_count=_optional_count(raw, "whole_run_context_full_window_count"),
+            partial_window_count=_optional_count(
+                raw,
+                "whole_run_context_partial_window_count",
+            ),
+            missing_window_count=_optional_count(raw, "whole_run_context_missing_window_count"),
+            missing_speed_window_count=_optional_count(
+                raw,
+                "whole_run_context_missing_speed_window_count",
+            ),
+            missing_rpm_window_count=_optional_count(
+                raw,
+                "whole_run_context_missing_rpm_window_count",
+            ),
+            stale_speed_window_count=_optional_count(
+                raw,
+                "whole_run_context_stale_speed_window_count",
+            ),
+            stale_rpm_window_count=_optional_count(
+                raw,
+                "whole_run_context_stale_rpm_window_count",
+            ),
+            low_speed_window_count=_optional_count(
+                raw,
+                "whole_run_context_low_speed_window_count",
+            ),
+            unstable_speed_window_count=_optional_count(
+                raw,
+                "whole_run_context_unstable_speed_window_count",
+            ),
+            assumed_speed_window_count=_optional_count(
+                raw,
+                "whole_run_context_assumed_speed_window_count",
+            ),
+        ),
+    )
+
+
+def _text(raw: Mapping[str, object] | None, key: str) -> str | None:
+    return text_or_none(raw.get(key)) if raw is not None else None
+
+
+def _count(raw: Mapping[str, object] | None, key: str) -> int:
+    return coerce_count(raw.get(key)) if raw is not None else 0
+
+
+def _optional_count(raw: Mapping[str, object] | None, key: str) -> int | None:
+    if raw is None or key not in raw:
+        return None
+    return coerce_count(raw.get(key))
+
+
+def _flag(raw: Mapping[str, object] | None, key: str) -> bool:
+    return bool(raw is not None and raw.get(key))
+
+
+def _optional_bool(raw: Mapping[str, object] | None, key: str) -> bool | None:
+    if raw is None:
+        return None
+    value = raw.get(key)
+    return value if isinstance(value, bool) else None

--- a/apps/server/vibesensor/shared/boundaries/reporting/evidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/evidence_facts.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Mapping
 from dataclasses import dataclass
 
-from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+from vibesensor.shared.boundaries.reporting.analysis_metadata import ReportAnalysisMetadata
 from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.shared.boundaries.reporting.summary import NormalizedReportSummary
@@ -34,7 +33,7 @@ class ReportEvidenceFacts:
 
 
 def build_report_evidence_facts(
-    payload: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     summary: NormalizedReportSummary,
     primary_candidate: PrimaryReportFacts,
@@ -42,10 +41,8 @@ def build_report_evidence_facts(
 ) -> ReportEvidenceFacts:
     """Build prepared evidence facts from persisted analysis plus domain finding data."""
 
-    metadata = payload.get("analysis_metadata")
-    analysis_metadata = metadata if isinstance(metadata, Mapping) else {}
-    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
-    data_basis = _resolve_data_basis(analysis_metadata, raw_backed_sample_count)
+    raw_backed_sample_count = analysis_metadata.raw_backed_sample_count
+    data_basis = analysis_metadata.data_basis
     supporting_window_count = primary_candidate.matched_evidence_window_count
     duration_s = _supporting_duration_s(
         supporting_window_count=supporting_window_count,
@@ -68,16 +65,6 @@ def build_report_evidence_facts(
         ),
         has_reference_gap=primary_candidate.has_reference_gaps,
     )
-
-
-def _resolve_data_basis(
-    analysis_metadata: Mapping[str, object],
-    raw_backed_sample_count: int,
-) -> str:
-    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
-    if raw_capture_mode in {"raw_backed", "partial_raw_backed", "summary_only"}:
-        return raw_capture_mode
-    return "raw_backed" if raw_backed_sample_count > 0 else "summary_only"
 
 
 def _supporting_duration_s(

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import DIAGNOSIS_AMBIGUOUS_SCORE_GAP
-from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.boundaries.reporting.analysis_metadata import (
+    ReportAnalysisMetadata,
+    report_analysis_metadata_from_payload,
+)
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.run_context_warning import (
     WARNING_CODE_WHOLE_RUN_CONTEXT_INCOMPLETE,
@@ -204,8 +208,15 @@ def prepare_report_facts(
     origin = resolve_report_origin(test_run)
     origin_location = normalize_origin_location(origin)
     config_snap = test_run.capture.setup.configuration_snapshot
-    fallback_reasons = _report_fallback_reasons(payload, summary=summary)
-    context_facts = _build_report_context_facts(payload, summary=summary)
+    analysis_metadata = report_analysis_metadata_from_payload(payload)
+    fallback_reasons = _report_fallback_reasons(
+        analysis_metadata,
+        summary=summary,
+    )
+    context_facts = _build_report_context_facts(
+        analysis_metadata,
+        summary=summary,
+    )
     sensor_facts = build_report_sensor_facts(
         test_run=test_run,
         sensor_locations_active=summary.active_sensor_locations,
@@ -220,7 +231,7 @@ def prepare_report_facts(
         warnings=warnings,
     )
     evidence_facts = build_report_evidence_facts(
-        payload,
+        analysis_metadata,
         summary=summary,
         primary_candidate=decision_facts.primary_candidate,
         decision_facts=decision_facts,
@@ -231,14 +242,13 @@ def prepare_report_facts(
         evidence_data_basis=evidence_facts.data_basis,
     )
     provisional_confidence_facts = build_report_confidence_facts(
-        has_explicit_analysis_metadata=isinstance(payload.get("analysis_metadata"), Mapping),
+        has_explicit_analysis_metadata=analysis_metadata.present,
         primary_candidate=decision_facts.primary_candidate,
         evidence_facts=evidence_facts,
         decision_facts=decision_facts,
         context_facts=context_facts,
     )
     whole_run_diagnosis_summaries = _report_whole_run_diagnosis_summaries(
-        payload,
         summary=summary,
         sensor_facts=sensor_facts,
         decision_facts=decision_facts,
@@ -246,6 +256,7 @@ def prepare_report_facts(
         confidence_facts=provisional_confidence_facts,
         context_facts=context_facts,
         fallback_reasons=fallback_reasons,
+        analysis_metadata=analysis_metadata,
     )
     confidence_facts = _report_surface_confidence_facts(
         whole_run_diagnosis_summaries,
@@ -310,12 +321,11 @@ def _tire_spec_text(tire_spec: object) -> str | None:
 
 
 def _build_report_context_facts(
-    payload: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     summary: NormalizedReportSummary,
 ) -> ReportContextFacts:
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, Mapping):
+    if not analysis_metadata.present:
         return ReportContextFacts(
             traceable=False,
             source="implicit",
@@ -334,70 +344,52 @@ def _build_report_context_facts(
             assumed_speed_window_count=0,
             warnings=(),
         )
-    whole_run_available = bool(analysis_metadata.get("whole_run_context_available")) or bool(
+    context_metadata = analysis_metadata.whole_run_context
+    whole_run_available = analysis_metadata.whole_run_context_available or bool(
         summary.whole_run_context_intervals
     )
     if whole_run_available:
         source = "whole_run"
-    elif _is_summary_only_context_fallback(analysis_metadata):
+    elif analysis_metadata.is_summary_only_context_fallback:
         source = "summary_only"
     else:
         source = "legacy"
     intervals = summary.whole_run_context_intervals if whole_run_available else ()
-    full_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_full_window_count",
+    full_window_count = _metadata_count_or_default(
+        context_metadata.full_window_count,
         default=sum(interval.full_context_window_count for interval in intervals),
     )
-    partial_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_partial_window_count",
+    partial_window_count = _metadata_count_or_default(
+        context_metadata.partial_window_count,
         default=sum(interval.partial_context_window_count for interval in intervals),
     )
-    missing_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_missing_window_count",
+    missing_window_count = _metadata_count_or_default(
+        context_metadata.missing_window_count,
         default=sum(interval.missing_context_window_count for interval in intervals),
     )
-    missing_speed_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_missing_speed_window_count",
+    missing_speed_window_count = _metadata_count_or_default(
+        context_metadata.missing_speed_window_count
     )
-    missing_rpm_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_missing_rpm_window_count",
+    missing_rpm_window_count = _metadata_count_or_default(context_metadata.missing_rpm_window_count)
+    stale_speed_window_count = _metadata_count_or_default(context_metadata.stale_speed_window_count)
+    low_speed_window_count = _metadata_count_or_default(context_metadata.low_speed_window_count)
+    unstable_speed_window_count = _metadata_count_or_default(
+        context_metadata.unstable_speed_window_count
     )
-    stale_speed_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_stale_speed_window_count",
+    assumed_speed_window_count = _metadata_count_or_default(
+        context_metadata.assumed_speed_window_count
     )
-    low_speed_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_low_speed_window_count",
-    )
-    unstable_speed_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_unstable_speed_window_count",
-    )
-    assumed_speed_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_assumed_speed_window_count",
-    )
-    stale_rpm_window_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_stale_rpm_window_count",
-    )
+    stale_rpm_window_count = _metadata_count_or_default(context_metadata.stale_rpm_window_count)
     default_window_count = (
         sum(interval.window_count for interval in intervals) if intervals else None
     )
-    window_count = _analysis_metadata_optional_count(
-        analysis_metadata,
-        "whole_run_context_window_count",
-        default=default_window_count,
+    window_count = (
+        context_metadata.window_count
+        if context_metadata.window_count is not None
+        else default_window_count
     )
-    interval_count = _analysis_metadata_count(
-        analysis_metadata,
-        "whole_run_context_interval_count",
+    interval_count = _metadata_count_or_default(
+        context_metadata.interval_count,
         default=len(intervals),
     )
     return ReportContextFacts(
@@ -433,7 +425,6 @@ def _build_report_context_facts(
 
 
 def _report_whole_run_diagnosis_summaries(
-    payload: Mapping[str, object],
     *,
     summary: NormalizedReportSummary,
     sensor_facts: ReportSensorFacts,
@@ -442,6 +433,7 @@ def _report_whole_run_diagnosis_summaries(
     confidence_facts: ReportConfidenceFacts,
     context_facts: ReportContextFacts,
     fallback_reasons: tuple[ReportFallbackReason, ...],
+    analysis_metadata: ReportAnalysisMetadata,
 ) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
     if summary.whole_run_diagnosis_summaries:
         return summary.whole_run_diagnosis_summaries
@@ -449,7 +441,7 @@ def _report_whole_run_diagnosis_summaries(
     if primary_candidate.domain_primary is None or primary_candidate.primary_source is None:
         return ()
     fallback_reason = _whole_run_diagnosis_fallback_reason(
-        payload,
+        analysis_metadata,
         summary=summary,
         fallback_reasons=fallback_reasons,
     )
@@ -519,31 +511,26 @@ def _report_whole_run_diagnosis_summaries(
 
 
 def _whole_run_diagnosis_fallback_reason(
-    payload: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     summary: NormalizedReportSummary,
     fallback_reasons: tuple[ReportFallbackReason, ...],
 ) -> str | None:
     if fallback_reasons:
         return fallback_reasons[0]
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, Mapping):
+    if not analysis_metadata.present:
         return "legacy_summary_only"
-    loss_policy_severity = text_or_none(analysis_metadata.get("raw_capture_loss_policy_severity"))
-    if loss_policy_severity == "fatal":
+    if analysis_metadata.raw_capture_loss_policy_severity == "fatal":
         return "raw_capture_loss_exceeded"
-    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
-    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
-    if raw_capture_mode == "summary_only" or raw_backed_sample_count <= 0:
+    if (
+        analysis_metadata.raw_capture_mode == "summary_only"
+        or analysis_metadata.raw_backed_sample_count <= 0
+    ):
         return "legacy_summary_only"
-    has_partial_whole_run_inputs = bool(
-        summary.whole_run_context_intervals
-        or summary.whole_run_order_summaries
-        or summary.whole_run_spatial_summaries
-        or analysis_metadata.get("whole_run_artifacts_available")
-        or analysis_metadata.get("whole_run_context_available")
-        or analysis_metadata.get("whole_run_order_family_summaries_available")
-        or analysis_metadata.get("whole_run_spatial_coherence_available")
+    has_partial_whole_run_inputs = analysis_metadata.has_partial_whole_run_inputs(
+        has_whole_run_context_intervals=bool(summary.whole_run_context_intervals),
+        has_whole_run_order_summaries=bool(summary.whole_run_order_summaries),
+        has_whole_run_spatial_summaries=bool(summary.whole_run_spatial_summaries),
     )
     if has_partial_whole_run_inputs:
         return "whole_run_evidence_incomplete"
@@ -551,7 +538,7 @@ def _whole_run_diagnosis_fallback_reason(
 
 
 def _report_fallback_reasons(
-    payload: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     summary: NormalizedReportSummary,
 ) -> tuple[ReportFallbackReason, ...]:
@@ -559,8 +546,7 @@ def _report_fallback_reasons(
     metadata = summary.metadata
     if metadata is not None:
         reasons.extend(finalization_stage_fallback_reasons(metadata.finalization_stages))
-    analysis_metadata = payload.get("analysis_metadata")
-    if isinstance(analysis_metadata, Mapping):
+    if analysis_metadata.present:
         reasons.extend(
             derive_report_fallback_reasons(
                 analysis_metadata,
@@ -673,33 +659,8 @@ def _fallback_diagnosis_is_suspicious(
     )
 
 
-def _is_summary_only_context_fallback(analysis_metadata: Mapping[str, object]) -> bool:
-    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
-    if raw_capture_mode == "summary_only":
-        return True
-    if raw_capture_mode == "raw_backed":
-        return False
-    return coerce_count(analysis_metadata.get("raw_backed_sample_count")) <= 0
-
-
-def _analysis_metadata_count(
-    analysis_metadata: Mapping[str, object],
-    key: str,
-    *,
-    default: int = 0,
-) -> int:
-    return coerce_count(analysis_metadata.get(key)) if key in analysis_metadata else default
-
-
-def _analysis_metadata_optional_count(
-    analysis_metadata: Mapping[str, object],
-    key: str,
-    *,
-    default: int | None,
-) -> int | None:
-    if key not in analysis_metadata:
-        return default
-    return coerce_count(analysis_metadata.get(key))
+def _metadata_count_or_default(value: int | None, *, default: int = 0) -> int:
+    return value if value is not None else default
 
 
 def _report_context_warnings(

--- a/apps/server/vibesensor/shared/boundaries/reporting/fallback_reasons.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/fallback_reasons.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Literal
 
-from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.boundaries.reporting.analysis_metadata import ReportAnalysisMetadata
 
 __all__ = [
     "REPORT_FALLBACK_REASONS_METADATA_KEY",
@@ -117,7 +118,7 @@ def finalization_stage_fallback_reasons(
 
 
 def derive_report_fallback_reasons(
-    analysis_metadata: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     has_whole_run_context_intervals: bool,
     has_whole_run_order_summaries: bool,
@@ -139,32 +140,24 @@ def derive_report_fallback_reasons(
 
 
 def _raw_capture_fallback_reasons(
-    analysis_metadata: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
 ) -> tuple[ReportFallbackReason, ...]:
     reasons: list[str] = []
-    if analysis_metadata.get("raw_capture_available") is False:
+    if analysis_metadata.raw_capture_available is False:
         reasons.append("raw_capture_not_configured")
-    finalize_status = text_or_none(analysis_metadata.get("raw_capture_finalize_status"))
-    if finalize_status == "timeout":
+    if analysis_metadata.raw_capture_finalize_status == "timeout":
         reasons.append("raw_capture_finalize_timeout")
-    elif finalize_status == "failed":
+    elif analysis_metadata.raw_capture_finalize_status == "failed":
         reasons.append("raw_capture_finalize_failed")
-    loss_policy_severity = text_or_none(analysis_metadata.get("raw_capture_loss_policy_severity"))
-    if loss_policy_severity == "fatal" or bool(
-        analysis_metadata.get("raw_capture_loss_policy_gate_whole_run")
-    ):
+    if analysis_metadata.has_fatal_raw_capture_loss:
         reasons.append("raw_capture_loss_exceeded")
-    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
-    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
-    if raw_capture_mode == "summary_only" or (
-        raw_capture_mode is None and raw_backed_sample_count <= 0
-    ):
+    if analysis_metadata.is_summary_only_capture:
         reasons.append("legacy_summary_only")
     return dedupe_report_fallback_reasons(reasons)
 
 
 def _whole_run_fallback_reasons(
-    analysis_metadata: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     has_whole_run_context_intervals: bool,
     has_whole_run_order_summaries: bool,
@@ -179,43 +172,40 @@ def _whole_run_fallback_reasons(
         has_whole_run_spatial_summaries=has_whole_run_spatial_summaries,
     ):
         return ("sidecar_summary_mismatch",)
-    has_partial_whole_run_inputs = bool(
-        has_whole_run_context_intervals
-        or has_whole_run_order_summaries
-        or has_whole_run_spatial_summaries
-        or analysis_metadata.get("whole_run_artifacts_available")
-        or analysis_metadata.get("whole_run_context_available")
-        or analysis_metadata.get("whole_run_order_family_summaries_available")
-        or analysis_metadata.get("whole_run_spatial_coherence_available")
+    has_partial_whole_run_inputs = analysis_metadata.has_partial_whole_run_inputs(
+        has_whole_run_context_intervals=has_whole_run_context_intervals,
+        has_whole_run_order_summaries=has_whole_run_order_summaries,
+        has_whole_run_spatial_summaries=has_whole_run_spatial_summaries,
     )
     if has_partial_whole_run_inputs:
         return ("whole_run_evidence_incomplete",)
-    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
-    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
-    if raw_capture_mode in {"raw_backed", "partial_raw_backed"} or raw_backed_sample_count > 0:
+    if (
+        analysis_metadata.raw_capture_mode in {"raw_backed", "partial_raw_backed"}
+        or analysis_metadata.raw_backed_sample_count > 0
+    ):
         return ("whole_run_evidence_missing",)
     return ()
 
 
 def _has_sidecar_summary_mismatch(
-    analysis_metadata: Mapping[str, object],
+    analysis_metadata: ReportAnalysisMetadata,
     *,
     has_whole_run_order_summaries: bool,
     has_whole_run_spatial_summaries: bool,
 ) -> bool:
     if (
-        bool(analysis_metadata.get("whole_run_diagnosis_summaries_available"))
-        and coerce_count(analysis_metadata.get("whole_run_diagnosis_summary_count")) > 0
+        analysis_metadata.whole_run_diagnosis_summaries_available
+        and analysis_metadata.whole_run_diagnosis_summary_count > 0
     ):
         return True
     if (
-        bool(analysis_metadata.get("whole_run_order_family_summaries_available"))
-        and coerce_count(analysis_metadata.get("whole_run_order_family_summary_count")) > 0
+        analysis_metadata.whole_run_order_family_summaries_available
+        and analysis_metadata.whole_run_order_family_summary_count > 0
         and not has_whole_run_order_summaries
     ):
         return True
     return bool(
-        bool(analysis_metadata.get("whole_run_spatial_coherence_available"))
-        and coerce_count(analysis_metadata.get("whole_run_spatial_coherence_summary_count")) > 0
+        analysis_metadata.whole_run_spatial_coherence_available
+        and analysis_metadata.whole_run_spatial_coherence_summary_count > 0
         and not has_whole_run_spatial_summaries
     )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -7,6 +7,9 @@ from math import ceil
 from typing import TYPE_CHECKING
 
 from vibesensor.shared.boundaries.analysis_payloads import analysis_result_to_summary
+from vibesensor.shared.boundaries.reporting.analysis_metadata import (
+    report_analysis_metadata_from_mapping,
+)
 from vibesensor.shared.boundaries.reporting.fallback_reasons import (
     REPORT_FALLBACK_REASONS_METADATA_KEY,
     derive_report_fallback_reasons,
@@ -245,7 +248,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
 
 def _set_initial_report_fallback_reasons(analysis_metadata: JsonObject) -> None:
     fallback_reasons = derive_report_fallback_reasons(
-        analysis_metadata,
+        report_analysis_metadata_from_mapping(analysis_metadata),
         has_whole_run_context_intervals=False,
         has_whole_run_order_summaries=False,
         has_whole_run_spatial_summaries=False,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from vibesensor.domain import CarOrderReferenceStatus
+from vibesensor.shared.boundaries.reporting.analysis_metadata import (
+    report_analysis_metadata_from_mapping,
+)
 from vibesensor.shared.boundaries.reporting.fallback_reasons import (
     REPORT_FALLBACK_REASONS_METADATA_KEY,
     derive_report_fallback_reasons,
@@ -394,7 +397,7 @@ def refresh_report_fallback_metadata(summary: PersistedAnalysis) -> PersistedAna
         payload["analysis_metadata"] = analysis_metadata
     normalized = report_summary_from_mapping(payload)
     fallback_reasons = derive_report_fallback_reasons(
-        analysis_metadata,
+        report_analysis_metadata_from_mapping(analysis_metadata),
         has_whole_run_context_intervals=bool(normalized.whole_run_context_intervals),
         has_whole_run_order_summaries=bool(normalized.whole_run_order_summaries),
         has_whole_run_spatial_summaries=bool(normalized.whole_run_spatial_summaries),


### PR DESCRIPTION
## What changed
- Added a typed report-facing analysis metadata boundary for stable persisted metadata keys.
- Rewired report facts, evidence facts, fallback reason derivation, history projection, and post-analysis fallback refresh through that boundary.
- Added focused tests for metadata decoding and report facts projection.

## Why
- Report generation had repeated raw `analysis_metadata` dict/key access across several modules.
- The stable string keys now stay at the persistence/report boundary while internal report logic consumes typed fields.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_report_analysis_metadata.py apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/shared/boundaries/test_report_payload.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/history/ apps/server/tests/shared/boundaries/`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make plan-validation`

## Risks / tradeoffs
- Payload shapes are preserved; the change is an internal boundary cleanup.
- Stable metadata keys are documented in code so new report consumers do not reopen raw dict access.

Fixes #3779