### PR TITLE
Refactor run metadata boundary mapping

### DIFF
--- a/apps/server/tests/shared/boundaries/test_run_metadata_sections.py
+++ b/apps/server/tests/shared/boundaries/test_run_metadata_sections.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.domain import Symptom
+from vibesensor.shared.boundaries.runs._metadata_codecs import (
+    PayloadFieldSpec,
+    decoded_values,
+    float_decoder,
+    include_if_not_none,
+    int_decoder,
+    optional_text_decoder,
+    project_payload_fields,
+    required_text_decoder,
+)
+from vibesensor.shared.boundaries.runs._metadata_sections import (
+    reference_context_to_json_object,
+    reference_tire_circumference,
+    run_finalization_stage_to_json_object,
+    run_finalization_stages_from_payload,
+    run_raw_capture_finalize_from_payload,
+    run_raw_capture_finalize_to_json_object,
+    run_sensor_snapshot_to_json_object,
+    run_sensor_snapshots_from_payload,
+    symptom_from_payload,
+    symptom_to_json_object,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectionFixture:
+    name: str
+    optional_count: int | None
+
+
+def test_metadata_codecs_decode_and_project_fields() -> None:
+    specs = (
+        PayloadFieldSpec("name", "name", required_text_decoder("name", "fallback")),
+        PayloadFieldSpec("count", "count", int_decoder("count"), include=include_if_not_none),
+        PayloadFieldSpec("ratio", "ratio", float_decoder("ratio"), include=include_if_not_none),
+        PayloadFieldSpec(
+            "note",
+            "note",
+            optional_text_decoder("note"),
+            include=include_if_not_none,
+        ),
+    )
+
+    decoded = decoded_values({"count": "7", "ratio": "2.5", "note": ""}, specs)
+    projected = project_payload_fields(
+        _ProjectionFixture(name="sensor", optional_count=None),
+        (
+            PayloadFieldSpec("name", "name", required_text_decoder("name")),
+            PayloadFieldSpec(
+                "optional_count",
+                "optional_count",
+                int_decoder("optional_count"),
+                include=include_if_not_none,
+            ),
+        ),
+    )
+
+    assert decoded == {"name": "fallback", "count": 7, "ratio": 2.5, "note": None}
+    assert projected == {"name": "sensor"}
+
+
+def test_metadata_sections_decode_reference_context_and_symptom() -> None:
+    symptom = symptom_from_payload(
+        {"description": "whine", "onset": "above 60 km/h", "context": "under load"}
+    )
+
+    assert symptom is not None
+    assert symptom.description == "whine"
+    assert reference_tire_circumference({"tire_circumference_m": "2.12"}) == 2.12
+    assert reference_context_to_json_object(2.12) == {"tire_circumference_m": 2.12}
+    assert symptom_to_json_object(symptom) == {
+        "description": "whine",
+        "onset": "above 60 km/h",
+        "context": "under load",
+    }
+    assert symptom_to_json_object(Symptom.unspecified()) is None
+
+
+def test_metadata_sections_decode_sensor_snapshot_map_and_list_payloads() -> None:
+    snapshots = run_sensor_snapshots_from_payload(
+        {
+            "sensor-b": {
+                "client_name": "Rear",
+                "location_code": "rear",
+                "sample_rate_hz": "800",
+            },
+            "sensor-a": {
+                "sensor_id": "sensor-a",
+                "display_name": "Front",
+                "location_code": "front",
+                "mount_orientation": "radial",
+            },
+            "invalid": "skip",
+        }
+    )
+    list_snapshots = run_sensor_snapshots_from_payload(
+        [{"client_id": "sensor-c", "location_code": "center"}]
+    )
+
+    assert [snapshot.sensor_id for snapshot in snapshots] == ["sensor-a", "sensor-b"]
+    assert snapshots[1].display_name == "Rear"
+    assert snapshots[1].sample_rate_hz == 800
+    assert run_sensor_snapshot_to_json_object(snapshots[0]) == {
+        "sensor_id": "sensor-a",
+        "display_name": "Front",
+        "location_code": "front",
+        "mount_orientation": "radial",
+    }
+    assert list_snapshots[0].sensor_id == "sensor-c"
+
+
+def test_metadata_sections_decode_finalize_and_stage_payloads() -> None:
+    finalize = run_raw_capture_finalize_from_payload(
+        {"status": "timeout", "queue_depth": "3", "error_summary": "slow flush"}
+    )
+    invalid_finalize = run_raw_capture_finalize_from_payload({"status": "unknown"})
+    stages = run_finalization_stages_from_payload(
+        [
+            {
+                "stage_name": "FinalizeRawCaptureStage",
+                "status": "degraded",
+                "duration_ms": "-4",
+                "artifacts_created": ["raw_capture_manifest"],
+                "warnings": ["timeout"],
+                "diagnostic_context": {"queue_depth": 3},
+            },
+            {"stage_name": "", "status": "ok", "duration_ms": 1},
+            {"stage_name": "BadStatus", "status": "unknown", "duration_ms": 1},
+        ]
+    )
+
+    assert finalize is not None
+    assert finalize.status == "timeout"
+    assert finalize.queue_depth == 3
+    assert invalid_finalize is None
+    assert run_raw_capture_finalize_to_json_object(finalize) == {
+        "status": "timeout",
+        "queue_depth": 3,
+        "error_summary": "slow flush",
+    }
+    assert len(stages) == 1
+    assert stages[0].duration_ms == 0
+    assert run_finalization_stage_to_json_object(stages[0]) == {
+        "stage_name": "FinalizeRawCaptureStage",
+        "status": "degraded",
+        "duration_ms": 0,
+        "artifacts_created": ["raw_capture_manifest"],
+        "warnings": ["timeout"],
+        "diagnostic_context": {"queue_depth": 3},
+    }

--- a/apps/server/vibesensor/shared/boundaries/runs/_metadata_codecs.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/_metadata_codecs.py
@@ -1,0 +1,150 @@
+"""Shared field-spec codecs for run metadata boundary sections."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
+from vibesensor.shared.time_utils import coerce_utc_offset_seconds
+from vibesensor.shared.types.json_types import JsonObject, is_json_object
+from vibesensor.shared.types.run_schema import (
+    RawCaptureFinalizeStatus,
+    RunFinalizationStageStatus,
+)
+
+type PayloadDecoder = Callable[[Mapping[str, object]], object]
+type IncludePredicate = Callable[[object], bool]
+
+
+def always_include(_value: object) -> bool:
+    return True
+
+
+def include_if_not_none(value: object) -> bool:
+    return value is not None
+
+
+def include_if_nonempty_text(value: object) -> bool:
+    return value is not None and bool(str(value).strip())
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadFieldSpec:
+    payload_key: str
+    field_name: str
+    decode: PayloadDecoder
+    include: IncludePredicate = always_include
+
+
+def required_text_decoder(payload_key: str, default: str = "") -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return text_or_none(payload.get(payload_key)) or default
+
+    return decode
+
+
+def optional_text_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return text_or_none(payload.get(payload_key))
+
+    return decode
+
+
+def int_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return as_int_or_none(payload.get(payload_key))
+
+    return decode
+
+
+def float_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return as_float_or_none(payload.get(payload_key))
+
+    return decode
+
+
+def bool_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return bool(payload.get(payload_key, False))
+
+    return decode
+
+
+def language_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return normalized_language(payload.get(payload_key))
+
+    return decode
+
+
+def utc_offset_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return coerce_utc_offset_seconds(payload.get(payload_key))
+
+    return decode
+
+
+def raw_capture_finalize_status_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        status = text_or_none(payload.get(payload_key))
+        if status not in {"completed", "not_configured", "enqueue_timeout", "timeout", "failed"}:
+            return None
+        return cast(RawCaptureFinalizeStatus, status)
+
+    return decode
+
+
+def finalization_stage_status_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        status = text_or_none(payload.get(payload_key))
+        if status not in {"ok", "skipped", "degraded", "failed"}:
+            return None
+        return cast(RunFinalizationStageStatus, status)
+
+    return decode
+
+
+def tuple_text_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        value = payload.get(payload_key)
+        if not isinstance(value, list):
+            return ()
+        return tuple(text for entry in value if (text := text_or_none(entry)) is not None)
+
+    return decode
+
+
+def json_object_decoder(payload_key: str) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        value = payload.get(payload_key)
+        return value if is_json_object(value) else {}
+
+    return decode
+
+
+def decoded_values(
+    payload: Mapping[str, object],
+    specs: tuple[PayloadFieldSpec, ...],
+) -> dict[str, object]:
+    return {spec.field_name: spec.decode(payload) for spec in specs}
+
+
+def project_payload_fields(
+    source: object,
+    specs: tuple[PayloadFieldSpec, ...],
+) -> JsonObject:
+    payload: dict[str, object] = {}
+    for spec in specs:
+        value = getattr(source, spec.field_name)
+        if spec.include(value):
+            payload[spec.payload_key] = value
+    return cast(JsonObject, payload)
+
+
+def normalized_language(value: object) -> str:
+    text = text_or_none(value)
+    return text.lower() if text is not None else "en"

--- a/apps/server/vibesensor/shared/boundaries/runs/_metadata_sections.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/_metadata_sections.py
@@ -1,0 +1,404 @@
+"""Focused run metadata boundary sections."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from vibesensor.domain import Symptom
+from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.run_schema import (
+    RawCaptureFinalizeStatus,
+    RunFinalizationStageResult,
+    RunFinalizationStageStatus,
+    RunRawCaptureFinalize,
+    RunSensorMetadata,
+)
+
+from ._metadata_codecs import (
+    PayloadDecoder,
+    PayloadFieldSpec,
+    decoded_values,
+    finalization_stage_status_decoder,
+    float_decoder,
+    include_if_nonempty_text,
+    include_if_not_none,
+    int_decoder,
+    json_object_decoder,
+    optional_text_decoder,
+    project_payload_fields,
+    raw_capture_finalize_status_decoder,
+    required_text_decoder,
+    tuple_text_decoder,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ReferenceContextState:
+    wheel_circumference_m: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class _SymptomState:
+    description: str
+    onset: str
+    context: str
+
+
+@dataclass(frozen=True, slots=True)
+class _RunSensorSnapshotState:
+    sensor_id: str
+    display_name: str
+    location_code: str
+    mount_orientation: str | None
+    sample_rate_hz: int | None
+    firmware_version: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RunRawCaptureFinalizeState:
+    status: RawCaptureFinalizeStatus | None
+    queue_depth: int | None
+    error_summary: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RunFinalizationStageResultState:
+    stage_name: str
+    status: RunFinalizationStageStatus | None
+    duration_ms: int
+    artifacts_created: tuple[str, ...]
+    warnings: tuple[str, ...]
+    diagnostic_context: JsonObject
+
+
+_REFERENCE_CONTEXT_FIELD_SPECS: tuple[PayloadFieldSpec, ...] = (
+    PayloadFieldSpec(
+        "tire_circumference_m",
+        "wheel_circumference_m",
+        float_decoder("tire_circumference_m"),
+        include=include_if_not_none,
+    ),
+)
+_SYMPTOM_FIELD_SPECS: tuple[PayloadFieldSpec, ...] = (
+    PayloadFieldSpec("description", "description", required_text_decoder("description")),
+    PayloadFieldSpec(
+        "onset",
+        "onset",
+        required_text_decoder("onset"),
+        include=include_if_nonempty_text,
+    ),
+    PayloadFieldSpec(
+        "context",
+        "context",
+        required_text_decoder("context"),
+        include=include_if_nonempty_text,
+    ),
+)
+_RUN_SENSOR_SNAPSHOT_ENCODE_FIELD_SPECS: tuple[PayloadFieldSpec, ...] = (
+    PayloadFieldSpec("sensor_id", "sensor_id", required_text_decoder("sensor_id")),
+    PayloadFieldSpec("display_name", "display_name", required_text_decoder("display_name")),
+    PayloadFieldSpec("location_code", "location_code", required_text_decoder("location_code")),
+    PayloadFieldSpec(
+        "mount_orientation",
+        "mount_orientation",
+        optional_text_decoder("mount_orientation"),
+        include=include_if_not_none,
+    ),
+    PayloadFieldSpec(
+        "sample_rate_hz",
+        "sample_rate_hz",
+        int_decoder("sample_rate_hz"),
+        include=include_if_not_none,
+    ),
+    PayloadFieldSpec(
+        "firmware_version",
+        "firmware_version",
+        optional_text_decoder("firmware_version"),
+        include=include_if_not_none,
+    ),
+)
+_RUN_RAW_CAPTURE_FINALIZE_FIELD_SPECS: tuple[PayloadFieldSpec, ...] = (
+    PayloadFieldSpec(
+        "status",
+        "status",
+        raw_capture_finalize_status_decoder("status"),
+    ),
+    PayloadFieldSpec(
+        "queue_depth",
+        "queue_depth",
+        int_decoder("queue_depth"),
+        include=include_if_not_none,
+    ),
+    PayloadFieldSpec(
+        "error_summary",
+        "error_summary",
+        optional_text_decoder("error_summary"),
+        include=include_if_not_none,
+    ),
+)
+_RUN_FINALIZATION_STAGE_FIELD_SPECS: tuple[PayloadFieldSpec, ...] = (
+    PayloadFieldSpec("stage_name", "stage_name", required_text_decoder("stage_name")),
+    PayloadFieldSpec("status", "status", finalization_stage_status_decoder("status")),
+    PayloadFieldSpec("duration_ms", "duration_ms", int_decoder("duration_ms")),
+    PayloadFieldSpec(
+        "artifacts_created",
+        "artifacts_created",
+        tuple_text_decoder("artifacts_created"),
+        include=lambda value: bool(value),
+    ),
+    PayloadFieldSpec(
+        "warnings",
+        "warnings",
+        tuple_text_decoder("warnings"),
+        include=lambda value: bool(value),
+    ),
+    PayloadFieldSpec(
+        "diagnostic_context",
+        "diagnostic_context",
+        json_object_decoder("diagnostic_context"),
+        include=lambda value: bool(value),
+    ),
+)
+_REFERENCE_CONTEXT_STATE_FACTORY: Callable[..., _ReferenceContextState] = _ReferenceContextState
+_SYMPTOM_STATE_FACTORY: Callable[..., _SymptomState] = _SymptomState
+_RUN_SENSOR_SNAPSHOT_STATE_FACTORY: Callable[..., _RunSensorSnapshotState] = _RunSensorSnapshotState
+_RUN_RAW_CAPTURE_FINALIZE_STATE_FACTORY: Callable[..., _RunRawCaptureFinalizeState] = (
+    _RunRawCaptureFinalizeState
+)
+_RUN_FINALIZATION_STAGE_RESULT_STATE_FACTORY: Callable[..., _RunFinalizationStageResultState] = (
+    _RunFinalizationStageResultState
+)
+
+
+def reference_tire_circumference(payload: object) -> float | None:
+    if (state := _reference_context_from_payload(payload)) is None:
+        return None
+    return state.wheel_circumference_m
+
+
+def reference_context_to_json_object(wheel_circumference_m: float | None) -> JsonObject | None:
+    if wheel_circumference_m is None:
+        return None
+    return project_payload_fields(
+        _ReferenceContextState(wheel_circumference_m=wheel_circumference_m),
+        _REFERENCE_CONTEXT_FIELD_SPECS,
+    )
+
+
+def symptom_from_payload(payload: object) -> Symptom | None:
+    state = _symptom_state_from_mapping(payload)
+    if state is None:
+        return None
+    return Symptom(
+        description=state.description,
+        onset=state.onset,
+        context=state.context,
+    )
+
+
+def symptom_to_json_object(symptom: Symptom | None) -> JsonObject | None:
+    if symptom is None or symptom.is_unspecified:
+        return None
+    return project_payload_fields(symptom, _SYMPTOM_FIELD_SPECS)
+
+
+def run_sensor_snapshots_from_payload(payload: object) -> tuple[RunSensorMetadata, ...]:
+    records: list[RunSensorMetadata] = []
+    if isinstance(payload, Mapping):
+        iterable: list[tuple[object, object]] = list(payload.items())
+        for sensor_id, entry in iterable:
+            if not isinstance(entry, Mapping):
+                continue
+            snapshot = _run_sensor_snapshot_from_mapping(entry, fallback_sensor_id=sensor_id)
+            if snapshot is not None:
+                records.append(snapshot)
+    elif isinstance(payload, list):
+        for entry in payload:
+            snapshot = _run_sensor_snapshot_from_mapping(entry)
+            if snapshot is not None:
+                records.append(snapshot)
+    records.sort(key=lambda snapshot: snapshot.sensor_id)
+    return tuple(records)
+
+
+def run_sensor_snapshot_to_json_object(snapshot: RunSensorMetadata) -> JsonObject:
+    return project_payload_fields(snapshot, _RUN_SENSOR_SNAPSHOT_ENCODE_FIELD_SPECS)
+
+
+def run_raw_capture_finalize_from_payload(payload: object) -> RunRawCaptureFinalize | None:
+    state = _run_raw_capture_finalize_state_from_mapping(payload)
+    if state is None or state.status is None:
+        return None
+    return RunRawCaptureFinalize(
+        status=state.status,
+        queue_depth=state.queue_depth,
+        error_summary=state.error_summary,
+    )
+
+
+def run_raw_capture_finalize_to_json_object(
+    finalize: RunRawCaptureFinalize,
+) -> JsonObject:
+    return project_payload_fields(finalize, _RUN_RAW_CAPTURE_FINALIZE_FIELD_SPECS)
+
+
+def run_finalization_stages_from_payload(
+    payload: object,
+) -> tuple[RunFinalizationStageResult, ...]:
+    if not isinstance(payload, list):
+        return ()
+    stages: list[RunFinalizationStageResult] = []
+    for entry in payload:
+        stage = _run_finalization_stage_from_payload(entry)
+        if stage is not None:
+            stages.append(stage)
+    return tuple(stages)
+
+
+def run_finalization_stage_to_json_object(
+    stage: RunFinalizationStageResult,
+) -> JsonObject:
+    return stage.to_json_object()
+
+
+def _reference_context_from_payload(payload: object) -> _ReferenceContextState | None:
+    if not isinstance(payload, Mapping):
+        return None
+    return _REFERENCE_CONTEXT_STATE_FACTORY(
+        **decoded_values(payload, _REFERENCE_CONTEXT_FIELD_SPECS)
+    )
+
+
+def _symptom_state_from_mapping(payload: object) -> _SymptomState | None:
+    if not isinstance(payload, Mapping):
+        return None
+    state = _SYMPTOM_STATE_FACTORY(**decoded_values(payload, _SYMPTOM_FIELD_SPECS))
+    if not state.description:
+        return None
+    return state
+
+
+def _sensor_id_decoder(*, fallback_sensor_id: object = None) -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return (
+            text_or_none(payload.get("sensor_id"))
+            or text_or_none(payload.get("client_id"))
+            or text_or_none(fallback_sensor_id)
+            or ""
+        )
+
+    return decode
+
+
+def _display_name_decoder() -> PayloadDecoder:
+    def decode(payload: Mapping[str, object]) -> object:
+        return (
+            text_or_none(payload.get("display_name"))
+            or text_or_none(payload.get("client_name"))
+            or ""
+        )
+
+    return decode
+
+
+def _run_sensor_snapshot_decode_field_specs(
+    *,
+    fallback_sensor_id: object = None,
+) -> tuple[PayloadFieldSpec, ...]:
+    return (
+        PayloadFieldSpec(
+            "sensor_id",
+            "sensor_id",
+            _sensor_id_decoder(fallback_sensor_id=fallback_sensor_id),
+        ),
+        PayloadFieldSpec("display_name", "display_name", _display_name_decoder()),
+        PayloadFieldSpec("location_code", "location_code", required_text_decoder("location_code")),
+        PayloadFieldSpec(
+            "mount_orientation",
+            "mount_orientation",
+            optional_text_decoder("mount_orientation"),
+        ),
+        PayloadFieldSpec("sample_rate_hz", "sample_rate_hz", int_decoder("sample_rate_hz")),
+        PayloadFieldSpec(
+            "firmware_version",
+            "firmware_version",
+            optional_text_decoder("firmware_version"),
+        ),
+    )
+
+
+def _run_sensor_snapshot_from_mapping(
+    payload: object,
+    *,
+    fallback_sensor_id: object = None,
+) -> RunSensorMetadata | None:
+    state = _run_sensor_snapshot_state_from_mapping(
+        payload,
+        fallback_sensor_id=fallback_sensor_id,
+    )
+    if state is None:
+        return None
+    return RunSensorMetadata(
+        sensor_id=state.sensor_id,
+        display_name=state.display_name,
+        location_code=state.location_code,
+        mount_orientation=state.mount_orientation,
+        sample_rate_hz=state.sample_rate_hz,
+        firmware_version=state.firmware_version,
+    )
+
+
+def _run_sensor_snapshot_state_from_mapping(
+    payload: object,
+    *,
+    fallback_sensor_id: object = None,
+) -> _RunSensorSnapshotState | None:
+    if not isinstance(payload, Mapping):
+        return None
+    state = _RUN_SENSOR_SNAPSHOT_STATE_FACTORY(
+        **decoded_values(
+            payload,
+            _run_sensor_snapshot_decode_field_specs(
+                fallback_sensor_id=fallback_sensor_id,
+            ),
+        )
+    )
+    if not state.sensor_id:
+        return None
+    return state
+
+
+def _run_raw_capture_finalize_state_from_mapping(
+    payload: object,
+) -> _RunRawCaptureFinalizeState | None:
+    if not isinstance(payload, Mapping):
+        return None
+    state = _RUN_RAW_CAPTURE_FINALIZE_STATE_FACTORY(
+        **decoded_values(payload, _RUN_RAW_CAPTURE_FINALIZE_FIELD_SPECS),
+    )
+    if state.status is None:
+        return None
+    return state
+
+
+def _run_finalization_stage_from_payload(
+    payload: object,
+) -> RunFinalizationStageResult | None:
+    if not isinstance(payload, Mapping):
+        return None
+    state = _RUN_FINALIZATION_STAGE_RESULT_STATE_FACTORY(
+        **decoded_values(payload, _RUN_FINALIZATION_STAGE_FIELD_SPECS)
+    )
+    if not state.stage_name or state.status is None:
+        return None
+    duration_ms = state.duration_ms if isinstance(state.duration_ms, int) else 0
+    return RunFinalizationStageResult(
+        stage_name=state.stage_name,
+        status=state.status,
+        duration_ms=max(0, duration_ms),
+        artifacts_created=state.artifacts_created,
+        warnings=state.warnings,
+        diagnostic_context=state.diagnostic_context,
+    )

--- a/apps/server/vibesensor/shared/boundaries/runs/metadata.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/metadata.py
@@ -5,33 +5,48 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import cast
 
 import msgspec
 
-from vibesensor.domain import Symptom
 from vibesensor.shared.boundaries.codecs import (
     analysis_settings_snapshot_from_mapping,
     analysis_settings_snapshot_to_metadata,
 )
-from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.boundaries.runs._metadata_codecs import (
+    PayloadFieldSpec,
+    bool_decoder,
+    decoded_values,
+    float_decoder,
+    include_if_not_none,
+    int_decoder,
+    language_decoder,
+    optional_text_decoder,
+    project_payload_fields,
+    required_text_decoder,
+    utc_offset_decoder,
+)
+from vibesensor.shared.boundaries.runs._metadata_sections import (
+    reference_context_to_json_object,
+    reference_tire_circumference,
+    run_finalization_stage_to_json_object,
+    run_finalization_stages_from_payload,
+    run_raw_capture_finalize_from_payload,
+    run_raw_capture_finalize_to_json_object,
+    run_sensor_snapshot_to_json_object,
+    run_sensor_snapshots_from_payload,
+    symptom_from_payload,
+    symptom_to_json_object,
+)
 from vibesensor.shared.boundaries.runs.car import (
     run_car_metadata_from_mapping,
     run_car_metadata_to_json_object,
 )
-from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
-from vibesensor.shared.time_utils import coerce_utc_offset_seconds
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.shared.types.run_schema import (
     PEAK_PICKER_METHOD,
     RUN_METADATA_TYPE,
     RUN_SCHEMA_VERSION,
-    RawCaptureFinalizeStatus,
-    RunFinalizationStageResult,
-    RunFinalizationStageStatus,
     RunMetadata,
-    RunRawCaptureFinalize,
-    RunSensorMetadata,
 )
 
 __all__ = [
@@ -80,30 +95,6 @@ class _RunMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
     recorded_utc_offset_seconds: object = None
 
 
-type _PayloadDecoder = Callable[[Mapping[str, object]], object]
-type _IncludePredicate = Callable[[object], bool]
-
-
-def _always_include(_value: object) -> bool:
-    return True
-
-
-def _include_if_not_none(value: object) -> bool:
-    return value is not None
-
-
-def _include_if_nonempty_text(value: object) -> bool:
-    return value is not None and bool(str(value).strip())
-
-
-@dataclass(frozen=True, slots=True)
-class _PayloadFieldSpec:
-    payload_key: str
-    field_name: str
-    decode: _PayloadDecoder
-    include: _IncludePredicate = _always_include
-
-
 @dataclass(frozen=True, slots=True)
 class _RunMetadataScalarState:
     record_type: str
@@ -132,406 +123,103 @@ class _RunMetadataScalarState:
     recorded_utc_offset_seconds: int | None
 
 
-@dataclass(frozen=True, slots=True)
-class _ReferenceContextState:
-    wheel_circumference_m: float | None
-
-
-@dataclass(frozen=True, slots=True)
-class _SymptomState:
-    description: str
-    onset: str
-    context: str
-
-
-@dataclass(frozen=True, slots=True)
-class _RunSensorSnapshotState:
-    sensor_id: str
-    display_name: str
-    location_code: str
-    mount_orientation: str | None
-    sample_rate_hz: int | None
-    firmware_version: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class _RunRawCaptureFinalizeState:
-    status: RawCaptureFinalizeStatus | None
-    queue_depth: int | None
-    error_summary: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class _RunFinalizationStageResultState:
-    stage_name: str
-    status: RunFinalizationStageStatus | None
-    duration_ms: int
-    artifacts_created: tuple[str, ...]
-    warnings: tuple[str, ...]
-    diagnostic_context: JsonObject
-
-
-def _required_text_decoder(payload_key: str, default: str = "") -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return text_or_none(payload.get(payload_key)) or default
-
-    return decode
-
-
-def _optional_text_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return text_or_none(payload.get(payload_key))
-
-    return decode
-
-
-def _int_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return as_int_or_none(payload.get(payload_key))
-
-    return decode
-
-
-def _float_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return as_float_or_none(payload.get(payload_key))
-
-    return decode
-
-
-def _bool_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return bool(payload.get(payload_key, False))
-
-    return decode
-
-
-def _language_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return _normalized_language(payload.get(payload_key))
-
-    return decode
-
-
-def _utc_offset_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return coerce_utc_offset_seconds(payload.get(payload_key))
-
-    return decode
-
-
-def _raw_capture_finalize_status_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        status = text_or_none(payload.get(payload_key))
-        if status not in {"completed", "not_configured", "enqueue_timeout", "timeout", "failed"}:
-            return None
-        return cast(RawCaptureFinalizeStatus, status)
-
-    return decode
-
-
-def _finalization_stage_status_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        status = text_or_none(payload.get(payload_key))
-        if status not in {"ok", "skipped", "degraded", "failed"}:
-            return None
-        return cast(RunFinalizationStageStatus, status)
-
-    return decode
-
-
-def _tuple_text_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        value = payload.get(payload_key)
-        if not isinstance(value, list):
-            return ()
-        return tuple(text for entry in value if (text := text_or_none(entry)) is not None)
-
-    return decode
-
-
-def _json_object_decoder(payload_key: str) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        value = payload.get(payload_key)
-        return value if is_json_object(value) else {}
-
-    return decode
-
-
-_RUN_METADATA_SCALAR_FIELD_SPECS: tuple[_PayloadFieldSpec, ...] = (
-    _PayloadFieldSpec(
+_RUN_METADATA_SCALAR_FIELD_SPECS: tuple[PayloadFieldSpec, ...] = (
+    PayloadFieldSpec(
         "record_type",
         "record_type",
-        _required_text_decoder("record_type", RUN_METADATA_TYPE),
+        required_text_decoder("record_type", RUN_METADATA_TYPE),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "schema_version",
         "schema_version",
-        _required_text_decoder("schema_version", RUN_SCHEMA_VERSION),
+        required_text_decoder("schema_version", RUN_SCHEMA_VERSION),
     ),
-    _PayloadFieldSpec("run_id", "run_id", _required_text_decoder("run_id")),
-    _PayloadFieldSpec(
+    PayloadFieldSpec("run_id", "run_id", required_text_decoder("run_id")),
+    PayloadFieldSpec(
         "start_time_utc",
         "start_time_utc",
-        _required_text_decoder("start_time_utc"),
+        required_text_decoder("start_time_utc"),
     ),
-    _PayloadFieldSpec("end_time_utc", "end_time_utc", _optional_text_decoder("end_time_utc")),
-    _PayloadFieldSpec(
+    PayloadFieldSpec("end_time_utc", "end_time_utc", optional_text_decoder("end_time_utc")),
+    PayloadFieldSpec(
         "sensor_model",
         "sensor_model",
-        _required_text_decoder("sensor_model", "unknown"),
+        required_text_decoder("sensor_model", "unknown"),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "firmware_version",
         "firmware_version",
-        _optional_text_decoder("firmware_version"),
+        optional_text_decoder("firmware_version"),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "strength_algorithm_version",
         "strength_algorithm_version",
-        _optional_text_decoder("strength_algorithm_version"),
+        optional_text_decoder("strength_algorithm_version"),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "peak_detector_version",
         "peak_detector_version",
-        _optional_text_decoder("peak_detector_version"),
+        optional_text_decoder("peak_detector_version"),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "calibration_profile_id",
         "calibration_profile_id",
-        _optional_text_decoder("calibration_profile_id"),
+        optional_text_decoder("calibration_profile_id"),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "vehicle_baseline_profile_id",
         "vehicle_baseline_profile_id",
-        _optional_text_decoder("vehicle_baseline_profile_id"),
+        optional_text_decoder("vehicle_baseline_profile_id"),
     ),
-    _PayloadFieldSpec(
-        "raw_sample_rate_hz", "raw_sample_rate_hz", _int_decoder("raw_sample_rate_hz")
-    ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec("raw_sample_rate_hz", "raw_sample_rate_hz", int_decoder("raw_sample_rate_hz")),
+    PayloadFieldSpec(
         "configured_raw_sample_rate_hz",
         "configured_raw_sample_rate_hz",
-        _int_decoder("configured_raw_sample_rate_hz"),
+        int_decoder("configured_raw_sample_rate_hz"),
     ),
-    _PayloadFieldSpec(
-        "feature_interval_s", "feature_interval_s", _float_decoder("feature_interval_s")
+    PayloadFieldSpec(
+        "feature_interval_s", "feature_interval_s", float_decoder("feature_interval_s")
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "fft_window_size_samples",
         "fft_window_size_samples",
-        _int_decoder("fft_window_size_samples"),
+        int_decoder("fft_window_size_samples"),
     ),
-    _PayloadFieldSpec(
-        "fft_window_type", "fft_window_type", _optional_text_decoder("fft_window_type")
+    PayloadFieldSpec(
+        "fft_window_type", "fft_window_type", optional_text_decoder("fft_window_type")
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "peak_picker_method",
         "peak_picker_method",
-        _required_text_decoder("peak_picker_method", PEAK_PICKER_METHOD),
+        required_text_decoder("peak_picker_method", PEAK_PICKER_METHOD),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "accel_scale_g_per_lsb",
         "accel_scale_g_per_lsb",
-        _float_decoder("accel_scale_g_per_lsb"),
+        float_decoder("accel_scale_g_per_lsb"),
     ),
-    _PayloadFieldSpec(
+    PayloadFieldSpec(
         "incomplete_for_order_analysis",
         "incomplete_for_order_analysis",
-        _bool_decoder("incomplete_for_order_analysis"),
+        bool_decoder("incomplete_for_order_analysis"),
     ),
-    _PayloadFieldSpec("case_id", "case_id", _required_text_decoder("case_id")),
-    _PayloadFieldSpec("sensor_mac", "sensor_mac", _optional_text_decoder("sensor_mac")),
-    _PayloadFieldSpec("report_date", "report_date", _optional_text_decoder("report_date")),
-    _PayloadFieldSpec("language", "language", _language_decoder("language")),
-    _PayloadFieldSpec(
+    PayloadFieldSpec("case_id", "case_id", required_text_decoder("case_id")),
+    PayloadFieldSpec("sensor_mac", "sensor_mac", optional_text_decoder("sensor_mac")),
+    PayloadFieldSpec("report_date", "report_date", optional_text_decoder("report_date")),
+    PayloadFieldSpec("language", "language", language_decoder("language")),
+    PayloadFieldSpec(
         "recorded_utc_offset_seconds",
         "recorded_utc_offset_seconds",
-        _utc_offset_decoder("recorded_utc_offset_seconds"),
-        include=_include_if_not_none,
-    ),
-)
-_REFERENCE_CONTEXT_FIELD_SPECS: tuple[_PayloadFieldSpec, ...] = (
-    _PayloadFieldSpec(
-        "tire_circumference_m",
-        "wheel_circumference_m",
-        _float_decoder("tire_circumference_m"),
-        include=_include_if_not_none,
-    ),
-)
-_SYMPTOM_FIELD_SPECS: tuple[_PayloadFieldSpec, ...] = (
-    _PayloadFieldSpec("description", "description", _required_text_decoder("description")),
-    _PayloadFieldSpec(
-        "onset",
-        "onset",
-        _required_text_decoder("onset"),
-        include=_include_if_nonempty_text,
-    ),
-    _PayloadFieldSpec(
-        "context",
-        "context",
-        _required_text_decoder("context"),
-        include=_include_if_nonempty_text,
-    ),
-)
-_RUN_SENSOR_SNAPSHOT_ENCODE_FIELD_SPECS: tuple[_PayloadFieldSpec, ...] = (
-    _PayloadFieldSpec("sensor_id", "sensor_id", _required_text_decoder("sensor_id")),
-    _PayloadFieldSpec("display_name", "display_name", _required_text_decoder("display_name")),
-    _PayloadFieldSpec("location_code", "location_code", _required_text_decoder("location_code")),
-    _PayloadFieldSpec(
-        "mount_orientation",
-        "mount_orientation",
-        _optional_text_decoder("mount_orientation"),
-        include=_include_if_not_none,
-    ),
-    _PayloadFieldSpec(
-        "sample_rate_hz",
-        "sample_rate_hz",
-        _int_decoder("sample_rate_hz"),
-        include=_include_if_not_none,
-    ),
-    _PayloadFieldSpec(
-        "firmware_version",
-        "firmware_version",
-        _optional_text_decoder("firmware_version"),
-        include=_include_if_not_none,
-    ),
-)
-_RUN_RAW_CAPTURE_FINALIZE_FIELD_SPECS: tuple[_PayloadFieldSpec, ...] = (
-    _PayloadFieldSpec(
-        "status",
-        "status",
-        _raw_capture_finalize_status_decoder("status"),
-    ),
-    _PayloadFieldSpec(
-        "queue_depth",
-        "queue_depth",
-        _int_decoder("queue_depth"),
-        include=_include_if_not_none,
-    ),
-    _PayloadFieldSpec(
-        "error_summary",
-        "error_summary",
-        _optional_text_decoder("error_summary"),
-        include=_include_if_not_none,
-    ),
-)
-_RUN_FINALIZATION_STAGE_FIELD_SPECS: tuple[_PayloadFieldSpec, ...] = (
-    _PayloadFieldSpec("stage_name", "stage_name", _required_text_decoder("stage_name")),
-    _PayloadFieldSpec("status", "status", _finalization_stage_status_decoder("status")),
-    _PayloadFieldSpec("duration_ms", "duration_ms", _int_decoder("duration_ms")),
-    _PayloadFieldSpec(
-        "artifacts_created",
-        "artifacts_created",
-        _tuple_text_decoder("artifacts_created"),
-        include=lambda value: bool(value),
-    ),
-    _PayloadFieldSpec(
-        "warnings",
-        "warnings",
-        _tuple_text_decoder("warnings"),
-        include=lambda value: bool(value),
-    ),
-    _PayloadFieldSpec(
-        "diagnostic_context",
-        "diagnostic_context",
-        _json_object_decoder("diagnostic_context"),
-        include=lambda value: bool(value),
+        utc_offset_decoder("recorded_utc_offset_seconds"),
+        include=include_if_not_none,
     ),
 )
 _RUN_METADATA_SCALAR_STATE_FACTORY: Callable[..., _RunMetadataScalarState] = _RunMetadataScalarState
-_REFERENCE_CONTEXT_STATE_FACTORY: Callable[..., _ReferenceContextState] = _ReferenceContextState
-_SYMPTOM_STATE_FACTORY: Callable[..., _SymptomState] = _SymptomState
-_RUN_SENSOR_SNAPSHOT_STATE_FACTORY: Callable[..., _RunSensorSnapshotState] = _RunSensorSnapshotState
-_RUN_RAW_CAPTURE_FINALIZE_STATE_FACTORY: Callable[..., _RunRawCaptureFinalizeState] = (
-    _RunRawCaptureFinalizeState
-)
-_RUN_FINALIZATION_STAGE_RESULT_STATE_FACTORY: Callable[..., _RunFinalizationStageResultState] = (
-    _RunFinalizationStageResultState
-)
-
-
-def _decoded_values(
-    payload: Mapping[str, object],
-    specs: tuple[_PayloadFieldSpec, ...],
-) -> dict[str, object]:
-    return {spec.field_name: spec.decode(payload) for spec in specs}
-
-
-def _project_payload_fields(
-    source: object,
-    specs: tuple[_PayloadFieldSpec, ...],
-) -> JsonObject:
-    payload: dict[str, object] = {}
-    for spec in specs:
-        value = getattr(source, spec.field_name)
-        if spec.include(value):
-            payload[spec.payload_key] = value
-    return cast(JsonObject, payload)
 
 
 def _run_metadata_scalar_state_from_mapping(data: Mapping[str, object]) -> _RunMetadataScalarState:
     return _RUN_METADATA_SCALAR_STATE_FACTORY(
-        **_decoded_values(data, _RUN_METADATA_SCALAR_FIELD_SPECS),
-    )
-
-
-def _reference_context_state_from_mapping(
-    payload: Mapping[str, object],
-) -> _ReferenceContextState:
-    return _REFERENCE_CONTEXT_STATE_FACTORY(
-        **_decoded_values(payload, _REFERENCE_CONTEXT_FIELD_SPECS),
-    )
-
-
-def _sensor_id_decoder(*, fallback_sensor_id: object = None) -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return (
-            text_or_none(payload.get("sensor_id"))
-            or text_or_none(payload.get("client_id"))
-            or text_or_none(fallback_sensor_id)
-            or ""
-        )
-
-    return decode
-
-
-def _display_name_decoder() -> _PayloadDecoder:
-    def decode(payload: Mapping[str, object]) -> object:
-        return (
-            text_or_none(payload.get("display_name"))
-            or text_or_none(payload.get("client_name"))
-            or ""
-        )
-
-    return decode
-
-
-def _run_sensor_snapshot_decode_field_specs(
-    *,
-    fallback_sensor_id: object = None,
-) -> tuple[_PayloadFieldSpec, ...]:
-    return (
-        _PayloadFieldSpec(
-            "sensor_id",
-            "sensor_id",
-            _sensor_id_decoder(fallback_sensor_id=fallback_sensor_id),
-        ),
-        _PayloadFieldSpec("display_name", "display_name", _display_name_decoder()),
-        _PayloadFieldSpec(
-            "location_code", "location_code", _required_text_decoder("location_code")
-        ),
-        _PayloadFieldSpec(
-            "mount_orientation",
-            "mount_orientation",
-            _optional_text_decoder("mount_orientation"),
-        ),
-        _PayloadFieldSpec("sample_rate_hz", "sample_rate_hz", _int_decoder("sample_rate_hz")),
-        _PayloadFieldSpec(
-            "firmware_version",
-            "firmware_version",
-            _optional_text_decoder("firmware_version"),
-        ),
+        **decoded_values(data, _RUN_METADATA_SCALAR_FIELD_SPECS),
     )
 
 
@@ -577,17 +265,17 @@ def run_metadata_from_mapping(data: Mapping[str, object]) -> RunMetadata:
             data.get("analysis_settings_snapshot"),
         ),
         car=run_car_metadata_from_mapping(data.get("active_car_snapshot")),
-        sensor_snapshots=_run_sensor_snapshots_from_payload(data.get("sensor_snapshots")),
-        raw_capture_finalize=_run_raw_capture_finalize_from_payload(
+        sensor_snapshots=run_sensor_snapshots_from_payload(data.get("sensor_snapshots")),
+        raw_capture_finalize=run_raw_capture_finalize_from_payload(
             data.get("raw_capture_finalize")
         ),
-        finalization_stages=_run_finalization_stages_from_payload(data.get("finalization_stages")),
+        finalization_stages=run_finalization_stages_from_payload(data.get("finalization_stages")),
         case_id=scalar_state.case_id,
         sensor_mac=scalar_state.sensor_mac,
-        symptom=_symptom_from_payload(data.get("symptom")),
+        symptom=symptom_from_payload(data.get("symptom")),
         report_date=scalar_state.report_date,
         language=scalar_state.language,
-        wheel_circumference_m=_reference_tire_circumference(data.get("reference_context")),
+        wheel_circumference_m=reference_tire_circumference(data.get("reference_context")),
         recorded_utc_offset_seconds=scalar_state.recorded_utc_offset_seconds,
     )
 
@@ -595,7 +283,7 @@ def run_metadata_from_mapping(data: Mapping[str, object]) -> RunMetadata:
 def run_metadata_to_json_object(metadata: RunMetadata) -> JsonObject:
     """Project typed run metadata to the canonical JSON-safe storage payload."""
 
-    payload = _project_payload_fields(metadata, _RUN_METADATA_SCALAR_FIELD_SPECS)
+    payload = project_payload_fields(metadata, _RUN_METADATA_SCALAR_FIELD_SPECS)
     payload["analysis_settings_snapshot"] = analysis_settings_snapshot_to_metadata(
         metadata.analysis_settings,
     )
@@ -603,20 +291,20 @@ def run_metadata_to_json_object(metadata: RunMetadata) -> JsonObject:
         payload["active_car_snapshot"] = car_metadata
     if metadata.sensor_snapshots:
         payload["sensor_snapshots"] = [
-            _run_sensor_snapshot_to_json_object(snapshot) for snapshot in metadata.sensor_snapshots
+            run_sensor_snapshot_to_json_object(snapshot) for snapshot in metadata.sensor_snapshots
         ]
     if metadata.raw_capture_finalize is not None:
-        payload["raw_capture_finalize"] = _run_raw_capture_finalize_to_json_object(
+        payload["raw_capture_finalize"] = run_raw_capture_finalize_to_json_object(
             metadata.raw_capture_finalize
         )
     if metadata.finalization_stages:
         payload["finalization_stages"] = [
-            _run_finalization_stage_to_json_object(stage) for stage in metadata.finalization_stages
+            run_finalization_stage_to_json_object(stage) for stage in metadata.finalization_stages
         ]
-    if (symptom := _symptom_to_json_object(metadata.symptom)) is not None:
+    if (symptom := symptom_to_json_object(metadata.symptom)) is not None:
         payload["symptom"] = symptom
     if (
-        reference_context := _reference_context_to_json_object(metadata.wheel_circumference_m)
+        reference_context := reference_context_to_json_object(metadata.wheel_circumference_m)
     ) is not None:
         payload["reference_context"] = reference_context
     return payload
@@ -631,189 +319,3 @@ def run_metadata_to_json_bytes(metadata: RunMetadata) -> bytes:
         strict=False,
     )
     return msgspec.json.encode(record)
-
-
-def _normalized_language(value: object) -> str:
-    text = text_or_none(value)
-    return text.lower() if text is not None else "en"
-
-
-def _symptom_from_payload(payload: object) -> Symptom | None:
-    state = _symptom_state_from_mapping(payload)
-    if state is None:
-        return None
-    return Symptom(
-        description=state.description,
-        onset=state.onset,
-        context=state.context,
-    )
-
-
-def _symptom_state_from_mapping(payload: object) -> _SymptomState | None:
-    if not isinstance(payload, Mapping):
-        return None
-    state = _SYMPTOM_STATE_FACTORY(**_decoded_values(payload, _SYMPTOM_FIELD_SPECS))
-    if not state.description:
-        return None
-    return state
-
-
-def _symptom_to_json_object(symptom: Symptom | None) -> JsonObject | None:
-    if symptom is None or symptom.is_unspecified:
-        return None
-    return _project_payload_fields(symptom, _SYMPTOM_FIELD_SPECS)
-
-
-def _reference_tire_circumference(payload: object) -> float | None:
-    if (state := _reference_context_from_payload(payload)) is None:
-        return None
-    return state.wheel_circumference_m
-
-
-def _reference_context_from_payload(payload: object) -> _ReferenceContextState | None:
-    if not isinstance(payload, Mapping):
-        return None
-    return _reference_context_state_from_mapping(payload)
-
-
-def _reference_context_to_json_object(wheel_circumference_m: float | None) -> JsonObject | None:
-    if wheel_circumference_m is None:
-        return None
-    return _project_payload_fields(
-        _ReferenceContextState(wheel_circumference_m=wheel_circumference_m),
-        _REFERENCE_CONTEXT_FIELD_SPECS,
-    )
-
-
-def _run_sensor_snapshots_from_payload(payload: object) -> tuple[RunSensorMetadata, ...]:
-    records: list[RunSensorMetadata] = []
-    if isinstance(payload, Mapping):
-        iterable: list[tuple[object, object]] = list(payload.items())
-        for sensor_id, entry in iterable:
-            if not isinstance(entry, Mapping):
-                continue
-            snapshot = _run_sensor_snapshot_from_mapping(entry, fallback_sensor_id=sensor_id)
-            if snapshot is not None:
-                records.append(snapshot)
-    elif isinstance(payload, list):
-        for entry in payload:
-            snapshot = _run_sensor_snapshot_from_mapping(entry)
-            if snapshot is not None:
-                records.append(snapshot)
-    records.sort(key=lambda snapshot: snapshot.sensor_id)
-    return tuple(records)
-
-
-def _run_sensor_snapshot_from_mapping(
-    payload: object,
-    *,
-    fallback_sensor_id: object = None,
-) -> RunSensorMetadata | None:
-    state = _run_sensor_snapshot_state_from_mapping(
-        payload,
-        fallback_sensor_id=fallback_sensor_id,
-    )
-    if state is None:
-        return None
-    return RunSensorMetadata(
-        sensor_id=state.sensor_id,
-        display_name=state.display_name,
-        location_code=state.location_code,
-        mount_orientation=state.mount_orientation,
-        sample_rate_hz=state.sample_rate_hz,
-        firmware_version=state.firmware_version,
-    )
-
-
-def _run_sensor_snapshot_state_from_mapping(
-    payload: object,
-    *,
-    fallback_sensor_id: object = None,
-) -> _RunSensorSnapshotState | None:
-    if not isinstance(payload, Mapping):
-        return None
-    state = _RUN_SENSOR_SNAPSHOT_STATE_FACTORY(
-        **_decoded_values(
-            payload,
-            _run_sensor_snapshot_decode_field_specs(
-                fallback_sensor_id=fallback_sensor_id,
-            ),
-        )
-    )
-    if not state.sensor_id:
-        return None
-    return state
-
-
-def _run_sensor_snapshot_to_json_object(snapshot: RunSensorMetadata) -> JsonObject:
-    return _project_payload_fields(snapshot, _RUN_SENSOR_SNAPSHOT_ENCODE_FIELD_SPECS)
-
-
-def _run_raw_capture_finalize_from_payload(payload: object) -> RunRawCaptureFinalize | None:
-    state = _run_raw_capture_finalize_state_from_mapping(payload)
-    if state is None or state.status is None:
-        return None
-    return RunRawCaptureFinalize(
-        status=state.status,
-        queue_depth=state.queue_depth,
-        error_summary=state.error_summary,
-    )
-
-
-def _run_raw_capture_finalize_state_from_mapping(
-    payload: object,
-) -> _RunRawCaptureFinalizeState | None:
-    if not isinstance(payload, Mapping):
-        return None
-    state = _RUN_RAW_CAPTURE_FINALIZE_STATE_FACTORY(
-        **_decoded_values(payload, _RUN_RAW_CAPTURE_FINALIZE_FIELD_SPECS),
-    )
-    if state.status is None:
-        return None
-    return state
-
-
-def _run_raw_capture_finalize_to_json_object(
-    finalize: RunRawCaptureFinalize,
-) -> JsonObject:
-    return _project_payload_fields(finalize, _RUN_RAW_CAPTURE_FINALIZE_FIELD_SPECS)
-
-
-def _run_finalization_stages_from_payload(
-    payload: object,
-) -> tuple[RunFinalizationStageResult, ...]:
-    if not isinstance(payload, list):
-        return ()
-    stages: list[RunFinalizationStageResult] = []
-    for entry in payload:
-        stage = _run_finalization_stage_from_payload(entry)
-        if stage is not None:
-            stages.append(stage)
-    return tuple(stages)
-
-
-def _run_finalization_stage_from_payload(
-    payload: object,
-) -> RunFinalizationStageResult | None:
-    if not isinstance(payload, Mapping):
-        return None
-    state = _RUN_FINALIZATION_STAGE_RESULT_STATE_FACTORY(
-        **_decoded_values(payload, _RUN_FINALIZATION_STAGE_FIELD_SPECS)
-    )
-    if not state.stage_name or state.status is None:
-        return None
-    duration_ms = state.duration_ms if isinstance(state.duration_ms, int) else 0
-    return RunFinalizationStageResult(
-        stage_name=state.stage_name,
-        status=state.status,
-        duration_ms=max(0, duration_ms),
-        artifacts_created=state.artifacts_created,
-        warnings=state.warnings,
-        diagnostic_context=state.diagnostic_context,
-    )
-
-
-def _run_finalization_stage_to_json_object(
-    stage: RunFinalizationStageResult,
-) -> JsonObject:
-    return stage.to_json_object()


### PR DESCRIPTION
## What changed
- Split run metadata field codecs and payload projection into `_metadata_codecs.py`.
- Split nested metadata section mapping into `_metadata_sections.py`.
- Kept `metadata.py` as the public JSON/mapping facade.
- Added direct tests for extracted codecs and sections.

## Why
- #3786 asked for run metadata mapping grouped by source/concern instead of one broad boundary module.
- Existing car metadata mapping was already separated, so this keeps that owner unchanged.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_run_metadata_codec.py apps/server/tests/shared/boundaries/test_run_metadata_sections.py apps/server/tests/shared/boundaries/test_report_summary_row_decoding.py apps/server/tests/use_cases/history/test_report_loader.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/ apps/server/tests/use_cases/history/test_report_loader.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks / tradeoffs
- Public payload shape should not change; tests cover legacy sensor map/list handling, finalization filtering, reference context, symptoms, and round trips.
- No history row migration and no API shape change.

Closes #3786