### PR TITLE
Refactor report summary presentation mapping

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_i18n.py
+++ b/apps/server/tests/adapters/pdf/test_report_i18n.py
@@ -11,8 +11,8 @@ from _paths import SERVER_ROOT
 from vibesensor import report_i18n
 from vibesensor.adapters.pdf.diagram_layout import canonical_location
 from vibesensor.domain import DiagnosisAssessment
+from vibesensor.shared.report_confidence_presentation import confidence_reason_text
 from vibesensor.shared.report_presentation import (
-    confidence_reason_text,
     display_location,
     display_speed_band,
     order_label_human,

--- a/apps/server/tests/shared/test_report_presentation_vehicle_data_confidence.py
+++ b/apps/server/tests/shared/test_report_presentation_vehicle_data_confidence.py
@@ -6,7 +6,10 @@ from vibesensor.domain import (
     diagnosis_assessment_from_components,
 )
 from vibesensor.report_i18n import tr as report_tr
-from vibesensor.shared.report_presentation import confidence_caveat_text, confidence_reason_text
+from vibesensor.shared.report_confidence_presentation import (
+    confidence_caveat_text,
+    confidence_reason_text,
+)
 
 
 def test_confidence_reason_text_mentions_user_confirmed_vehicle_data_scope() -> None:

--- a/apps/server/vibesensor/shared/boundaries/reporting/_summary_row_codec.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/_summary_row_codec.py
@@ -1,0 +1,148 @@
+"""Reusable row-codec primitives for report summary boundary payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.codecs.scalars import (
+    coerce_count,
+    optional_float,
+    text_or_none,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _FieldDecoder:
+    name: str
+    read: Callable[[Mapping[str, object]], object]
+
+
+@dataclass(frozen=True, slots=True)
+class _RowDecoder[RowModelT]:
+    factory: Callable[..., RowModelT]
+    fields: tuple[_FieldDecoder, ...]
+    required_fields: frozenset[str] = frozenset()
+
+
+def _field(name: str, read: Callable[[Mapping[str, object]], object]) -> _FieldDecoder:
+    return _FieldDecoder(name=name, read=read)
+
+
+def _payload_field(name: str, read: Callable[[object], object]) -> _FieldDecoder:
+    def read_field(row: Mapping[str, object]) -> object:
+        return read(row.get(name))
+
+    return _field(name, read_field)
+
+
+def _text_field(name: str) -> _FieldDecoder:
+    return _payload_field(name, text_or_none)
+
+
+def _float_field(name: str) -> _FieldDecoder:
+    return _payload_field(name, optional_float)
+
+
+def _float_or_field(name: str, default: float = 0.0) -> _FieldDecoder:
+    def read_float_or(raw: object) -> object:
+        return optional_float(raw) or default
+
+    return _payload_field(name, read_float_or)
+
+
+def _count_field(name: str) -> _FieldDecoder:
+    return _payload_field(name, coerce_count)
+
+
+def _optional_count(raw_value: object) -> int | None:
+    if raw_value is None or isinstance(raw_value, bool):
+        return None
+    try:
+        return coerce_count(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_count_field(name: str) -> _FieldDecoder:
+    return _payload_field(name, _optional_count)
+
+
+def _bool_field(name: str) -> _FieldDecoder:
+    return _payload_field(name, bool)
+
+
+def _text_tuple(raw_values: object) -> tuple[str, ...]:
+    if not isinstance(raw_values, list):
+        return ()
+    return tuple(
+        value
+        for value in (text_or_none(raw_value) for raw_value in raw_values)
+        if value is not None
+    )
+
+
+def _text_tuple_field(name: str) -> _FieldDecoder:
+    return _payload_field(name, _text_tuple)
+
+
+def _literal_text_or_none[LiteralTextT: str](
+    raw_value: object,
+    allowed: frozenset[LiteralTextT],
+) -> LiteralTextT | None:
+    value = text_or_none(raw_value)
+    if value is None or value not in allowed:
+        return None
+    return value
+
+
+def _enum_field[LiteralTextT: str](
+    name: str,
+    allowed: frozenset[LiteralTextT],
+) -> _FieldDecoder:
+    def read_enum(raw: object) -> object:
+        return _literal_text_or_none(raw, allowed)
+
+    return _payload_field(name, read_enum)
+
+
+def _decode_row[RowModelT](
+    raw: object,
+    decoder: _RowDecoder[RowModelT],
+) -> RowModelT | None:
+    if not isinstance(raw, Mapping):
+        return None
+    values = {field.name: field.read(raw) for field in decoder.fields}
+    if any(values[name] is None for name in decoder.required_fields):
+        return None
+    return decoder.factory(**values)
+
+
+def _decode_rows[RowModelT](
+    raw_rows: object,
+    decoder: _RowDecoder[RowModelT],
+) -> tuple[RowModelT, ...]:
+    if not isinstance(raw_rows, list):
+        return ()
+    return tuple(decoded for row in raw_rows if (decoded := _decode_row(row, decoder)) is not None)
+
+
+def _rows_field[RowModelT](
+    name: str,
+    decoder: _RowDecoder[RowModelT],
+) -> _FieldDecoder:
+    def read_rows(raw: object) -> object:
+        return _decode_rows(raw, decoder)
+
+    return _payload_field(name, read_rows)
+
+
+def _row_field[RowModelT](
+    name: str,
+    decoder: _RowDecoder[RowModelT],
+    default: RowModelT,
+) -> _FieldDecoder:
+    def read_row(raw: object) -> object:
+        return _decode_row(raw, decoder) or default
+
+    return _payload_field(name, read_row)

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import cast
 
@@ -12,6 +12,23 @@ from vibesensor.shared.boundaries.codecs.scalars import (
     coerce_count,
     optional_float,
     text_or_none,
+)
+from vibesensor.shared.boundaries.reporting._summary_row_codec import (
+    _bool_field,
+    _count_field,
+    _decode_row,
+    _decode_rows,
+    _enum_field,
+    _float_field,
+    _float_or_field,
+    _literal_text_or_none,
+    _optional_count_field,
+    _payload_field,
+    _row_field,
+    _RowDecoder,
+    _rows_field,
+    _text_field,
+    _text_tuple_field,
 )
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.summary_fields.hotspot import (
@@ -337,80 +354,6 @@ class NormalizedReportSummary:
     whole_run_diagnosis_summaries: tuple[ReportWholeRunDiagnosisSummary, ...]
 
 
-@dataclass(frozen=True, slots=True)
-class _FieldDecoder:
-    name: str
-    read: Callable[[Mapping[str, object]], object]
-
-
-@dataclass(frozen=True, slots=True)
-class _RowDecoder[RowModelT]:
-    factory: Callable[..., RowModelT]
-    fields: tuple[_FieldDecoder, ...]
-    required_fields: frozenset[str] = frozenset()
-
-
-def _field(name: str, read: Callable[[Mapping[str, object]], object]) -> _FieldDecoder:
-    return _FieldDecoder(name=name, read=read)
-
-
-def _payload_field(name: str, read: Callable[[object], object]) -> _FieldDecoder:
-    def read_field(row: Mapping[str, object]) -> object:
-        return read(row.get(name))
-
-    return _field(name, read_field)
-
-
-def _text_field(name: str) -> _FieldDecoder:
-    return _payload_field(name, text_or_none)
-
-
-def _float_field(name: str) -> _FieldDecoder:
-    return _payload_field(name, optional_float)
-
-
-def _float_or_field(name: str, default: float = 0.0) -> _FieldDecoder:
-    def read_float_or(raw: object) -> object:
-        return optional_float(raw) or default
-
-    return _payload_field(name, read_float_or)
-
-
-def _count_field(name: str) -> _FieldDecoder:
-    return _payload_field(name, coerce_count)
-
-
-def _optional_count(raw_value: object) -> int | None:
-    if raw_value is None or isinstance(raw_value, bool):
-        return None
-    try:
-        return coerce_count(raw_value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _optional_count_field(name: str) -> _FieldDecoder:
-    return _payload_field(name, _optional_count)
-
-
-def _bool_field(name: str) -> _FieldDecoder:
-    return _payload_field(name, bool)
-
-
-def _text_tuple(raw_values: object) -> tuple[str, ...]:
-    if not isinstance(raw_values, list):
-        return ()
-    return tuple(
-        value
-        for value in (text_or_none(raw_value) for raw_value in raw_values)
-        if value is not None
-    )
-
-
-def _text_tuple_field(name: str) -> _FieldDecoder:
-    return _payload_field(name, _text_tuple)
-
-
 def _data_quality_limitations(raw_values: object) -> tuple[DiagnosisDataQualityLimitation, ...]:
     if not isinstance(raw_values, list):
         return ()
@@ -422,68 +365,6 @@ def _data_quality_limitations(raw_values: object) -> tuple[DiagnosisDataQualityL
             limitations.append(limitation)
             seen.add(limitation)
     return tuple(limitations)
-
-
-def _literal_text_or_none[LiteralTextT: str](
-    raw_value: object,
-    allowed: frozenset[LiteralTextT],
-) -> LiteralTextT | None:
-    value = text_or_none(raw_value)
-    if value is None or value not in allowed:
-        return None
-    return value
-
-
-def _enum_field[LiteralTextT: str](
-    name: str,
-    allowed: frozenset[LiteralTextT],
-) -> _FieldDecoder:
-    def read_enum(raw: object) -> object:
-        return _literal_text_or_none(raw, allowed)
-
-    return _payload_field(name, read_enum)
-
-
-def _decode_row[RowModelT](
-    raw: object,
-    decoder: _RowDecoder[RowModelT],
-) -> RowModelT | None:
-    if not isinstance(raw, Mapping):
-        return None
-    values = {field.name: field.read(raw) for field in decoder.fields}
-    if any(values[name] is None for name in decoder.required_fields):
-        return None
-    return decoder.factory(**values)
-
-
-def _decode_rows[RowModelT](
-    raw_rows: object,
-    decoder: _RowDecoder[RowModelT],
-) -> tuple[RowModelT, ...]:
-    if not isinstance(raw_rows, list):
-        return ()
-    return tuple(decoded for row in raw_rows if (decoded := _decode_row(row, decoder)) is not None)
-
-
-def _rows_field[RowModelT](
-    name: str,
-    decoder: _RowDecoder[RowModelT],
-) -> _FieldDecoder:
-    def read_rows(raw: object) -> object:
-        return _decode_rows(raw, decoder)
-
-    return _payload_field(name, read_rows)
-
-
-def _row_field[RowModelT](
-    name: str,
-    decoder: _RowDecoder[RowModelT],
-    default: RowModelT,
-) -> _FieldDecoder:
-    def read_row(raw: object) -> object:
-        return _decode_row(raw, decoder) or default
-
-    return _payload_field(name, read_row)
 
 
 _PROOF_BASIS_VALUES: frozenset[LocationProofBasis] = frozenset(

--- a/apps/server/vibesensor/shared/report_confidence_presentation.py
+++ b/apps/server/vibesensor/shared/report_confidence_presentation.py
@@ -1,0 +1,308 @@
+"""Confidence and fallback wording for report presentation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vibesensor.domain import Finding
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
+from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
+from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+from vibesensor.shared.report_presentation import display_location, human_source
+
+__all__ = [
+    "confidence_caveat_text",
+    "confidence_pct_text",
+    "confidence_reason_text",
+    "confidence_snapshot_text",
+    "first_confidence_reason_clause",
+    "proof_caveat_text",
+]
+
+
+def first_confidence_reason_clause(primary_candidate_facts: PrimaryReportFacts) -> str | None:
+    finding = primary_candidate_facts.domain_primary
+    if finding is None or finding.confidence_assessment is None:
+        return None
+    for clause in str(finding.confidence_assessment.reason or "").split(";"):
+        text = clause.strip().rstrip(".")
+        if text:
+            return text
+    return None
+
+
+def confidence_pct_text(finding: Finding) -> str:
+    if finding.confidence_assessment is not None:
+        return finding.confidence_assessment.pct_text
+    return finding.confidence_pct_text
+
+
+def confidence_reason_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    if confidence_facts.uses_summary_fallback:
+        return _localized_fallback_reason(confidence_facts.fallback_reason, tr=tr) or (
+            tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY")
+            if confidence_facts.data_basis == "summary_only"
+            else ""
+        )
+    strengths = _confidence_signal_texts(confidence_facts, tr=tr)
+    caveats = _confidence_caveat_texts(confidence_facts, tr=tr)
+    strength = strengths[0] if strengths else ""
+    caveat = "; ".join(caveats[:2])
+    if confidence_facts.label_key == "CONFIDENCE_LOW" and caveat and strength:
+        return tr(
+            "REPORT_CONFIDENCE_REASON_LIMITED_SUPPORT",
+            caveat=caveat,
+            strength=strength,
+        )
+    if strength and caveat:
+        return tr(
+            "REPORT_CONFIDENCE_REASON_WITH_CAVEAT",
+            strength=strength,
+            caveat=caveat,
+        )
+    return strength or caveat
+
+
+def confidence_snapshot_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    label = tr(confidence_facts.label_key)
+    reason = confidence_reason_text(confidence_facts, tr=tr)
+    if not reason:
+        return f"{label} ({confidence_facts.pct_text})"
+    return f"{label} ({confidence_facts.pct_text}) — {reason}"
+
+
+def confidence_caveat_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    if confidence_facts.uses_summary_fallback:
+        if confidence_facts.data_basis == "summary_only":
+            return tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY")
+        return None
+    caveats = _confidence_caveat_texts(confidence_facts, tr=tr)
+    if not caveats:
+        return None
+    return "; ".join(caveats[:2])
+
+
+def proof_caveat_text(
+    *,
+    confidence_facts: ReportConfidenceFacts,
+    action_status_key: str,
+    location_confidence_key: str,
+    tr: Callable[..., str],
+) -> str | None:
+    if action_status_key == "action_ready_caution":
+        return None
+    reason = (
+        confidence_caveat_text(confidence_facts, tr=tr)
+        if action_status_key != "action_ready"
+        else None
+    )
+    if reason:
+        return reason
+    if location_confidence_key == "weak":
+        return tr("REPORT_PROOF_CAVEAT_WEAK")
+    if location_confidence_key == "mixed":
+        return tr("REPORT_PROOF_CAVEAT_MIXED")
+    return None
+
+
+def _confidence_signal_texts(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    parts: list[str] = []
+    for key in confidence_facts.signal_keys:
+        if key == "raw_backed":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_RAW_BACKED",
+                    samples=str(max(0, confidence_facts.raw_backed_sample_count)),
+                )
+            )
+        elif key == "repeated_support":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_REPEATED_SUPPORT",
+                    count=str(max(0, confidence_facts.supporting_window_count or 0)),
+                )
+            )
+        elif key == "sustained_support" and confidence_facts.supporting_duration_s is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_SUSTAINED_SUPPORT",
+                    duration=f"{confidence_facts.supporting_duration_s:.1f}",
+                )
+            )
+        elif key == "stable_frequency":
+            low = confidence_facts.stable_frequency_min_hz
+            high = confidence_facts.stable_frequency_max_hz
+            if low is None or high is None:
+                continue
+            if abs(high - low) < 0.05:
+                parts.append(
+                    tr(
+                        "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_SINGLE",
+                        hz=f"{low:.1f}",
+                    )
+                )
+            else:
+                parts.append(
+                    tr(
+                        "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_BAND",
+                        low=f"{low:.1f}",
+                        high=f"{high:.1f}",
+                    )
+                )
+        elif key == "tight_order_lock":
+            parts.append(tr("REPORT_CONFIDENCE_SIGNAL_TIGHT_ORDER_LOCK"))
+        elif key == "localized_support" and confidence_facts.top_support_location is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_LOCALIZED_SUPPORT",
+                    location=display_location(confidence_facts.top_support_location, tr=tr),
+                )
+            )
+        elif key == "clean_signal":
+            parts.append(tr("REPORT_CONFIDENCE_SIGNAL_CLEAN_SIGNAL"))
+        elif key == "user_confirmed_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_USER_CONFIRMED_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
+    return tuple(parts)
+
+
+def _confidence_caveat_texts(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    parts: list[str] = []
+    for key in confidence_facts.caveat_keys:
+        if key == "summary_only":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
+        elif key == "raw_replay_incomplete":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RAW_REPLAY_INCOMPLETE"))
+        elif key == LEGACY_CONTEXT_CAVEAT_KEY:
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
+        elif key == "sparse_support":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_SPARSE_SUPPORT",
+                    count=str(max(0, confidence_facts.supporting_window_count or 0)),
+                )
+            )
+        elif key == "speed_context_gaps":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS"))
+        elif key == "rpm_context_gaps":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RPM_CONTEXT_GAPS"))
+        elif key == "brief_support" and confidence_facts.supporting_duration_s is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_BRIEF_SUPPORT",
+                    duration=f"{confidence_facts.supporting_duration_s:.1f}",
+                )
+            )
+        elif key == "drifting_frequency":
+            low = confidence_facts.stable_frequency_min_hz
+            high = confidence_facts.stable_frequency_max_hz
+            if low is None or high is None:
+                continue
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_DRIFTING_FREQUENCY",
+                    low=f"{low:.1f}",
+                    high=f"{high:.1f}",
+                )
+            )
+        elif key == "loose_order_lock":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LOOSE_ORDER_LOCK"))
+        elif key == "mixed_support_locations":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_MIXED_LOCATIONS"))
+        elif key == "weak_spatial":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_WEAK_SPATIAL"))
+        elif key == "close_alternative" and confidence_facts.alternative_source is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_CLOSE_ALTERNATIVE",
+                    source=human_source(confidence_facts.alternative_source, tr=tr),
+                )
+            )
+        elif key == "incomplete_reference":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_REFERENCE_GAP"))
+        elif key == "noisy_signal":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_NOISY_SIGNAL"))
+        elif key == "secondary_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_SECONDARY_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
+        elif key == "approximate_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_APPROXIMATE_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
+        elif key == "unverified_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_UNVERIFIED_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
+    return tuple(parts)
+
+
+def _vehicle_data_scope_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    if confidence_facts.car_data_reference_scope == "driveline":
+        return tr("REPORT_CONFIDENCE_CAR_SCOPE_DRIVELINE")
+    if confidence_facts.car_data_reference_scope == "engine_speed_derived":
+        return tr("REPORT_CONFIDENCE_CAR_SCOPE_ENGINE_SPEED_DERIVED")
+    return tr("REPORT_CONFIDENCE_CAR_SCOPE_TIRE")
+
+
+def _localized_fallback_reason(value: object, *, tr: Callable[..., str]) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if _display_lang(tr) != "nl":
+        return text
+    replacements = {
+        "missing reference data may affect accuracy": "Referentie ontbreekt",
+        "speed was not steady during measurement": "snelheid wisselde",
+    }
+    clauses: list[str] = []
+    for clause in text.split(";"):
+        cleaned = clause.strip().rstrip(".")
+        if not cleaned:
+            continue
+        clauses.append(replacements.get(cleaned.casefold(), cleaned))
+    return "; ".join(clauses)
+
+
+def _display_lang(tr: Callable[..., str]) -> str:
+    try:
+        return "nl" if tr("UNKNOWN") == "Onbekend" else "en"
+    except Exception:
+        return "en"

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -7,9 +7,7 @@ import math
 from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, VibrationSource
