### PR TITLE
Refactor raw capture replay sample phases

### DIFF
--- a/apps/server/tests/use_cases/run/test_raw_capture_replay_phases.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay_phases.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorClockSync,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
+from vibesensor.use_cases.run import raw_capture_replay
+
+_SAMPLE_RATE_HZ = 800
+_FFT_N = 64
+_RUN_START_MONOTONIC_US = 1_000_000
+
+
+def _metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": _SAMPLE_RATE_HZ,
+            "sample_rate_hz": _SAMPLE_RATE_HZ,
+            "feature_interval_s": 1.0,
+            "fft_window_size_samples": _FFT_N,
+            "accel_scale_g_per_lsb": 0.001,
+            "language": "en",
+        }
+    )
+
+
+def _wave(freq_hz: float, sample_count: int) -> np.ndarray:
+    time_axis = np.arange(sample_count, dtype=np.float64) / float(_SAMPLE_RATE_HZ)
+    wave = np.round(1000.0 * np.sin(2.0 * math.pi * freq_hz * time_axis)).astype(np.int16)
+    return np.column_stack(
+        [
+            wave,
+            np.zeros(sample_count, dtype=np.int16),
+            np.zeros(sample_count, dtype=np.int16),
+        ]
+    )
+
+
+def _analysis_window_end_us(*, raw_start_offset_us: int, sample_end: int) -> int:
+    return int(
+        raw_start_offset_us + (float(sample_end) / float(_SAMPLE_RATE_HZ) * 1_000_000.0),
+    )
+
+
+def _verified_clock_sync() -> RawCaptureSensorClockSync:
+    return RawCaptureSensorClockSync(
+        clock_domain="server_monotonic",
+        proof_state="verified",
+        observed_monotonic_us=1_010_000,
+        last_sync_monotonic_us=1_009_000,
+        sync_offset_us=5_000,
+        sync_rtt_us=4_000,
+        max_sync_age_us=15_000_000,
+        max_sync_rtt_us=50_000,
+    )
+
+
+def _raw_capture(
+    run_id: str,
+    *,
+    sensors: list[tuple[str, list[tuple[int, np.ndarray]]]],
+) -> RawRunCapture:
+    sensor_rows: list[RawCaptureSensorData] = []
+    sensor_manifests: list[RawCaptureSensorManifest] = []
+    total_samples = 0
+    total_bytes = 0
+    for client_id, chunks in sensors:
+        sample_start = 0
+        byte_offset = 0
+        chunk_indexes: list[RawCaptureChunkIndex] = []
+        sample_arrays: list[np.ndarray] = []
+        for t0_us, samples in chunks:
+            normalized = np.ascontiguousarray(samples, dtype=np.int16)
+            sample_arrays.append(normalized)
+            chunk_indexes.append(
+                RawCaptureChunkIndex(
+                    sample_start=sample_start,
+                    sample_count=int(normalized.shape[0]),
+                    t0_us=t0_us,
+                    byte_offset=byte_offset,
+                )
+            )
+            sample_start += int(normalized.shape[0])
+            byte_offset += int(normalized.nbytes)
+        samples_i16 = np.vstack(sample_arrays)
+        manifest = RawCaptureSensorManifest(
+            client_id=client_id,
+            sample_rate_hz=_SAMPLE_RATE_HZ,
+            data_file=f"{client_id}.raw.i16le",
+            index_file=f"{client_id}.index.jsonl",
+            sample_count=int(samples_i16.shape[0]),
+            chunk_count=len(chunk_indexes),
+            bytes_written=int(samples_i16.nbytes),
+            first_t0_us=chunks[0][0],
+            last_t0_us=chunks[-1][0],
+            clock_sync=_verified_clock_sync(),
+            declared_sample_rate_hz=_SAMPLE_RATE_HZ,
+            sample_rate_proof_state="observed_consistent",
+        )
+        sensor_rows.append(
+            RawCaptureSensorData(
+                manifest=manifest,
+                samples_i16=samples_i16,
+                chunks=tuple(chunk_indexes),
+            )
+        )
+        sensor_manifests.append(manifest)
+        total_samples += manifest.sample_count
+        total_bytes += manifest.bytes_written
+    manifest = RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=tuple(sensor_manifests),
+        total_samples=total_samples,
+        total_bytes=total_bytes,
+        created_at="2025-01-01T00:00:01Z",
+        run_start_monotonic_us=_RUN_START_MONOTONIC_US,
+    )
+    return RawRunCapture(manifest=manifest, sensors=tuple(sensor_rows))
+
+
+def test_raw_replay_phase_builds_timelines_and_windows_per_client() -> None:
+    sensor_a_offset_us = 100_000
+    sensor_b_offset_us = 140_000
+    raw_capture = _raw_capture(
+        "run-phase-windows",
+        sensors=[
+            (
+                "sensor-a",
+                [(_RUN_START_MONOTONIC_US + sensor_a_offset_us, _wave(28.0, _FFT_N))],
+            ),
+            (
+                "sensor-b",
+                [(_RUN_START_MONOTONIC_US + sensor_b_offset_us, _wave(52.0, _FFT_N))],
+            ),
+        ],
+    )
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "client_id": "sensor-a",
+                "analysis_window_end_us": _analysis_window_end_us(
+                    raw_start_offset_us=sensor_a_offset_us,
+                    sample_end=_FFT_N,
+                ),
+                "sample_rate_hz": _SAMPLE_RATE_HZ,
+                "vibration_strength_db": 0.0,
+                "dominant_freq_hz": 0.0,
+            },
+            {
+                "client_id": "sensor-b",
+                "analysis_window_end_us": _analysis_window_end_us(
+                    raw_start_offset_us=sensor_b_offset_us,
+                    sample_end=_FFT_N,
+                ),
+                "sample_rate_hz": _SAMPLE_RATE_HZ,
+                "vibration_strength_db": 0.0,
+                "dominant_freq_hz": 0.0,
+            },
+        ]
+    )
+
+    context = raw_capture_replay._build_replay_context(
+        metadata=_metadata("run-phase-windows"),
+        raw_capture=raw_capture,
+        fft_n=_FFT_N,
+    )
+    windows = raw_capture_replay._build_replay_windows(
+        samples=samples,
+        raw_capture=raw_capture,
+        context=context,
+    )
+
+    assert set(context.timelines) == {"sensor-a", "sensor-b"}
+    assert windows.raw_backed_count == 2
+    assert windows.complete_window_count == 2
+    assert windows.partial_window_count == 0
+    assert windows.missing_window_count == 0
+    assert [coverage.client_id for coverage in windows.coverages] == ["sensor-a", "sensor-b"]
+    assert {sample.client_id for sample in windows.samples} == {"sensor-a", "sensor-b"}
+    assert all(sample.dominant_freq_hz is not None for sample in windows.samples)
+
+
+def test_raw_replay_phase_marks_unavailable_capture_windows_missing() -> None:
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "client_id": "sensor-a",
+                "t_s": 0.2,
+                "sample_rate_hz": _SAMPLE_RATE_HZ,
+                "vibration_strength_db": 3.0,
+                "dominant_freq_hz": 4.0,
+            },
+            {
+                "client_id": "sensor-b",
+                "t_s": 0.3,
+                "sample_rate_hz": _SAMPLE_RATE_HZ,
+                "vibration_strength_db": 5.0,
+                "dominant_freq_hz": 6.0,
+            },
+        ]
+    )
+
+    result = raw_capture_replay._build_raw_capture_unavailable_replay_result(samples)
+
+    assert result.samples == samples
+    assert result.summary.raw_capture_available is False
+    assert result.summary.replay_confidence == "unavailable"
+    assert result.summary.raw_capture_mode == "summary_only"
+    assert result.summary.missing_window_count == 2
+    assert [coverage.reason for coverage in result.window_coverages] == [
+        "raw_capture_unavailable",
+        "raw_capture_unavailable",
+    ]

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -49,6 +49,7 @@ __all__ = [
 
 type RawReplayCoverageState = Literal["complete", "partial", "missing"]
 type RawReplayConfidence = Literal["full", "partial", "fallback", "unavailable"]
+type RawCaptureMode = Literal["raw_backed", "partial_raw_backed", "summary_only"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,7 +90,7 @@ class RawReplaySummary:
     stale_sync_sensor_count: int
     high_rtt_sensor_count: int
     replay_confidence: RawReplayConfidence
-    raw_capture_mode: str
+    raw_capture_mode: RawCaptureMode
     raw_capture_loss_policy_severity: str = "ok"
     raw_capture_loss_policy_reason: str = "raw_capture_loss_ok"
     raw_capture_loss_policy_gate_whole_run: bool = False
@@ -123,6 +124,49 @@ class _ComputedStrengthMetrics:
     analytically_valid: bool
 
 
+@dataclass(frozen=True, slots=True)
+class _ReplayBuildContext:
+    fft_n: int
+    timelines: dict[str, RawSensorTimeline]
+    fft_computer: SpectralAnalysisComputer
+    accel_scale_g_per_lsb: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class _ReplayWindowBuildResult:
+    samples: tuple[SensorFrame, ...]
+    coverages: tuple[RawReplayWindowCoverage, ...]
+    raw_backed_count: int
+    complete_window_count: int
+    partial_window_count: int
+    missing_window_count: int
+    sample_rate_mismatch_count: int
+    timing_fallback_count: int
+    fft_unusable_window_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _RawTimelineSummary:
+    gap_count: int
+    overlap_count: int
+    sample_rate_unverified_sensor_count: int
+    unanchored_sensor_count: int
+    legacy_sensor_count: int
+    sync_unverified_sensor_count: int
+    stale_sync_sensor_count: int
+    high_rtt_sensor_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _RawCaptureLossCounts:
+    dropped_chunk_count: int
+    late_packet_chunk_count: int
+    queue_overflow_chunk_count: int
+    invalid_chunk_count: int
+    write_error_chunk_count: int
+    udp_ingest_queue_drop_count: int
+
+
 def build_raw_backed_samples(
     *,
     samples: tuple[SensorFrame, ...],
@@ -132,165 +176,92 @@ def build_raw_backed_samples(
     """Replace summary strength metrics with raw-backed metrics when possible."""
 
     if raw_capture is None:
-        return RawReplayResult(
-            samples=samples,
-            summary=RawReplaySummary(
-                raw_capture_available=False,
-                raw_backed_summary_row_count=0,
-                replay_window_count=len(samples),
-                complete_window_count=0,
-                partial_window_count=0,
-                missing_window_count=len(samples),
-                gap_count=0,
-                overlap_count=0,
-                dropped_chunk_count=0,
-                late_packet_chunk_count=0,
-                queue_overflow_chunk_count=0,
-                invalid_chunk_count=0,
-                write_error_chunk_count=0,
-                timing_fallback_count=0,
-                sample_rate_mismatch_count=0,
-                fft_unusable_window_count=0,
-                sample_rate_unverified_sensor_count=0,
-                unanchored_sensor_count=0,
-                legacy_sensor_count=0,
-                sync_unverified_sensor_count=0,
-                stale_sync_sensor_count=0,
-                high_rtt_sensor_count=0,
-                replay_confidence="unavailable",
-                raw_capture_mode="summary_only",
-                udp_ingest_queue_drop_count=0,
-            ),
-            window_coverages=tuple(
-                RawReplayWindowCoverage(
-                    client_id=sample.client_id,
-                    t_s=sample.t_s,
-                    coverage_state="missing",
-                    raw_backed=False,
-                    reason="raw_capture_unavailable",
-                )
-                for sample in samples
-            ),
-        )
+        return _build_raw_capture_unavailable_replay_result(samples)
     fft_n = int(metadata.fft_window_size_samples or 0)
     if fft_n <= 0:
         return _build_fft_unavailable_replay_result(samples=samples, raw_capture=raw_capture)
-    timelines = {
-        sensor.manifest.client_id: _build_sensor_timeline(
-            raw_capture, sensor_id=sensor.manifest.client_id
-        )
-        for sensor in raw_capture.sensors
-    }
-    fft_computer = _build_fft_computer(metadata)
-    replayed: list[SensorFrame] = []
-    coverages: list[RawReplayWindowCoverage] = []
-    complete_window_count = 0
-    partial_window_count = 0
-    missing_window_count = 0
-    sample_rate_mismatch_count = 0
-    timing_fallback_count = 0
-    fft_unusable_window_count = 0
-    raw_backed_count = 0
-    scale = metadata.accel_scale_g_per_lsb
-    for sample in samples:
-        rebuilt, coverage = _rebuild_sample(
-            sample=sample,
-            timeline=timelines.get(sample.client_id),
-            raw_capture=raw_capture,
-            fft_computer=fft_computer,
-            fft_n=fft_n,
-            accel_scale_g_per_lsb=scale,
-        )
-        if coverage.raw_backed:
-            raw_backed_count += 1
-        if coverage.coverage_state == "complete":
-            complete_window_count += 1
-        elif coverage.coverage_state == "partial":
-            partial_window_count += 1
-        else:
-            missing_window_count += 1
-        if coverage.reason == "sample_rate_mismatch":
-            sample_rate_mismatch_count += 1
-        if coverage.reason == "timing_fallback":
-            timing_fallback_count += 1
-        if coverage.reason == "fft_no_valid_bins":
-            fft_unusable_window_count += 1
-        replayed.append(rebuilt)
-        coverages.append(coverage)
-    gap_count = sum(len(timeline.gap_intervals) for timeline in timelines.values())
-    overlap_count = sum(len(timeline.overlap_intervals) for timeline in timelines.values())
-    unanchored_sensor_count = sum(1 for timeline in timelines.values() if not timeline.anchored)
-    sample_rate_unverified_sensor_count = sum(
-        1 for sensor in raw_capture.sensors if sensor.manifest.sample_rate_unverified
+    context = _build_replay_context(
+        metadata=metadata,
+        raw_capture=raw_capture,
+        fft_n=fft_n,
     )
-    legacy_sensor_count = sum(
-        1 for timeline in timelines.values() if raw_timeline_is_legacy(timeline)
+    windows = _build_replay_windows(
+        samples=samples,
+        raw_capture=raw_capture,
+        context=context,
     )
-    sync_unverified_sensor_count = sum(
-        1 for timeline in timelines.values() if _timeline_has_unverified_sync(timeline)
+    timeline_summary = _summarize_raw_timelines(
+        raw_capture=raw_capture,
+        timelines=context.timelines,
     )
-    stale_sync_sensor_count = sum(
-        1
-        for timeline in timelines.values()
-        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "stale_sync"
-    )
-    high_rtt_sensor_count = sum(
-        1
-        for timeline in timelines.values()
-        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
-    )
-    dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
-    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
+    loss_counts = _summarize_raw_capture_losses(raw_capture)
     loss_policy = assess_raw_capture_loss_policy(raw_capture.manifest)
-    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
-    queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
-    invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
-    write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
     replay_confidence = _replay_confidence(
-        raw_backed_summary_row_count=raw_backed_count,
+        raw_backed_summary_row_count=windows.raw_backed_count,
         replay_window_count=len(samples),
-        partial_window_count=partial_window_count,
-        missing_window_count=missing_window_count,
-        gap_count=gap_count,
-        overlap_count=overlap_count,
-        dropped_chunk_count=dropped_chunk_count,
-        late_packet_chunk_count=late_packet_chunk_count,
-        sample_rate_mismatch_count=sample_rate_mismatch_count,
-        fft_unusable_window_count=fft_unusable_window_count,
-        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
-        unanchored_sensor_count=unanchored_sensor_count,
-        sync_unverified_sensor_count=sync_unverified_sensor_count,
+        partial_window_count=windows.partial_window_count,
+        missing_window_count=windows.missing_window_count,
+        gap_count=timeline_summary.gap_count,
+        overlap_count=timeline_summary.overlap_count,
+        dropped_chunk_count=loss_counts.dropped_chunk_count,
+        late_packet_chunk_count=loss_counts.late_packet_chunk_count,
+        sample_rate_mismatch_count=windows.sample_rate_mismatch_count,
+        fft_unusable_window_count=windows.fft_unusable_window_count,
+        sample_rate_unverified_sensor_count=(timeline_summary.sample_rate_unverified_sensor_count),
+        unanchored_sensor_count=timeline_summary.unanchored_sensor_count,
+        sync_unverified_sensor_count=timeline_summary.sync_unverified_sensor_count,
     )
-    raw_capture_mode = (
-        "summary_only"
-        if raw_backed_count <= 0
-        else ("raw_backed" if replay_confidence == "full" else "partial_raw_backed")
+    return _assemble_raw_replay_result(
+        windows=windows,
+        timeline_summary=timeline_summary,
+        loss_counts=loss_counts,
+        loss_policy=loss_policy,
+        replay_window_count=len(samples),
+        replay_confidence=replay_confidence,
+        raw_capture_mode=_raw_capture_mode(
+            raw_backed_count=windows.raw_backed_count,
+            replay_confidence=replay_confidence,
+        ),
     )
+
+
+def _assemble_raw_replay_result(
+    *,
+    windows: _ReplayWindowBuildResult,
+    timeline_summary: _RawTimelineSummary,
+    loss_counts: _RawCaptureLossCounts,
+    loss_policy: RawCaptureLossPolicyAssessment,
+    replay_window_count: int,
+    replay_confidence: RawReplayConfidence,
+    raw_capture_mode: RawCaptureMode,
+) -> RawReplayResult:
     return RawReplayResult(
-        samples=tuple(replayed),
+        samples=windows.samples,
         summary=RawReplaySummary(
             raw_capture_available=True,
-            raw_backed_summary_row_count=raw_backed_count,
-            replay_window_count=len(samples),
-            complete_window_count=complete_window_count,
-            partial_window_count=partial_window_count,
-            missing_window_count=missing_window_count,
-            gap_count=gap_count,
-            overlap_count=overlap_count,
-            dropped_chunk_count=dropped_chunk_count,
-            late_packet_chunk_count=late_packet_chunk_count,
-            queue_overflow_chunk_count=queue_overflow_chunk_count,
-            invalid_chunk_count=invalid_chunk_count,
-            write_error_chunk_count=write_error_chunk_count,
-            timing_fallback_count=timing_fallback_count,
-            sample_rate_mismatch_count=sample_rate_mismatch_count,
-            fft_unusable_window_count=fft_unusable_window_count,
-            sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
-            unanchored_sensor_count=unanchored_sensor_count,
-            legacy_sensor_count=legacy_sensor_count,
-            sync_unverified_sensor_count=sync_unverified_sensor_count,
-            stale_sync_sensor_count=stale_sync_sensor_count,
-            high_rtt_sensor_count=high_rtt_sensor_count,
+            raw_backed_summary_row_count=windows.raw_backed_count,
+            replay_window_count=replay_window_count,
+            complete_window_count=windows.complete_window_count,
+            partial_window_count=windows.partial_window_count,
+            missing_window_count=windows.missing_window_count,
+            gap_count=timeline_summary.gap_count,
+            overlap_count=timeline_summary.overlap_count,
+            dropped_chunk_count=loss_counts.dropped_chunk_count,
+            late_packet_chunk_count=loss_counts.late_packet_chunk_count,
+            queue_overflow_chunk_count=loss_counts.queue_overflow_chunk_count,
+            invalid_chunk_count=loss_counts.invalid_chunk_count,
+            write_error_chunk_count=loss_counts.write_error_chunk_count,
+            timing_fallback_count=windows.timing_fallback_count,
+            sample_rate_mismatch_count=windows.sample_rate_mismatch_count,
+            fft_unusable_window_count=windows.fft_unusable_window_count,
+            sample_rate_unverified_sensor_count=(
+                timeline_summary.sample_rate_unverified_sensor_count
+            ),
+            unanchored_sensor_count=timeline_summary.unanchored_sensor_count,
+            legacy_sensor_count=timeline_summary.legacy_sensor_count,
+            sync_unverified_sensor_count=timeline_summary.sync_unverified_sensor_count,
+            stale_sync_sensor_count=timeline_summary.stale_sync_sensor_count,
+            high_rtt_sensor_count=timeline_summary.high_rtt_sensor_count,
             replay_confidence=replay_confidence,
             raw_capture_mode=raw_capture_mode,
             raw_capture_loss_policy_severity=loss_policy.severity,
@@ -300,32 +271,34 @@ def build_raw_backed_samples(
             raw_capture_loss_policy_max_events_per_minute=(
                 loss_policy.max_sensor_loss_events_per_minute
             ),
-            udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
+            udp_ingest_queue_drop_count=loss_counts.udp_ingest_queue_drop_count,
             warnings=_build_replay_warnings(
-                raw_backed_summary_row_count=raw_backed_count,
-                timing_fallback_count=timing_fallback_count,
-                partial_window_count=partial_window_count,
-                missing_window_count=missing_window_count,
-                gap_count=gap_count,
-                overlap_count=overlap_count,
-                dropped_chunk_count=dropped_chunk_count,
-                late_packet_chunk_count=late_packet_chunk_count,
-                udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
-                queue_overflow_chunk_count=queue_overflow_chunk_count,
-                invalid_chunk_count=invalid_chunk_count,
-                write_error_chunk_count=write_error_chunk_count,
-                sample_rate_mismatch_count=sample_rate_mismatch_count,
-                fft_unusable_window_count=fft_unusable_window_count,
-                sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
-                legacy_sensor_count=legacy_sensor_count,
-                unanchored_sensor_count=unanchored_sensor_count,
-                sync_unverified_sensor_count=sync_unverified_sensor_count,
-                stale_sync_sensor_count=stale_sync_sensor_count,
-                high_rtt_sensor_count=high_rtt_sensor_count,
+                raw_backed_summary_row_count=windows.raw_backed_count,
+                timing_fallback_count=windows.timing_fallback_count,
+                partial_window_count=windows.partial_window_count,
+                missing_window_count=windows.missing_window_count,
+                gap_count=timeline_summary.gap_count,
+                overlap_count=timeline_summary.overlap_count,
+                dropped_chunk_count=loss_counts.dropped_chunk_count,
+                late_packet_chunk_count=loss_counts.late_packet_chunk_count,
+                udp_ingest_queue_drop_count=loss_counts.udp_ingest_queue_drop_count,
+                queue_overflow_chunk_count=loss_counts.queue_overflow_chunk_count,
+                invalid_chunk_count=loss_counts.invalid_chunk_count,
+                write_error_chunk_count=loss_counts.write_error_chunk_count,
+                sample_rate_mismatch_count=windows.sample_rate_mismatch_count,
+                fft_unusable_window_count=windows.fft_unusable_window_count,
+                sample_rate_unverified_sensor_count=(
+                    timeline_summary.sample_rate_unverified_sensor_count
+                ),
+                legacy_sensor_count=timeline_summary.legacy_sensor_count,
+                unanchored_sensor_count=timeline_summary.unanchored_sensor_count,
+                sync_unverified_sensor_count=timeline_summary.sync_unverified_sensor_count,
+                stale_sync_sensor_count=timeline_summary.stale_sync_sensor_count,
+                high_rtt_sensor_count=timeline_summary.high_rtt_sensor_count,
                 loss_policy=loss_policy,
             ),
         ),
-        window_coverages=tuple(coverages),
+        window_coverages=windows.coverages,
     )
 
 
@@ -484,6 +457,178 @@ def _rebuild_sample(
                 else ("timing_fallback" if window.timing_source == "legacy_t_s" else None)
             ),
         ),
+    )
+
+
+def _raw_capture_mode(
+    *,
+    raw_backed_count: int,
+    replay_confidence: RawReplayConfidence,
+) -> RawCaptureMode:
+    if raw_backed_count <= 0:
+        return "summary_only"
+    if replay_confidence == "full":
+        return "raw_backed"
+    return "partial_raw_backed"
+
+
+def _build_raw_capture_unavailable_replay_result(
+    samples: tuple[SensorFrame, ...],
+) -> RawReplayResult:
+    return RawReplayResult(
+        samples=samples,
+        summary=RawReplaySummary(
+            raw_capture_available=False,
+            raw_backed_summary_row_count=0,
+            replay_window_count=len(samples),
+            complete_window_count=0,
+            partial_window_count=0,
+            missing_window_count=len(samples),
+            gap_count=0,
+            overlap_count=0,
+            dropped_chunk_count=0,
+            late_packet_chunk_count=0,
+            queue_overflow_chunk_count=0,
+            invalid_chunk_count=0,
+            write_error_chunk_count=0,
+            timing_fallback_count=0,
+            sample_rate_mismatch_count=0,
+            fft_unusable_window_count=0,
+            sample_rate_unverified_sensor_count=0,
+            unanchored_sensor_count=0,
+            legacy_sensor_count=0,
+            sync_unverified_sensor_count=0,
+            stale_sync_sensor_count=0,
+            high_rtt_sensor_count=0,
+            replay_confidence="unavailable",
+            raw_capture_mode="summary_only",
+            udp_ingest_queue_drop_count=0,
+        ),
+        window_coverages=tuple(
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="missing",
+                raw_backed=False,
+                reason="raw_capture_unavailable",
+            )
+            for sample in samples
+        ),
+    )
+
+
+def _build_replay_context(
+    *,
+    metadata: RunMetadata,
+    raw_capture: RawRunCapture,
+    fft_n: int,
+) -> _ReplayBuildContext:
+    timelines = {
+        sensor.manifest.client_id: _build_sensor_timeline(
+            raw_capture, sensor_id=sensor.manifest.client_id
+        )
+        for sensor in raw_capture.sensors
+    }
+    return _ReplayBuildContext(
+        fft_n=fft_n,
+        timelines=timelines,
+        fft_computer=_build_fft_computer(metadata),
+        accel_scale_g_per_lsb=metadata.accel_scale_g_per_lsb,
+    )
+
+
+def _build_replay_windows(
+    *,
+    samples: tuple[SensorFrame, ...],
+    raw_capture: RawRunCapture,
+    context: _ReplayBuildContext,
+) -> _ReplayWindowBuildResult:
+    replayed: list[SensorFrame] = []
+    coverages: list[RawReplayWindowCoverage] = []
+    raw_backed_count = 0
+    complete_window_count = 0
+    partial_window_count = 0
+    missing_window_count = 0
+    sample_rate_mismatch_count = 0
+    timing_fallback_count = 0
+    fft_unusable_window_count = 0
+    for sample in samples:
+        rebuilt, coverage = _rebuild_sample(
+            sample=sample,
+            timeline=context.timelines.get(sample.client_id),
+            raw_capture=raw_capture,
+            fft_computer=context.fft_computer,
+            fft_n=context.fft_n,
+            accel_scale_g_per_lsb=context.accel_scale_g_per_lsb,
+        )
+        if coverage.raw_backed:
+            raw_backed_count += 1
+        if coverage.coverage_state == "complete":
+            complete_window_count += 1
+        elif coverage.coverage_state == "partial":
+            partial_window_count += 1
+        else:
+            missing_window_count += 1
+        if coverage.reason == "sample_rate_mismatch":
+            sample_rate_mismatch_count += 1
+        if coverage.reason == "timing_fallback":
+            timing_fallback_count += 1
+        if coverage.reason == "fft_no_valid_bins":
+            fft_unusable_window_count += 1
+        replayed.append(rebuilt)
+        coverages.append(coverage)
+    return _ReplayWindowBuildResult(
+        samples=tuple(replayed),
+        coverages=tuple(coverages),
+        raw_backed_count=raw_backed_count,
+        complete_window_count=complete_window_count,
+        partial_window_count=partial_window_count,
+        missing_window_count=missing_window_count,
+        sample_rate_mismatch_count=sample_rate_mismatch_count,
+        timing_fallback_count=timing_fallback_count,
+        fft_unusable_window_count=fft_unusable_window_count,
+    )
+
+
+def _summarize_raw_timelines(
+    *,
+    raw_capture: RawRunCapture,
+    timelines: dict[str, RawSensorTimeline],
+) -> _RawTimelineSummary:
+    return _RawTimelineSummary(
+        gap_count=sum(len(timeline.gap_intervals) for timeline in timelines.values()),
+        overlap_count=sum(len(timeline.overlap_intervals) for timeline in timelines.values()),
+        sample_rate_unverified_sensor_count=sum(
+            1 for sensor in raw_capture.sensors if sensor.manifest.sample_rate_unverified
+        ),
+        unanchored_sensor_count=sum(1 for timeline in timelines.values() if not timeline.anchored),
+        legacy_sensor_count=sum(
+            1 for timeline in timelines.values() if raw_timeline_is_legacy(timeline)
+        ),
+        sync_unverified_sensor_count=sum(
+            1 for timeline in timelines.values() if _timeline_has_unverified_sync(timeline)
+        ),
+        stale_sync_sensor_count=sum(
+            1
+            for timeline in timelines.values()
+            if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "stale_sync"
+        ),
+        high_rtt_sensor_count=sum(
+            1
+            for timeline in timelines.values()
+            if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
+        ),
+    )
+
+
+def _summarize_raw_capture_losses(raw_capture: RawRunCapture) -> _RawCaptureLossCounts:
+    return _RawCaptureLossCounts(
+        dropped_chunk_count=raw_capture.manifest.total_dropped_chunk_count,
+        late_packet_chunk_count=raw_capture.manifest.total_late_packet_chunk_count,
+        queue_overflow_chunk_count=raw_capture.manifest.losses.queue_overflow_chunk_count,
+        invalid_chunk_count=raw_capture.manifest.losses.invalid_chunk_count,
+        write_error_chunk_count=raw_capture.manifest.losses.write_error_chunk_count,
+        udp_ingest_queue_drop_count=raw_capture.manifest.losses.udp_ingest_queue_drop_count,
     )
 
 

--- a/tools/dev/maintainability_allowlist.yml
+++ b/tools/dev/maintainability_allowlist.yml
@@ -20,9 +20,6 @@ functions:
   apps/server/tests_e2e/test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys:
     max_lines: 263
     reason: Docker user journey scenario intentionally keeps full workflow assertions together.
-  apps/server/vibesensor/use_cases/run/raw_capture_replay.py::build_raw_backed_samples:
-    max_lines: 234
-    reason: Raw-capture replay assembly retained until sample-building phases are separated.
   apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py::test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metadata:
     max_lines: 234
     reason: Whole-run order trace persistence scenario kept together to preserve fixture chronology.


### PR DESCRIPTION
## What changed
- Split `build_raw_backed_samples` into replay context, window rebuild, timeline summary, loss summary, mode selection, and result assembly helpers.
- Added direct phase tests for multi-client timeline/window replay and unavailable raw-capture assembly.
- Removed the obsolete maintainability allowlist entry for `build_raw_backed_samples`.

## Why
- Raw replay sample building mixed several phases in one large function.
- Smaller helpers make alignment and fallback behavior easier to test without changing storage or analysis consumers.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py apps/server/tests/use_cases/run/test_raw_capture_replay_sample_rate.py apps/server/tests/use_cases/run/test_raw_capture_replay_phases.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks / edge cases
- No raw capture storage format change.
- No replay output contract change intended.
- Existing missing-sample, multi-client, timestamp-alignment, sample-rate, and fallback cases stay covered.

Fixes #3784