### PR TITLE
Refactor frontend workflow and spectrum state seams

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -38,6 +38,7 @@ import {
   createCarsFeatureTransport,
   type CarsFeatureTransport,
 } from "./cars_feature_transport";
+import { createWorkflowGenerationGuard } from "./workflow_generation_guard";
 import { batch, computed, signal, type ReadonlySignal } from "../ui_signals";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
@@ -175,26 +176,23 @@ export function createCarsFeatureWorkflow(
   const tireOptions = signal<readonly CarLibraryTireOption[]>([]);
   const gearboxOptions = signal<readonly CarLibraryGearbox[]>([]);
   const noGearboxesMessage = signal<string | null>(null);
-  let wizardLoadGeneration = 0;
+  const wizardLoads = createWorkflowGenerationGuard({
+    isActive: () => isOpen.value,
+  });
 
   function nextWizardLoadGeneration(): number {
-    wizardLoadGeneration += 1;
-    return wizardLoadGeneration;
+    return wizardLoads.begin();
   }
 
   function invalidateWizardLoads(): void {
-    wizardLoadGeneration += 1;
+    wizardLoads.invalidate();
   }
 
   function canApplyWizardLoad(
     generation: number,
     matchesState: (state: WizardState) => boolean,
   ): boolean {
-    return (
-      isOpen.value &&
-      generation === wizardLoadGeneration &&
-      matchesState(wizardState.value)
-    );
+    return wizardLoads.isCurrent(generation) && matchesState(wizardState.value);
   }
 
   function focusIfCurrent(

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -20,6 +20,7 @@ import {
   createSettingsSpeedSourceTransport,
   type SettingsSpeedSourceTransport,
 } from "./settings_speed_source_transport";
+import { createWorkflowGenerationGuard } from "./workflow_generation_guard";
 import { applySpeedSourcePayloadToSettings } from "./dashboard_startup_state";
 import {
   createHiddenTabPollingObserverOptions,
@@ -167,10 +168,19 @@ export function createSettingsSpeedSourceWorkflow(
   const obdSelectionError = signal(false);
   const diagnosticsOpen = signal(false);
   let disposed = false;
-  let loadGeneration = 0;
-  let saveGeneration = 0;
-  let scanGeneration = 0;
-  let pairGeneration = 0;
+  const workflowActive = () => !disposed;
+  const loadRequests = createWorkflowGenerationGuard({
+    isActive: workflowActive,
+  });
+  const saveRequests = createWorkflowGenerationGuard({
+    isActive: workflowActive,
+  });
+  const scanRequests = createWorkflowGenerationGuard({
+    isActive: workflowActive,
+  });
+  const pairRequests = createWorkflowGenerationGuard({
+    isActive: workflowActive,
+  });
   let saveInFlight = false;
   const renderState = computed<SettingsSpeedSourceRenderState>(() => {
     const settingsSnapshot: SpeedSourceStateSnapshot & {
@@ -207,13 +217,6 @@ export function createSettingsSpeedSourceWorkflow(
 
   function getRenderState(): SettingsSpeedSourceRenderState {
     return renderState.value;
-  }
-
-  function isCurrentRequest(
-    requestGeneration: number,
-    currentGeneration: number,
-  ): boolean {
-    return !disposed && requestGeneration === currentGeneration;
   }
 
   function shouldRunBackgroundRescan(): boolean {
@@ -332,7 +335,7 @@ export function createSettingsSpeedSourceWorkflow(
     if (disposed) {
       return;
     }
-    const requestGeneration = ++loadGeneration;
+    const requestGeneration = loadRequests.begin();
     let payload: SpeedSourcePayload;
     try {
       payload = await deps.queryClient.fetchQuery({
@@ -341,12 +344,12 @@ export function createSettingsSpeedSourceWorkflow(
         staleTime: 0,
       });
     } catch (error) {
-      if (!isCurrentRequest(requestGeneration, loadGeneration)) {
+      if (!loadRequests.isCurrent(requestGeneration)) {
         return;
       }
       throw error;
     }
-    if (!isCurrentRequest(requestGeneration, loadGeneration)) {
+    if (!loadRequests.isCurrent(requestGeneration)) {
       return;
     }
     applyPayload(payload, { preserveResolvedSource: true });
@@ -449,7 +452,7 @@ export function createSettingsSpeedSourceWorkflow(
     }
 
     saveInFlight = true;
-    const requestGeneration = ++saveGeneration;
+    const requestGeneration = saveRequests.begin();
     const payload: SpeedSourceRequest = {
       manual_speed_kph: manualSpeedKph,
       speed_source: source,
@@ -460,7 +463,7 @@ export function createSettingsSpeedSourceWorkflow(
 
     try {
       const saved = await transport.saveSpeedSource(payload);
-      if (!isCurrentRequest(requestGeneration, saveGeneration)) {
+      if (!saveRequests.isCurrent(requestGeneration)) {
         return;
       }
       deps.queryClient.setQueryData(
@@ -470,12 +473,12 @@ export function createSettingsSpeedSourceWorkflow(
       await deps.queryClient.invalidateQueries({
         queryKey: serverStateQueryKeys.settings.gpsStatus(),
       });
-      if (!isCurrentRequest(requestGeneration, saveGeneration)) {
+      if (!saveRequests.isCurrent(requestGeneration)) {
         return;
       }
       applyPayload(saved);
     } catch (error) {
-      if (!isCurrentRequest(requestGeneration, saveGeneration)) {
+      if (!saveRequests.isCurrent(requestGeneration)) {
         return;
       }
       showSaveFeedback(
@@ -483,7 +486,7 @@ export function createSettingsSpeedSourceWorkflow(
         deps.t("settings.speed.save_failed_detail", { source: activeSource }),
       );
     } finally {
-      if (requestGeneration === saveGeneration) {
+      if (saveRequests.isLatest(requestGeneration)) {
         saveInFlight = false;
       }
     }
@@ -495,7 +498,7 @@ export function createSettingsSpeedSourceWorkflow(
     if (disposed || scanInFlight.value || pairInFlightMac.value !== null) {
       return;
     }
-    const requestGeneration = ++scanGeneration;
+    const requestGeneration = scanRequests.begin();
     batch(() => {
       scanInFlight.value = true;
       if (mode === "manual") {
@@ -509,7 +512,7 @@ export function createSettingsSpeedSourceWorkflow(
         queryKey: serverStateQueryKeys.settings.speedSourceObdScan(),
         staleTime: 0,
       });
-      if (!isCurrentRequest(requestGeneration, scanGeneration)) {
+      if (!scanRequests.isCurrent(requestGeneration)) {
         return;
       }
       if (mode === "manual") {
@@ -527,7 +530,7 @@ export function createSettingsSpeedSourceWorkflow(
         mergeScannedDevices(payload.devices);
       }
     } catch (error) {
-      if (!isCurrentRequest(requestGeneration, scanGeneration)) {
+      if (!scanRequests.isCurrent(requestGeneration)) {
         return;
       }
       if (mode === "manual") {
@@ -539,7 +542,7 @@ export function createSettingsSpeedSourceWorkflow(
         );
       }
     } finally {
-      if (isCurrentRequest(requestGeneration, scanGeneration)) {
+      if (scanRequests.isCurrent(requestGeneration)) {
         scanInFlight.value = false;
       }
     }
@@ -549,7 +552,7 @@ export function createSettingsSpeedSourceWorkflow(
     if (disposed || pairInFlightMac.value !== null) {
       return;
     }
-    const requestGeneration = ++pairGeneration;
+    const requestGeneration = pairRequests.begin();
     clearObdSelectionFeedback();
     batch(() => {
       pairInFlightMac.value = macAddress;
@@ -557,7 +560,7 @@ export function createSettingsSpeedSourceWorkflow(
     });
     try {
       const payload = await transport.pairObdDevice(macAddress);
-      if (!isCurrentRequest(requestGeneration, pairGeneration)) {
+      if (!pairRequests.isCurrent(requestGeneration)) {
         return;
       }
       batch(() => {
@@ -580,11 +583,11 @@ export function createSettingsSpeedSourceWorkflow(
       await deps.queryClient.invalidateQueries({
         queryKey: serverStateQueryKeys.settings.gpsStatus(),
       });
-      if (!isCurrentRequest(requestGeneration, pairGeneration)) {
+      if (!pairRequests.isCurrent(requestGeneration)) {
         return;
       }
     } catch (error) {
-      if (!isCurrentRequest(requestGeneration, pairGeneration)) {
+      if (!pairRequests.isCurrent(requestGeneration)) {
         return;
       }
       obdScanStatusMessage.value = deps.t("settings.speed.obd_pair_failed");
@@ -594,7 +597,7 @@ export function createSettingsSpeedSourceWorkflow(
           : deps.t("settings.speed.obd_pair_failed"),
       );
     } finally {
-      if (isCurrentRequest(requestGeneration, pairGeneration)) {
+      if (pairRequests.isCurrent(requestGeneration)) {
         pairInFlightMac.value = null;
       }
     }
@@ -628,10 +631,10 @@ export function createSettingsSpeedSourceWorkflow(
   return {
     dispose(): void {
       disposed = true;
-      loadGeneration += 1;
-      saveGeneration += 1;
-      scanGeneration += 1;
-      pairGeneration += 1;
+      loadRequests.invalidate();
+      saveRequests.invalidate();
+      scanRequests.invalidate();
+      pairRequests.invalidate();
       saveInFlight = false;
       obdBackgroundRescan.dispose();
     },

--- a/apps/ui/src/app/features/workflow_generation_guard.ts
+++ b/apps/ui/src/app/features/workflow_generation_guard.ts
@@ -1,0 +1,32 @@
+export interface WorkflowGenerationGuard {
+  begin(): number;
+  invalidate(): void;
+  isCurrent(generation: number): boolean;
+  isLatest(generation: number): boolean;
+}
+
+export interface WorkflowGenerationGuardOptions {
+  isActive?: () => boolean;
+}
+
+export function createWorkflowGenerationGuard(
+  options: WorkflowGenerationGuardOptions = {},
+): WorkflowGenerationGuard {
+  const isActive = options.isActive ?? (() => true);
+  let currentGeneration = 0;
+  return {
+    begin() {
+      currentGeneration += 1;
+      return currentGeneration;
+    },
+    invalidate() {
+      currentGeneration += 1;
+    },
+    isCurrent(generation) {
+      return isActive() && generation === currentGeneration;
+    },
+    isLatest(generation) {
+      return generation === currentGeneration;
+    },
+  };
+}

--- a/apps/ui/src/spectrum_chart.ts
+++ b/apps/ui/src/spectrum_chart.ts
@@ -1,5 +1,14 @@
-import { spectrumDbDisplayRangeFromDataBounds } from "./spectrum";
 import { getSpectrumCssVars } from "./spectrum_css_vars";
+import {
+  buildSpectrumChartTickValues,
+  calculateSpectrumChartRanges,
+  createSpectrumChartBox,
+  findClosestSpectrumChartIndex,
+  normalizeSpectrumChartData,
+  projectSpectrumChartValue,
+  type SpectrumChartBox,
+  type SpectrumChartRange,
+} from "./spectrum_chart_model";
 import {
   computed,
   effect,
@@ -67,15 +76,9 @@ export interface CreateSpectrumChartDeps {
 }
 
 const DEFAULT_HEIGHT = 360;
-const EMPTY_DATA: SpectrumAlignedData = [[]];
 const HOVER_POINT_RADIUS = 4;
 const X_TICK_COUNT = 6;
 const Y_TICK_COUNT = 6;
-
-type ChartRange = {
-  max: number;
-  min: number;
-};
 
 type ChartState = {
   plugins: readonly SpectrumChartPlugin[];
@@ -100,10 +103,13 @@ export function createSpectrumChart(
     plugins: plugins.value,
     text: deps.text.value,
   };
-  let currentData = normalizeData(deps.data.value);
-  let currentXRange: ChartRange | null = null;
-  let currentYRange: ChartRange | null = null;
-  let currentBbox = createChartBox(width.value, height.value);
+  let currentData = normalizeSpectrumChartData(deps.data.value);
+  let currentXRange: SpectrumChartRange | null = null;
+  let currentYRange: SpectrumChartRange | null = null;
+  let currentBbox: SpectrumChartBox = createSpectrumChartBox(
+    width.value,
+    height.value,
+  );
   let disposed = false;
   let forceAxesRecalc = true;
 
@@ -149,14 +155,14 @@ export function createSpectrumChart(
     },
     valToPos(value, scale) {
       if (scale === "x") {
-        return projectValue(
+        return projectSpectrumChartValue(
           value,
           currentXRange ?? { min: 0, max: 1 },
           currentBbox.left,
           currentBbox.width,
         );
       }
-      return projectValue(
+      return projectSpectrumChartValue(
         value,
         currentYRange ?? { min: -120, max: 0 },
         currentBbox.top + currentBbox.height,
@@ -181,47 +187,12 @@ export function createSpectrumChart(
   }
 
   function recalculateRanges(): void {
-    const freqAxis = currentData[0] ?? [];
-    const xMin = freqAxis[0] ?? 0;
-    const xMax = freqAxis[freqAxis.length - 1] ?? Math.max(1, xMin);
-    currentXRange = {
-      min: xMin,
-      max: xMax > xMin ? xMax : xMin + 1,
-    };
-
-    let dataMin = Number.POSITIVE_INFINITY;
-    let dataMax = Number.NEGATIVE_INFINITY;
-    let sawValue = false;
-    const visibleSeries = getVisibleSeriesIndexes();
-    const sourceIndexes = visibleSeries.length
-      ? visibleSeries
-      : Array.from(
-          { length: Math.max(0, currentData.length - 1) },
-          (_, index) => index + 1,
-        );
-    for (const seriesIndex of sourceIndexes) {
-      const series = currentData[seriesIndex];
-      if (!series) {
-        continue;
-      }
-      for (const value of series) {
-        if (!Number.isFinite(value)) {
-          continue;
-        }
-        sawValue = true;
-        dataMin = Math.min(dataMin, value);
-        dataMax = Math.max(dataMax, value);
-      }
-    }
-    if (!sawValue) {
-      currentYRange = { min: -120, max: 0 };
-      return;
-    }
-    const [min, max] = spectrumDbDisplayRangeFromDataBounds(dataMin, dataMax);
-    currentYRange = {
-      min,
-      max: max > min ? max : min + 1,
-    };
+    const ranges = calculateSpectrumChartRanges(
+      currentData,
+      getVisibleSeriesIndexes(),
+    );
+    currentXRange = ranges.x;
+    currentYRange = ranges.y;
   }
 
   function resizeCanvas(cssWidth: number, cssHeight: number): void {
@@ -233,7 +204,7 @@ export function createSpectrumChart(
     canvas.style.width = `${renderWidth}px`;
     canvas.style.height = `${renderHeight}px`;
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    currentBbox = createChartBox(renderWidth, renderHeight);
+    currentBbox = createSpectrumChartBox(renderWidth, renderHeight);
   }
 
   function clearCanvas(cssWidth: number, cssHeight: number): void {
@@ -263,7 +234,10 @@ export function createSpectrumChart(
     ctx.textAlign = "center";
     ctx.textBaseline = "top";
 
-    for (const value of buildTickValues(currentXRange, X_TICK_COUNT)) {
+    for (const value of buildSpectrumChartTickValues(
+      currentXRange,
+      X_TICK_COUNT,
+    )) {
       const x = plotContext.valToPos(value, "x");
       ctx.beginPath();
       ctx.moveTo(x, top);
@@ -274,7 +248,10 @@ export function createSpectrumChart(
 
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
-    for (const value of buildTickValues(currentYRange, Y_TICK_COUNT)) {
+    for (const value of buildSpectrumChartTickValues(
+      currentYRange,
+      Y_TICK_COUNT,
+    )) {
       const y = plotContext.valToPos(value, "y");
       ctx.beginPath();
       ctx.moveTo(left, y);
@@ -431,7 +408,12 @@ export function createSpectrumChart(
       return;
     }
     updateCursorIndex(
-      findClosestIndex(currentData[0] ?? [], x, currentXRange, currentBbox),
+      findClosestSpectrumChartIndex(
+        currentData[0] ?? [],
+        x,
+        currentXRange,
+        currentBbox,
+      ),
     );
   }
 
@@ -482,7 +464,7 @@ export function createSpectrumChart(
       renderChart(true);
     },
     setData(data: SpectrumAlignedData, resetScales = true): void {
-      currentData = normalizeData(data);
+      currentData = normalizeSpectrumChartData(data);
       renderChart(resetScales);
     },
     setSeriesIsolation(seriesIdx: number | null): void {
@@ -503,31 +485,6 @@ function computeWidth(measureEl: HTMLElement): number {
   return Math.max(320, Math.floor(measureEl.getBoundingClientRect().width));
 }
 
-function createChartBox(
-  width: number,
-  height: number,
-): {
-  height: number;
-  left: number;
-  top: number;
-  width: number;
-} {
-  const left = 54;
-  const right = 16;
-  const top = 16;
-  const bottom = 36;
-  return {
-    top,
-    left,
-    width: Math.max(1, width - left - right),
-    height: Math.max(1, height - top - bottom),
-  };
-}
-
-function normalizeData(data: SpectrumAlignedData): SpectrumAlignedData {
-  return data.length ? data : EMPTY_DATA;
-}
-
 function requireCanvasContext(
   canvas: HTMLCanvasElement,
 ): CanvasRenderingContext2D {
@@ -538,66 +495,10 @@ function requireCanvasContext(
   return context;
 }
 
-function projectValue(
-  value: number,
-  range: ChartRange,
-  start: number,
-  span: number,
-): number {
-  const denominator = range.max - range.min || 1;
-  return start + ((value - range.min) / denominator) * span;
-}
-
-function buildTickValues(range: ChartRange, count: number): number[] {
-  if (count <= 1) {
-    return [range.min];
-  }
-  const step = (range.max - range.min) / (count - 1 || 1);
-  const ticks: number[] = [];
-  for (let index = 0; index < count; index += 1) {
-    ticks.push(range.min + step * index);
-  }
-  return ticks;
-}
-
 function formatHzTick(value: number): string {
   return value >= 100 ? value.toFixed(0) : value.toFixed(1);
 }
 
 function formatDbTick(value: number): string {
   return value.toFixed(0);
-}
-
-function findClosestIndex(
-  freqAxis: readonly number[],
-  x: number,
-  xRange: ChartRange | null,
-  bbox: { left: number; width: number },
-): number | null {
-  if (freqAxis.length === 0 || xRange === null) {
-    return null;
-  }
-  const freqValue =
-    xRange.min +
-    ((x - bbox.left) / (bbox.width || 1)) * (xRange.max - xRange.min);
-  let low = 0;
-  let high = freqAxis.length - 1;
-  while (low < high) {
-    const mid = Math.floor((low + high) / 2);
-    const nextValue = freqAxis[mid];
-    if ((nextValue ?? 0) < freqValue) {
-      low = mid + 1;
-    } else {
-      high = mid;
-    }
-  }
-  const candidate = low;
-  const previous = Math.max(0, candidate - 1);
-  const candidateDistance = Math.abs(
-    (freqAxis[candidate] ?? freqValue) - freqValue,
-  );
-  const previousDistance = Math.abs(
-    (freqAxis[previous] ?? freqValue) - freqValue,
-  );
-  return previousDistance <= candidateDistance ? previous : candidate;
 }

--- a/apps/ui/src/spectrum_chart_model.ts
+++ b/apps/ui/src/spectrum_chart_model.ts
@@ -1,0 +1,149 @@
+import { spectrumDbDisplayRangeFromDataBounds } from "./spectrum";
+
+export interface SpectrumChartRange {
+  max: number;
+  min: number;
+}
+
+export interface SpectrumChartBox {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}
+
+export interface SpectrumChartRanges {
+  x: SpectrumChartRange;
+  y: SpectrumChartRange;
+}
+
+type SpectrumChartData = number[][];
+
+const EMPTY_DATA: SpectrumChartData = [[]];
+
+export function normalizeSpectrumChartData(
+  data: SpectrumChartData,
+): SpectrumChartData {
+  return data.length ? data : EMPTY_DATA;
+}
+
+export function createSpectrumChartBox(
+  width: number,
+  height: number,
+): SpectrumChartBox {
+  const left = 54;
+  const right = 16;
+  const top = 16;
+  const bottom = 36;
+  return {
+    top,
+    left,
+    width: Math.max(1, width - left - right),
+    height: Math.max(1, height - top - bottom),
+  };
+}
+
+export function calculateSpectrumChartRanges(
+  data: SpectrumChartData,
+  visibleSeriesIndexes: readonly number[],
+): SpectrumChartRanges {
+  const freqAxis = data[0] ?? [];
+  const xMin = freqAxis[0] ?? 0;
+  const xMax = freqAxis[freqAxis.length - 1] ?? Math.max(1, xMin);
+
+  let dataMin = Number.POSITIVE_INFINITY;
+  let dataMax = Number.NEGATIVE_INFINITY;
+  let sawValue = false;
+  const sourceIndexes = visibleSeriesIndexes.length
+    ? visibleSeriesIndexes
+    : Array.from(
+        { length: Math.max(0, data.length - 1) },
+        (_, index) => index + 1,
+      );
+  for (const seriesIndex of sourceIndexes) {
+    const series = data[seriesIndex];
+    if (!series) {
+      continue;
+    }
+    for (const value of series) {
+      if (!Number.isFinite(value)) {
+        continue;
+      }
+      sawValue = true;
+      dataMin = Math.min(dataMin, value);
+      dataMax = Math.max(dataMax, value);
+    }
+  }
+
+  if (!sawValue) {
+    return {
+      x: { min: xMin, max: xMax > xMin ? xMax : xMin + 1 },
+      y: { min: -120, max: 0 },
+    };
+  }
+
+  const [min, max] = spectrumDbDisplayRangeFromDataBounds(dataMin, dataMax);
+  return {
+    x: { min: xMin, max: xMax > xMin ? xMax : xMin + 1 },
+    y: { min, max: max > min ? max : min + 1 },
+  };
+}
+
+export function projectSpectrumChartValue(
+  value: number,
+  range: SpectrumChartRange,
+  start: number,
+  span: number,
+): number {
+  const denominator = range.max - range.min || 1;
+  return start + ((value - range.min) / denominator) * span;
+}
+
+export function buildSpectrumChartTickValues(
+  range: SpectrumChartRange,
+  count: number,
+): number[] {
+  if (count <= 1) {
+    return [range.min];
+  }
+  const step = (range.max - range.min) / (count - 1 || 1);
+  const ticks: number[] = [];
+  for (let index = 0; index < count; index += 1) {
+    ticks.push(range.min + step * index);
+  }
+  return ticks;
+}
+
+export function findClosestSpectrumChartIndex(
+  freqAxis: readonly number[],
+  x: number,
+  xRange: SpectrumChartRange | null,
+  bbox: Pick<SpectrumChartBox, "left" | "width">,
+): number | null {
+  if (freqAxis.length === 0 || xRange === null) {
+    return null;
+  }
+  const freqValue =
+    xRange.min +
+    ((x - bbox.left) / (bbox.width || 1)) * (xRange.max - xRange.min);
+  let low = 0;
+  let high = freqAxis.length - 1;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const nextValue = freqAxis[mid];
+    if ((nextValue ?? 0) < freqValue) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  const candidate = low;
+  const previous = Math.max(0, candidate - 1);
+  const candidateDistance = Math.abs(
+    (freqAxis[candidate] ?? freqValue) - freqValue,
+  );
+  const previousDistance = Math.abs(
+    (freqAxis[previous] ?? freqValue) - freqValue,
+  );
+  return previousDistance <= candidateDistance ? previous : candidate;
+}

--- a/apps/ui/tests/spectrum_chart_model.spec.ts
+++ b/apps/ui/tests/spectrum_chart_model.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildSpectrumChartTickValues,
+  calculateSpectrumChartRanges,
+  createSpectrumChartBox,
+  findClosestSpectrumChartIndex,
+  normalizeSpectrumChartData,
+  projectSpectrumChartValue,
+} from "../src/spectrum_chart_model";
+
+describe("spectrum chart model", () => {
+  test("normalizes empty chart data without DOM or canvas", () => {
+    expect(normalizeSpectrumChartData([])).toEqual([[]]);
+  });
+
+  test("calculates visible-series ranges from finite spectrum values", () => {
+    const ranges = calculateSpectrumChartRanges(
+      [
+        [10, 20, 30],
+        [0, 10, 30],
+        [0, 80, 90],
+      ],
+      [1],
+    );
+
+    expect(ranges.x).toEqual({ min: 10, max: 30 });
+    expect(ranges.y).toEqual({ min: 0, max: 40 });
+  });
+
+  test("falls back to all data series when no series is visible", () => {
+    const ranges = calculateSpectrumChartRanges(
+      [
+        [10, 20],
+        [10, 20],
+        [70, 80],
+      ],
+      [],
+    );
+
+    expect(ranges.y).toEqual({ min: 0, max: 90 });
+  });
+
+  test("projects ticks and cursor indexes from the headless chart box", () => {
+    const box = createSpectrumChartBox(400, 260);
+    const xRange = { min: 10, max: 30 };
+
+    expect(box).toEqual({ top: 16, left: 54, width: 330, height: 208 });
+    expect(buildSpectrumChartTickValues(xRange, 3)).toEqual([10, 20, 30]);
+    expect(projectSpectrumChartValue(20, xRange, box.left, box.width)).toBe(
+      219,
+    );
+    expect(findClosestSpectrumChartIndex([10, 20, 30], 225, xRange, box)).toBe(
+      1,
+    );
+  });
+});

--- a/apps/ui/tests/workflow_generation_guard.spec.ts
+++ b/apps/ui/tests/workflow_generation_guard.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import { createWorkflowGenerationGuard } from "../src/app/features/workflow_generation_guard";
+
+describe("createWorkflowGenerationGuard", () => {
+  test("accepts only the latest active generation", () => {
+    let active = true;
+    const guard = createWorkflowGenerationGuard({ isActive: () => active });
+
+    const first = guard.begin();
+    const second = guard.begin();
+
+    expect(guard.isCurrent(first)).toBe(false);
+    expect(guard.isCurrent(second)).toBe(true);
+    active = false;
+    expect(guard.isCurrent(second)).toBe(false);
+  });
+
+  test("invalidates in-flight work while preserving latest checks", () => {
+    const guard = createWorkflowGenerationGuard();
+    const generation = guard.begin();
+
+    expect(guard.isLatest(generation)).toBe(true);
+
+    guard.invalidate();
+
+    expect(guard.isCurrent(generation)).toBe(false);
+    expect(guard.isLatest(generation)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3783.

What changed:
- Added `workflow_generation_guard` for reusable stale async generation checks.
- Wired cars wizard loads and settings speed-source requests through that guard.
- Added `spectrum_chart_model` for headless spectrum chart data math: normalize, ranges, chart box, ticks, projection, cursor index.
- Kept `spectrum_chart` focused on canvas setup, drawing, pointer events, and plugins.
- Added focused unit tests for both extracted helpers.

Why:
- Workflow request freshness and spectrum data math were embedded in larger UI/rendering files.
- The split makes state behavior testable without DOM/canvas setup and keeps render adapters narrower.

Validation:
- `cd apps/ui && npm run test:unit -- --run tests/workflow_generation_guard.spec.ts tests/spectrum_chart_model.spec.ts tests/cars_feature_workflow_lifecycle.spec.ts tests/settings_speed_source_workflow.spec.ts tests/spectrum_chart_lifecycle.spec.ts tests/spectrum_cache.spec.ts`
- `cd apps/ui && npm run test:unit`
- `make ui-typecheck`
- `cd apps/ui && npm run build`
- `make plan-validation`
- `git diff --check`

Risks / tradeoffs:
- No backend contract or UI behavior changes intended.
- Main risk is stale async behavior drift; existing lifecycle tests and new guard tests cover it.
- Spectrum visual behavior should stay unchanged because drawing code still uses the same computed values through extracted pure helpers.

Follow-ups:
- None.