-from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.report_i18n import human_location, location_candidates
-from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
 from vibesensor.strength_bands import BANDS
@@ -18,16 +16,11 @@ __all__ = [
     "action_status_text",
     "append_unique_line",
     "candidate_signal_text",
-    "confidence_caveat_text",
-    "confidence_pct_text",
-    "confidence_reason_text",
-    "confidence_snapshot_text",
     "coverage_label",
     "coverage_notes",
     "display_location",
     "display_phase_label",
     "display_speed_band",
-    "first_confidence_reason_clause",
     "has_source_overlap",
     "human_source",
     "is_transient_primary",
@@ -35,7 +28,6 @@ __all__ = [
     "order_label_human",
     "peak_classification_text",
     "presented_location_confidence_key",
-    "proof_caveat_text",
     "runner_up_corner",
     "source_with_confidence",
     "strength_label",
@@ -126,17 +118,6 @@ def presented_location_confidence_key(
     if action_status_key == "action_ready_caution" and location_confidence_key != "weak":
         return "limited"
     return location_confidence_key
-
-
-def first_confidence_reason_clause(primary_candidate_facts: PrimaryReportFacts) -> str | None:
-    finding = primary_candidate_facts.domain_primary
-    if finding is None or finding.confidence_assessment is None:
-        return None
-    for clause in str(finding.confidence_assessment.reason or "").split(";"):
-        text = clause.strip().rstrip(".")
-        if text:
-            return text
-    return None
 
 
 def display_location(value: object, *, short: bool = True, tr: Callable[..., str]) -> str:
@@ -290,69 +271,6 @@ def coverage_notes(
     return tuple(notes)
 
 
-def confidence_pct_text(finding: Finding) -> str:
-    if finding.confidence_assessment is not None:
-        return finding.confidence_assessment.pct_text
-    return finding.confidence_pct_text
-
-
-def confidence_reason_text(
-    confidence_facts: ReportConfidenceFacts,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    if confidence_facts.uses_summary_fallback:
-        return _localized_fallback_reason(confidence_facts.fallback_reason, tr=tr) or (
-            tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY")
-            if confidence_facts.data_basis == "summary_only"
-            else ""
-        )
-    strengths = _confidence_signal_texts(confidence_facts, tr=tr)
-    caveats = _confidence_caveat_texts(confidence_facts, tr=tr)
-    strength = strengths[0] if strengths else ""
-    caveat = "; ".join(caveats[:2])
-    if confidence_facts.label_key == "CONFIDENCE_LOW" and caveat and strength:
-        return tr(
-            "REPORT_CONFIDENCE_REASON_LIMITED_SUPPORT",
-            caveat=caveat,
-            strength=strength,
-        )
-    if strength and caveat:
-        return tr(
-            "REPORT_CONFIDENCE_REASON_WITH_CAVEAT",
-            strength=strength,
-            caveat=caveat,
-        )
-    return strength or caveat
-
-
-def confidence_snapshot_text(
-    confidence_facts: ReportConfidenceFacts,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    label = tr(confidence_facts.label_key)
-    reason = confidence_reason_text(confidence_facts, tr=tr)
-    if not reason:
-        return f"{label} ({confidence_facts.pct_text})"
-    return f"{label} ({confidence_facts.pct_text}) — {reason}"
-
-
-def confidence_caveat_text(
-    confidence_facts: ReportConfidenceFacts,
-    *,
-    tr: Callable[..., str],
-) -> str | None:
-    if confidence_facts.uses_summary_fallback:
-        if confidence_facts.data_basis == "summary_only":
-            return tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY")
-        return None
-    caveats = _confidence_caveat_texts(confidence_facts, tr=tr)
-    if not caveats:
-        return None
-    return "; ".join(caveats[:2])
-
-
 def human_source(source: object, *, tr: Callable[[str], str]) -> str:
     """Resolve a source code to its user-facing label."""
     raw = str(source or "").strip().lower()
@@ -368,10 +286,15 @@ def human_source(source: object, *, tr: Callable[[str], str]) -> str:
 
 
 def source_with_confidence(finding: Finding, *, tr: Callable[..., str]) -> str:
+    confidence = (
+        finding.confidence_assessment.pct_text
+        if finding.confidence_assessment is not None
+        else finding.confidence_pct_text
+    )
     return tr(
         "REPORT_SOURCE_WITH_CONFIDENCE",
         source=human_source(finding.suspected_source, tr=tr),
-        confidence=confidence_pct_text(finding),
+        confidence=confidence,
     )
 
 
@@ -391,213 +314,6 @@ def runner_up_corner(
     if len(ranked_rows) < 2:
         return None
     return display_location(ranked_rows[1].location, tr=tr)
-
-
-def proof_caveat_text(
-    *,
-    confidence_facts: ReportConfidenceFacts,
-    action_status_key: str,
-    location_confidence_key: str,
-    tr: Callable[..., str],
-) -> str | None:
-    if action_status_key == "action_ready_caution":
-        return None
-    reason = (
-        confidence_caveat_text(confidence_facts, tr=tr)
-        if action_status_key != "action_ready"
-        else None
-    )
-    if reason:
-        return reason
-    if location_confidence_key == "weak":
-        return tr("REPORT_PROOF_CAVEAT_WEAK")
-    if location_confidence_key == "mixed":
-        return tr("REPORT_PROOF_CAVEAT_MIXED")
-    return None
-
-
-def _confidence_signal_texts(
-    confidence_facts: ReportConfidenceFacts,
-    *,
-    tr: Callable[..., str],
-) -> tuple[str, ...]:
-    parts: list[str] = []
-    for key in confidence_facts.signal_keys:
-        if key == "raw_backed":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_SIGNAL_RAW_BACKED",
-                    samples=str(max(0, confidence_facts.raw_backed_sample_count)),
-                )
-            )
-        elif key == "repeated_support":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_SIGNAL_REPEATED_SUPPORT",
-                    count=str(max(0, confidence_facts.supporting_window_count or 0)),
-                )
-            )
-        elif key == "sustained_support" and confidence_facts.supporting_duration_s is not None:
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_SIGNAL_SUSTAINED_SUPPORT",
-                    duration=f"{confidence_facts.supporting_duration_s:.1f}",
-                )
-            )
-        elif key == "stable_frequency":
-            low = confidence_facts.stable_frequency_min_hz
-            high = confidence_facts.stable_frequency_max_hz
-            if low is None or high is None:
-                continue
-            if abs(high - low) < 0.05:
-                parts.append(
-                    tr(
-                        "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_SINGLE",
-                        hz=f"{low:.1f}",
-                    )
-                )
-            else:
-                parts.append(
-                    tr(
-                        "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_BAND",
-                        low=f"{low:.1f}",
-                        high=f"{high:.1f}",
-                    )
-                )
-        elif key == "tight_order_lock":
-            parts.append(tr("REPORT_CONFIDENCE_SIGNAL_TIGHT_ORDER_LOCK"))
-        elif key == "localized_support" and confidence_facts.top_support_location is not None:
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_SIGNAL_LOCALIZED_SUPPORT",
-                    location=display_location(confidence_facts.top_support_location, tr=tr),
-                )
-            )
-        elif key == "clean_signal":
-            parts.append(tr("REPORT_CONFIDENCE_SIGNAL_CLEAN_SIGNAL"))
-        elif key == "user_confirmed_vehicle_data":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_SIGNAL_USER_CONFIRMED_VEHICLE_DATA",
-                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
-                )
-            )
-    return tuple(parts)
-
-
-def _confidence_caveat_texts(
-    confidence_facts: ReportConfidenceFacts,
-    *,
-    tr: Callable[..., str],
-) -> tuple[str, ...]:
-    parts: list[str] = []
-    for key in confidence_facts.caveat_keys:
-        if key == "summary_only":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
-        elif key == "raw_replay_incomplete":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RAW_REPLAY_INCOMPLETE"))
-        elif key == LEGACY_CONTEXT_CAVEAT_KEY:
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
-        elif key == "sparse_support":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_SPARSE_SUPPORT",
-                    count=str(max(0, confidence_facts.supporting_window_count or 0)),
-                )
-            )
-        elif key == "speed_context_gaps":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS"))
-        elif key == "rpm_context_gaps":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RPM_CONTEXT_GAPS"))
-        elif key == "brief_support" and confidence_facts.supporting_duration_s is not None:
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_BRIEF_SUPPORT",
-                    duration=f"{confidence_facts.supporting_duration_s:.1f}",
-                )
-            )
-        elif key == "drifting_frequency":
-            low = confidence_facts.stable_frequency_min_hz
-            high = confidence_facts.stable_frequency_max_hz
-            if low is None or high is None:
-                continue
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_DRIFTING_FREQUENCY",
-                    low=f"{low:.1f}",
-                    high=f"{high:.1f}",
-                )
-            )
-        elif key == "loose_order_lock":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LOOSE_ORDER_LOCK"))
-        elif key == "mixed_support_locations":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_MIXED_LOCATIONS"))
-        elif key == "weak_spatial":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_WEAK_SPATIAL"))
-        elif key == "close_alternative" and confidence_facts.alternative_source is not None:
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_CLOSE_ALTERNATIVE",
-                    source=human_source(confidence_facts.alternative_source, tr=tr),
-                )
-            )
-        elif key == "incomplete_reference":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_REFERENCE_GAP"))
-        elif key == "noisy_signal":
-            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_NOISY_SIGNAL"))
-        elif key == "secondary_vehicle_data":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_SECONDARY_VEHICLE_DATA",
-                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
-                )
-            )
-        elif key == "approximate_vehicle_data":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_APPROXIMATE_VEHICLE_DATA",
-                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
-                )
-            )
-        elif key == "unverified_vehicle_data":
-            parts.append(
-                tr(
-                    "REPORT_CONFIDENCE_CAVEAT_UNVERIFIED_VEHICLE_DATA",
-                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
-                )
-            )
-    return tuple(parts)
-
-
-def _vehicle_data_scope_text(
-    confidence_facts: ReportConfidenceFacts,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    if confidence_facts.car_data_reference_scope == "driveline":
-        return tr("REPORT_CONFIDENCE_CAR_SCOPE_DRIVELINE")
-    if confidence_facts.car_data_reference_scope == "engine_speed_derived":
-        return tr("REPORT_CONFIDENCE_CAR_SCOPE_ENGINE_SPEED_DERIVED")
-    return tr("REPORT_CONFIDENCE_CAR_SCOPE_TIRE")
-
-
-def _localized_fallback_reason(value: object, *, tr: Callable[..., str]) -> str:
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    if _display_lang(tr) != "nl":
-        return text
-    replacements = {
-        "missing reference data may affect accuracy": "Referentie ontbreekt",
-        "speed was not steady during measurement": "snelheid wisselde",
-    }
-    clauses: list[str] = []
-    for clause in text.split(";"):
-        cleaned = clause.strip().rstrip(".")
-        if not cleaned:
-            continue
-        clauses.append(replacements.get(cleaned.casefold(), cleaned))
-    return "; ".join(clauses)
 
 
 def append_unique_line(lines: list[str], text: object) -> None:

--- a/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 
 from vibesensor.domain import Finding, TestRun
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
+from vibesensor.shared.report_confidence_presentation import confidence_reason_text
 from vibesensor.shared.report_presentation import (
-    confidence_reason_text,
     display_speed_band,
     human_source,
     strength_label,

--- a/apps/server/vibesensor/use_cases/history/report_document/document_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_context.py
@@ -11,12 +11,12 @@ from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts, PreparedReportInput
 from vibesensor.shared.boundaries.reporting.facts import ReportRunFacts
 from vibesensor.shared.boundaries.reporting.findings import FindingPresentation
+from vibesensor.shared.report_confidence_presentation import proof_caveat_text
 from vibesensor.shared.report_presentation import (
     coverage_label,
     coverage_notes,
     display_location,
     display_speed_band,
-    proof_caveat_text,
     runner_up_corner,
 )
 from vibesensor.shared.time_utils import (

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
+from vibesensor.shared.report_confidence_presentation import confidence_snapshot_text
 from vibesensor.shared.report_presentation import (
-    confidence_snapshot_text,
     display_location,
     human_source,
 )

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -13,6 +13,7 @@ from vibesensor.shared.boundaries.reporting.document import (
     PatternEvidence,
     VerdictPageData,
 )
+from vibesensor.shared.report_confidence_presentation import proof_caveat_text
 from vibesensor.shared.report_diagnostics import first_nonpass_detail
 from vibesensor.shared.report_presentation import (
     action_status_text,
@@ -21,7 +22,6 @@ from vibesensor.shared.report_presentation import (
     human_source,
     location_confidence_text,
     presented_location_confidence_key,
-    proof_caveat_text,
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
 

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -9,17 +9,16 @@ from vibesensor.domain import Finding, SuitabilityCheck, TestRun
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.document import AppendixAData, RankedCandidateRow
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+from vibesensor.shared.report_confidence_presentation import confidence_pct_text, proof_caveat_text
 from vibesensor.shared.report_diagnostics import check_state, has_warning_code, nonpass_detail_lines
 from vibesensor.shared.report_presentation import (
     append_unique_line,
     candidate_signal_text,
-    confidence_pct_text,
     display_location,
     display_speed_band,
     has_source_overlap,
     human_source,
     is_transient_primary,
-    proof_caveat_text,
     uses_shared_overlap_wording,
 )
 from vibesensor.shared.run_context_warning import RunContextWarning


### PR DESCRIPTION
## What changed
- Moved reusable report-summary row decoding primitives into `_summary_row_codec.py`.
- Moved confidence and fallback wording into `report_confidence_presentation.py`.
- Updated report-document/PDF callers to import the focused confidence presentation layer.
- Kept report summary payload models, report text, i18n keys, and PDF structure unchanged.

## Why
- #3787 asks for clearer layers between summary facts, presentation wording, and projection helpers.
- The split keeps the public report behavior stable while reducing mixed responsibilities in the broad presentation module.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_report_payload.py apps/server/tests/shared/boundaries/test_report_summary_row_decoding.py apps/server/tests/shared/test_report_presentation_vehicle_data_confidence.py apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_persistence_summary.py apps/server/tests/use_cases/history/test_report_facts.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks / tradeoffs
- No report redesign, no diagnostic scoring changes, and no history/API payload migration.
- Confidence wording still uses the same i18n keys and formatting.

Closes #3787