### PR TITLE
Refactor fuzz tooling layers

### DIFF
--- a/apps/server/tests/hygiene/test_fuzz_tooling_layers.py
+++ b/apps/server/tests/hygiene/test_fuzz_tooling_layers.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_TOOLS_DEV = _REPO_ROOT / "tools" / "dev"
+
+
+def _load_tool_module(name: str) -> ModuleType:
+    module_path = _TOOLS_DEV / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_test_module", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_processing_fuzz_assertions_are_testable_without_cli() -> None:
+    module = _load_tool_module("fuzz_processing_assertions")
+
+    assert module.is_sorted_desc([3.0, 2.0, 2.0, 1.0])
+    assert not module.is_sorted_desc([1.0, 3.0])
+    module.json_no_nan({"value": 1.0})
+    with pytest.raises(ValueError):
+        module.json_no_nan({"value": float("nan")})
+
+
+def test_analysis_summary_assertions_are_testable_without_cli() -> None:
+    module = _load_tool_module("fuzz_analysis_assertions")
+    validated: list[object] = []
+
+    class _TypeAdapter:
+        def __init__(self, schema: object) -> None:
+            self.schema = schema
+
+        def validate_python(self, value: object) -> object:
+            validated.append((self.schema, value))
+            return value
+
+    module.validate_summary(
+        {"rows": 2, "findings": [], "run_suitability": {}},
+        expected_rows=2,
+        TypeAdapter=_TypeAdapter,
+        AnalysisSummary=object,
+    )
+
+    assert validated
+    with pytest.raises(AssertionError, match="summary findings missing"):
+        module.validate_summary(
+            {"rows": 2, "run_suitability": {}},
+            expected_rows=2,
+            TypeAdapter=_TypeAdapter,
+            AnalysisSummary=object,
+        )
+
+
+def test_analysis_scenario_materializer_is_testable_without_cli() -> None:
+    module = _load_tool_module("fuzz_analysis_scenarios")
+
+    class _AnalysisSettingsSnapshot:
+        @classmethod
+        def from_dict(cls, metadata: dict[str, object]) -> dict[str, object]:
+            return metadata
+
+    def _vehicle_orders_hz(*, speed_mps: float, settings: object) -> dict[str, float]:
+        return {"wheel_hz": speed_mps}
+
+    samples = module.materialize_samples(
+        {
+            "metadata": {
+                "run_id": "fuzz-test",
+                "raw_sample_rate_hz": 800,
+                "current_gear_ratio": 1.0,
+                "final_drive_ratio": 4.0,
+            },
+            "sensors": [
+                {
+                    "client_id": "fl-wheel",
+                    "client_name": "Front Left Wheel",
+                    "location": "front_left_wheel",
+                }
+            ],
+            "scenario": "steady",
+            "fault_kind": "wheel",
+            "steps": 1,
+            "dt_s": 1.0,
+            "low_speed": 36.0,
+            "high_speed": 72.0,
+            "floor_amp_g": 0.01,
+            "base_fault_amp_g": 0.1,
+            "diffuse_excitation": False,
+            "missing_speed_ratio": 0.0,
+            "blank_location_ratio": 0.0,
+            "drop_counter": 0,
+            "overflow_counter": 0,
+            "accel_scale": 0.02,
+            "background_hz": 20.0,
+            "clutter_hz": 40.0,
+        },
+        vibration_strength_db_scalar=lambda *, peak_band_rms_amp_g, floor_amp_g: (
+            peak_band_rms_amp_g / floor_amp_g
+        ),
+        bucket_for_strength=lambda value: "l1" if value > 1.0 else "l0",
+        AnalysisSettingsSnapshot=_AnalysisSettingsSnapshot,
+        vehicle_orders_hz=_vehicle_orders_hz,
+    )
+
+    assert len(samples) == 1
+    assert samples[0]["run_id"] == "fuzz-test"
+    assert samples[0]["sample_rate_hz"] == 800
+    assert json.dumps(samples, allow_nan=False)
+
+
+def test_common_worker_helpers_are_testable_without_cli() -> None:
+    module = _load_tool_module("fuzz_common")
+
+    assert module.worker_seed(None, 3) is None
+    assert module.worker_seed(100, 3) == 103
+    assert module.worker_prefix(None) == ""
+    assert module.worker_prefix(2) == "[worker 2] "
+
+
+def test_fuzz_artifact_writers_are_testable_without_cli(tmp_path: Path) -> None:
+    module = _load_tool_module("fuzz_artifacts")
+
+    processing_path = module.write_processing_failure_artifact(
+        target="fft",
+        case={"value": 1.0},
+        output={"ok": False},
+        exc=RuntimeError("boom"),
+        artifact_dir=tmp_path,
+    )
+    assert processing_path is not None
+    processing_payload = json.loads(processing_path.read_text(encoding="utf-8"))
+    assert processing_payload["target"] == "fft"
+    assert processing_payload["case"] == {"value": 1.0}
+    assert processing_payload["output"] == {"ok": False}
+    assert processing_payload["exception_type"] == "RuntimeError"
+
+    analysis_path = module.write_analysis_failure_artifact(
+        case={"metadata": {"run_id": "fuzz-run"}, "samples": []},
+        summary={"rows": 0},
+        exc=ValueError("bad"),
+        artifact_dir=tmp_path,
+    )
+    assert analysis_path is not None
+    assert analysis_path.name.endswith("-fuzz-run.json")
+    analysis_payload = json.loads(analysis_path.read_text(encoding="utf-8"))
+    assert analysis_payload["summary"] == {"rows": 0}
+    assert analysis_payload["exception_type"] == "ValueError"

--- a/tools/dev/fuzz_analysis_assertions.py
+++ b/tools/dev/fuzz_analysis_assertions.py
@@ -1,0 +1,26 @@
+"""Assertion helpers for analysis fuzz targets."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+def validate_summary(
+    summary: Mapping[str, object],
+    expected_rows: int,
+    TypeAdapter: Any,
+    AnalysisSummary: Any,
+) -> None:
+    TypeAdapter(AnalysisSummary).validate_python(summary)
+    summary_rows = summary.get("rows")
+    if summary_rows != expected_rows:
+        raise AssertionError(
+            f"summary rows {summary_rows!r} != expected {expected_rows}"
+        )
+    if summary.get("findings") is None:
+        raise AssertionError("summary findings missing")
+    if summary.get("run_suitability") is None:
+        raise AssertionError("summary run_suitability missing")
+    json.dumps(summary, ensure_ascii=False, allow_nan=False)

--- a/tools/dev/fuzz_analysis_engine.py
+++ b/tools/dev/fuzz_analysis_engine.py
@@ -9,93 +9,29 @@ script writes a JSON reproduction artifact under ``artifacts/fuzz/``.
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
-import os
 import subprocess
 import sys
 import tempfile
 import threading
 import time
-import traceback
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+
+from fuzz_analysis_assertions import validate_summary
+from fuzz_analysis_scenarios import (
+    coerce_include_samples,
+    materialize_samples,
+    sample_case_strategy,
+)
+from fuzz_artifacts import write_analysis_failure_artifact
+from fuzz_common import terminate_processes, worker_prefix, worker_seed
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _load_repo_tooling_support():
-    helper_path = REPO_ROOT / "tools" / "repo_tooling_support.py"
-    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-_repo_tooling_support = _load_repo_tooling_support()
 ARTIFACT_DIR = REPO_ROOT / "artifacts" / "fuzz"
-
-SENSOR_FIXTURES: tuple[dict[str, str], ...] = (
-    {
-        "client_id": "fl-wheel",
-        "client_name": "Front Left Wheel",
-        "location": "front_left_wheel",
-    },
-    {
-        "client_id": "fr-wheel",
-        "client_name": "Front Right Wheel",
-        "location": "front_right_wheel",
-    },
-    {
-        "client_id": "rl-wheel",
-        "client_name": "Rear Left Wheel",
-        "location": "rear_left_wheel",
-    },
-    {
-        "client_id": "rr-wheel",
-        "client_name": "Rear Right Wheel",
-        "location": "rear_right_wheel",
-    },
-    {
-        "client_id": "drive-tunnel",
-        "client_name": "Driveshaft Tunnel",
-        "location": "driveshaft_tunnel",
-    },
-    {
-        "client_id": "engine-bay",
-        "client_name": "Engine Bay",
-        "location": "engine_bay",
-    },
-    {
-        "client_id": "driver-seat",
-        "client_name": "Driver Seat",
-        "location": "driver_seat",
-    },
-)
-
-SCENARIO_KINDS: tuple[str, ...] = (
-    "idle",
-    "steady",
-    "accel",
-    "decel",
-    "oscillate",
-)
-
-FAULT_KINDS: tuple[str, ...] = (
-    "none",
-    "wheel",
-    "driveline",
-    "engine",
-    "random",
-)
-
-LANGUAGE_CHOICES: tuple[str | None, ...] = (None, "en", "EN", "nl", "NL")
-SENSOR_MODELS: tuple[str, ...] = ("ADXL345", "ICM-42688-P", "LSM6DSOX", "unknown")
 
 
 @dataclass(frozen=True)
@@ -186,493 +122,6 @@ def _parse_args() -> FuzzConfig:
     )
 
 
-def _timestamp_at(offset_s: float) -> str:
-    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-    return (base + timedelta(seconds=offset_s)).isoformat().replace("+00:00", "Z")
-
-
-def _sample_rate_from_metadata(metadata: Mapping[str, object]) -> int | None:
-    raw = metadata.get("raw_sample_rate_hz")
-    return int(raw) if isinstance(raw, int) else None
-
-
-def _coerce_include_samples(case: Mapping[str, object], override: bool | None) -> bool:
-    if override is not None:
-        return override
-    raw = case.get("include_samples")
-    return bool(raw) if isinstance(raw, bool) else False
-
-
-def _metadata_strategy(st: Any) -> Any:
-    positive_int = st.integers(min_value=32, max_value=6400)
-    positive_float = st.floats(
-        min_value=0.05, max_value=2.0, allow_nan=False, allow_infinity=False
-    )
-    settings_float = st.floats(
-        min_value=0.1,
-        max_value=10.0,
-        allow_nan=False,
-        allow_infinity=False,
-    )
-    return st.fixed_dictionaries(
-        {
-            "run_id": st.from_regex(r"[a-z0-9][a-z0-9_-]{2,20}", fullmatch=True),
-            "start_time_utc": st.just(_timestamp_at(0.0)),
-            "end_time_utc": st.one_of(
-                st.none(),
-                st.just(_timestamp_at(60.0)),
-                st.just(_timestamp_at(180.0)),
-            ),
-            "sensor_model": st.sampled_from(SENSOR_MODELS),
-            "raw_sample_rate_hz": st.one_of(st.none(), positive_int, st.just(0)),
-            "feature_interval_s": st.one_of(st.none(), positive_float),
-            "fft_window_size_samples": st.one_of(
-                st.none(),
-                st.sampled_from((128, 256, 512, 1024, 2048, 4096)),
-            ),
-            "accel_scale_g_per_lsb": st.one_of(
-                st.none(),
-                st.floats(
-                    min_value=1e-5,
-                    max_value=0.05,
-                    allow_nan=False,
-                    allow_infinity=False,
-                ),
-            ),
-            "language": st.one_of(st.none(), st.sampled_from(("en", "nl", "EN", "NL"))),
-            "incomplete_for_order_analysis": st.booleans(),
-            "tire_width_mm": st.floats(
-                min_value=100.0,
-                max_value=355.0,
-                allow_nan=False,
-                allow_infinity=False,
-            ),
-            "tire_aspect_pct": st.floats(
-                min_value=25.0,
-                max_value=80.0,
-                allow_nan=False,
-                allow_infinity=False,
-            ),
-            "rim_in": st.floats(
-                min_value=13.0,
-                max_value=24.0,
-                allow_nan=False,
-                allow_infinity=False,
-            ),
-            "final_drive_ratio": settings_float,
-            "current_gear_ratio": st.floats(
-                min_value=0.4,
-                max_value=4.8,
-                allow_nan=False,
-                allow_infinity=False,
-            ),
-        }
-    )
-
-
-def _sensor_selection_strategy(st: Any) -> Any:
-    return st.lists(
-        st.sampled_from(SENSOR_FIXTURES),
-        min_size=1,
-        max_size=4,
-        unique_by=lambda sensor: sensor["client_id"],
-    )
-
-
-def _speed_for_step(
-    kind: str,
-    step: int,
-    total_steps: int,
-    low_kmh: float,
-    high_kmh: float,
-) -> float:
-    if total_steps <= 1:
-        return low_kmh
-    ratio = step / float(total_steps - 1)
-    if kind == "idle":
-        return 0.0
-    if kind == "steady":
-        return low_kmh
-    if kind == "accel":
-        return low_kmh + ((high_kmh - low_kmh) * ratio)
-    if kind == "decel":
-        return high_kmh - ((high_kmh - low_kmh) * ratio)
-    midpoint = 0.5
-    swing = abs(ratio - midpoint) / midpoint
-    return low_kmh + ((high_kmh - low_kmh) * (1.0 - swing))
-
-
-def _build_peak(
-    *,
-    hz: float,
-    amp_g: float,
-    vibration_strength_db_scalar: Any,
-    bucket_for_strength: Any,
-    floor_amp_g: float,
-) -> dict[str, float | str]:
-    strength_db = vibration_strength_db_scalar(
-        peak_band_rms_amp_g=amp_g,
-        floor_amp_g=floor_amp_g,
-    )
-    return {
-        "hz": round(max(0.1, hz), 3),
-        "amp": round(max(1e-6, amp_g), 6),
-        "vibration_strength_db": round(strength_db, 3),
-        "strength_bucket": bucket_for_strength(strength_db),
-    }
-
-
-def _order_hz_for_fault(
-    *,
-    fault_kind: str,
-    speed_kmh: float | None,
-    metadata: Mapping[str, object],
-    AnalysisSettingsSnapshot: Any,
-    vehicle_orders_hz: Any,
-) -> float | None:
-    if speed_kmh is None or speed_kmh <= 0.0:
-        return None
-    settings = AnalysisSettingsSnapshot.from_dict(metadata)
-    order_refs = vehicle_orders_hz(speed_mps=speed_kmh / 3.6, settings=settings)
-    if not isinstance(order_refs, Mapping):
-        return None
-    if fault_kind == "wheel":
-        value = order_refs.get("wheel_hz")
-        return float(value) if isinstance(value, (int, float)) else None
-    if fault_kind == "driveline":
-        value = order_refs.get("drive_hz")
-        return float(value) if isinstance(value, (int, float)) else None
-    if fault_kind == "engine":
-        value = order_refs.get("engine_hz")
-        return float(value) if isinstance(value, (int, float)) else None
-    return None
-
-
-def _sample_case_strategy(st: Any) -> Any:
-    @st.composite
-    def _build(draw: Any) -> dict[str, object]:
-        metadata = draw(_metadata_strategy(st))
-        sensors = draw(_sensor_selection_strategy(st))
-        scenario = draw(st.sampled_from(SCENARIO_KINDS))
-        fault_kind = draw(st.sampled_from(FAULT_KINDS))
-        include_samples = draw(st.booleans())
-        lang = draw(st.sampled_from(LANGUAGE_CHOICES))
-        steps = draw(st.integers(min_value=0, max_value=28))
-        dt_s = draw(
-            st.floats(
-                min_value=0.2,
-                max_value=2.5,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        low_speed = draw(
-            st.floats(
-                min_value=10.0,
-                max_value=90.0,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        high_speed = draw(
-            st.floats(
-                min_value=max(low_speed + 5.0, 20.0),
-                max_value=180.0,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        floor_amp_g = draw(
-            st.floats(
-                min_value=0.0005,
-                max_value=0.05,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        base_fault_amp_g = draw(
-            st.floats(
-                min_value=0.002,
-                max_value=0.4,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        diffuse_excitation = draw(st.booleans())
-        missing_speed_ratio = draw(
-            st.floats(
-                min_value=0.0,
-                max_value=0.7,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        blank_location_ratio = draw(
-            st.floats(
-                min_value=0.0,
-                max_value=0.5,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        drop_counter = draw(st.integers(min_value=0, max_value=100))
-        overflow_counter = draw(st.integers(min_value=0, max_value=30))
-        accel_scale = draw(
-            st.floats(
-                min_value=0.005,
-                max_value=0.35,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        background_hz = draw(
-            st.floats(
-                min_value=8.0,
-                max_value=120.0,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        clutter_hz = draw(
-            st.floats(
-                min_value=20.0,
-                max_value=250.0,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-
-        return {
-            "metadata": metadata,
-            "sensors": sensors,
-            "scenario": scenario,
-            "fault_kind": fault_kind,
-            "include_samples": include_samples,
-            "lang": lang,
-            "steps": steps,
-            "dt_s": dt_s,
-            "low_speed": low_speed,
-            "high_speed": high_speed,
-            "floor_amp_g": floor_amp_g,
-            "base_fault_amp_g": base_fault_amp_g,
-            "diffuse_excitation": diffuse_excitation,
-            "missing_speed_ratio": missing_speed_ratio,
-            "blank_location_ratio": blank_location_ratio,
-            "drop_counter": drop_counter,
-            "overflow_counter": overflow_counter,
-            "accel_scale": accel_scale,
-            "background_hz": background_hz,
-            "clutter_hz": clutter_hz,
-        }
-
-    return _build()
-
-
-def _materialize_samples(
-    case: Mapping[str, object],
-    *,
-    vibration_strength_db_scalar: Any,
-    bucket_for_strength: Any,
-    AnalysisSettingsSnapshot: Any,
-    vehicle_orders_hz: Any,
-) -> list[dict[str, object]]:
-    metadata = case["metadata"]
-    if not isinstance(metadata, Mapping):
-        raise TypeError("case metadata must be a mapping")
-    sensors = case["sensors"]
-    if not isinstance(sensors, Sequence):
-        raise TypeError("case sensors must be a sequence")
-
-    scenario = str(case["scenario"])
-    fault_kind = str(case["fault_kind"])
-    steps = int(case["steps"])
-    dt_s = float(case["dt_s"])
-    low_speed = float(case["low_speed"])
-    high_speed = float(case["high_speed"])
-    floor_amp_g = float(case["floor_amp_g"])
-    base_fault_amp_g = float(case["base_fault_amp_g"])
-    diffuse_excitation = bool(case["diffuse_excitation"])
-    missing_speed_ratio = float(case["missing_speed_ratio"])
-    blank_location_ratio = float(case["blank_location_ratio"])
-    drop_counter = int(case["drop_counter"])
-    overflow_counter = int(case["overflow_counter"])
-    accel_scale = float(case["accel_scale"])
-    background_hz = float(case["background_hz"])
-    clutter_hz = float(case["clutter_hz"])
-    raw_sample_rate_hz = _sample_rate_from_metadata(metadata)
-
-    samples: list[dict[str, object]] = []
-    for step in range(steps):
-        speed_kmh = _speed_for_step(scenario, step, steps, low_speed, high_speed)
-        if steps > 0 and (step / max(1, steps)) < missing_speed_ratio:
-            sampled_speed_kmh: float | None = None
-        else:
-            sampled_speed_kmh = round(speed_kmh, 3)
-
-        fault_hz = _order_hz_for_fault(
-            fault_kind=fault_kind,
-            speed_kmh=sampled_speed_kmh,
-            metadata=metadata,
-            AnalysisSettingsSnapshot=AnalysisSettingsSnapshot,
-            vehicle_orders_hz=vehicle_orders_hz,
-        )
-        timestamp_offset = step * dt_s
-
-        for sensor_index, sensor in enumerate(sensors):
-            if not isinstance(sensor, Mapping):
-                continue
-            dominance = 1.0
-            if fault_kind != "none" and not diffuse_excitation:
-                dominance = (
-                    1.65 if sensor_index == 0 else (0.55 + (sensor_index * 0.12))
-                )
-
-            base_amp_g = max(1e-6, floor_amp_g * (1.2 + (sensor_index * 0.18)))
-            fault_amp_g = max(1e-6, base_fault_amp_g * dominance)
-            if fault_kind == "none":
-                fault_amp_g = base_amp_g * 1.35
-
-            if scenario == "idle":
-                fault_amp_g *= 0.65
-
-            vibration_strength_db = vibration_strength_db_scalar(
-                peak_band_rms_amp_g=max(base_amp_g, fault_amp_g),
-                floor_amp_g=floor_amp_g,
-            )
-            peaks = [
-                _build_peak(
-                    hz=fault_hz or background_hz,
-                    amp_g=max(base_amp_g, fault_amp_g),
-                    vibration_strength_db_scalar=vibration_strength_db_scalar,
-                    bucket_for_strength=bucket_for_strength,
-                    floor_amp_g=floor_amp_g,
-                ),
-                _build_peak(
-                    hz=background_hz + (sensor_index * 3.0) + (step % 5),
-                    amp_g=max(1e-6, base_amp_g * 0.85),
-                    vibration_strength_db_scalar=vibration_strength_db_scalar,
-                    bucket_for_strength=bucket_for_strength,
-                    floor_amp_g=floor_amp_g,
-                ),
-                _build_peak(
-                    hz=clutter_hz + (sensor_index * 1.5),
-                    amp_g=max(1e-6, base_amp_g * 0.45),
-                    vibration_strength_db_scalar=vibration_strength_db_scalar,
-                    bucket_for_strength=bucket_for_strength,
-                    floor_amp_g=floor_amp_g,
-                ),
-            ]
-
-            sample: dict[str, object] = {
-                "run_id": str(metadata.get("run_id") or ""),
-                "timestamp_utc": _timestamp_at(timestamp_offset),
-                "t_s": round(timestamp_offset, 3),
-                "client_id": str(sensor.get("client_id") or ""),
-                "client_name": str(sensor.get("client_name") or ""),
-                "location": (
-                    ""
-                    if (sensor_index / max(1, len(sensors))) < blank_location_ratio
-                    else str(sensor.get("location") or "")
-                ),
-                "sample_rate_hz": raw_sample_rate_hz,
-                "speed_kmh": sampled_speed_kmh,
-                "gps_speed_kmh": sampled_speed_kmh,
-                "speed_source": "gps" if sampled_speed_kmh is not None else "none",
-                "engine_rpm": (
-                    round((sampled_speed_kmh or 0.0) * 35.0, 3)
-                    if fault_kind == "engine" and sampled_speed_kmh is not None
-                    else None
-                ),
-                "engine_rpm_source": (
-                    "estimated_from_speed_and_ratios"
-                    if fault_kind == "engine" and sampled_speed_kmh is not None
-                    else "missing"
-                ),
-                "gear": float(metadata.get("current_gear_ratio") or 0.0) or None,
-                "final_drive_ratio": float(metadata.get("final_drive_ratio") or 0.0)
-                or None,
-                "accel_x_g": round(base_amp_g * (0.8 + accel_scale), 6),
-                "accel_y_g": round(base_amp_g * (0.6 + (accel_scale * 0.5)), 6),
-                "accel_z_g": round(1.0 + base_amp_g * (0.4 + accel_scale), 6),
-                "dominant_freq_hz": round(fault_hz or background_hz, 3),
-                "dominant_axis": "combined",
-                "top_peaks": peaks,
-                "vibration_strength_db": round(vibration_strength_db, 3),
-                "strength_bucket": bucket_for_strength(vibration_strength_db),
-                "strength_peak_amp_g": round(max(base_amp_g, fault_amp_g), 6),
-                "strength_floor_amp_g": round(floor_amp_g, 6),
-                "frames_dropped_total": drop_counter + step,
-                "queue_overflow_drops": overflow_counter + (step // 3),
-            }
-            samples.append(sample)
-    return samples
-
-
-def _validate_summary(
-    summary: Mapping[str, object],
-    expected_rows: int,
-    TypeAdapter: Any,
-    AnalysisSummary: Any,
-) -> None:
-    TypeAdapter(AnalysisSummary).validate_python(summary)
-    summary_rows = summary.get("rows")
-    if summary_rows != expected_rows:
-        raise AssertionError(
-            f"summary rows {summary_rows!r} != expected {expected_rows}"
-        )
-    if summary.get("findings") is None:
-        raise AssertionError("summary findings missing")
-    if summary.get("run_suitability") is None:
-        raise AssertionError("summary run_suitability missing")
-    json.dumps(summary, ensure_ascii=False, allow_nan=False)
-
-
-def _write_failure_artifact(
-    *,
-    case: Mapping[str, object] | None,
-    summary: Mapping[str, object] | None,
-    exc: BaseException,
-    artifact_dir: Path,
-) -> Path | None:
-    if case is None:
-        return None
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-    run_id = "unknown-run"
-    metadata = case.get("metadata")
-    if isinstance(metadata, Mapping):
-        raw_run_id = metadata.get("run_id")
-        if isinstance(raw_run_id, str) and raw_run_id.strip():
-            run_id = raw_run_id.strip()
-    artifact_path = artifact_dir / (
-        f"analysis-fuzz-failure-{timestamp}-{os.getpid()}-{run_id}.json"
-    )
-    payload: dict[str, object] = {
-        "exception_type": type(exc).__name__,
-        "exception_message": str(exc),
-        "traceback": traceback.format_exc(),
-        "case": case,
-        "summary": summary,
-    }
-    artifact_path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False),
-        encoding="utf-8",
-    )
-    return artifact_path
-
-
-def _worker_seed(base_seed: int | None, worker_index: int) -> int | None:
-    if base_seed is None:
-        return None
-    return base_seed + worker_index
-
-
-def _worker_prefix(worker_index: int | None) -> str:
-    if worker_index is None:
-        return ""
-    return f"[worker {worker_index}] "
-
-
 def _build_worker_command(
     config: FuzzConfig, *, worker_index: int, result_file: Path
 ) -> list[str]:
@@ -693,16 +142,12 @@ def _build_worker_command(
         str(result_file),
     ]
     if config.seed is not None:
-        cmd.extend(["--seed", str(_worker_seed(config.seed, worker_index))])
+        cmd.extend(["--seed", str(worker_seed(config.seed, worker_index))])
     if config.include_samples is True:
         cmd.append("--include-samples")
     elif config.include_samples is False:
         cmd.append("--no-include-samples")
     return cmd
-
-
-def _terminate_processes(processes: Sequence[subprocess.Popen[str]]) -> None:
-    _repo_tooling_support.terminate_processes(processes)
 
 
 def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
@@ -722,8 +167,8 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
     from vibesensor.adapters.analysis_summary import summarize_run_data
     from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
     from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
+    from vibesensor.shared.order_bands import vehicle_orders_hz
     from vibesensor.strength_bands import bucket_for_strength
-    from vibesensor.use_cases.diagnostics import vehicle_orders_hz
     from vibesensor.vibration_strength import vibration_strength_db_scalar
 
     stop_event = threading.Event()
@@ -733,7 +178,7 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
     current_summary: dict[str, object] | None = None
     total_examples = 0
     worker_index = config.worker_index if config.worker_index is not None else 0
-    worker_seed = _worker_seed(config.seed, worker_index)
+    worker_seed_value = worker_seed(config.seed, worker_index)
 
     @settings(
         max_examples=config.batch_examples,
@@ -747,13 +192,13 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
         ),
         phases=(Phase.generate, Phase.target, Phase.shrink),
     )
-    @given(case=_sample_case_strategy(st))
+    @given(case=sample_case_strategy(st))
     def _fuzz(case: dict[str, object]) -> None:
         nonlocal current_case, current_summary, total_examples
         total_examples += 1
         current_case = case
         current_summary = None
-        samples = _materialize_samples(
+        samples = materialize_samples(
             case,
             vibration_strength_db_scalar=vibration_strength_db_scalar,
             bucket_for_strength=bucket_for_strength,
@@ -769,7 +214,7 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
         lang = case.get("lang")
         if lang is not None and not isinstance(lang, str):
             raise TypeError("lang must be a string or None")
-        include_samples = _coerce_include_samples(case, config.include_samples)
+        include_samples = coerce_include_samples(case, config.include_samples)
         summary = summarize_run_data(
             dict(metadata),
             samples,
@@ -778,22 +223,22 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
             file_name=f"{metadata.get('run_id', 'fuzz-run')}.jsonl",
         )
         current_summary = dict(summary)
-        _validate_summary(
+        validate_summary(
             current_summary,
             expected_rows=len(samples),
             TypeAdapter=TypeAdapter,
             AnalysisSummary=AnalysisSummary,
         )
 
-    if worker_seed is not None:
-        _fuzz = seed(worker_seed)(_fuzz)
+    if worker_seed_value is not None:
+        _fuzz = seed(worker_seed_value)(_fuzz)
 
     try:
         while not stop_event.is_set() and time.monotonic() < deadline:
             _fuzz()
     except BaseException as exc:
         stop_event.set()
-        artifact_path = _write_failure_artifact(
+        artifact_path = write_analysis_failure_artifact(
             case=current_case,
             summary=current_summary,
             exc=exc,
@@ -809,7 +254,7 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
         "elapsed_s": elapsed_s,
         "examples": total_examples,
     }
-    prefix = _worker_prefix(config.worker_index)
+    prefix = worker_prefix(config.worker_index)
     print(
         f"{prefix}Fuzz run passed: "
         f"{elapsed_s:.1f}s against summarize_run_data() "
@@ -845,13 +290,19 @@ def _run_process_coordinator(config: FuzzConfig) -> int:
                     if exit_code != 0 and failure is None:
                         failure = (worker_index, exit_code)
                 if failure is not None:
-                    _terminate_processes([process for _, process, _ in processes])
+                    terminate_processes(
+                        [process for _, process, _ in processes],
+                        repo_root=REPO_ROOT,
+                    )
                     break
                 if remaining:
                     time.sleep(0.2)
                 pending = remaining
         finally:
-            _terminate_processes([process for _, process, _ in processes])
+            terminate_processes(
+                [process for _, process, _ in processes],
+                repo_root=REPO_ROOT,
+            )
 
         if failure is not None:
             worker_index, exit_code = failure

--- a/tools/dev/fuzz_analysis_scenarios.py
+++ b/tools/dev/fuzz_analysis_scenarios.py
@@ -1,0 +1,486 @@
+"""Scenario definitions and materializers for analysis fuzzing."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+SENSOR_FIXTURES: tuple[dict[str, str], ...] = (
+    {
+        "client_id": "fl-wheel",
+        "client_name": "Front Left Wheel",
+        "location": "front_left_wheel",
+    },
+    {
+        "client_id": "fr-wheel",
+        "client_name": "Front Right Wheel",
+        "location": "front_right_wheel",
+    },
+    {
+        "client_id": "rl-wheel",
+        "client_name": "Rear Left Wheel",
+        "location": "rear_left_wheel",
+    },
+    {
+        "client_id": "rr-wheel",
+        "client_name": "Rear Right Wheel",
+        "location": "rear_right_wheel",
+    },
+    {
+        "client_id": "drive-tunnel",
+        "client_name": "Driveshaft Tunnel",
+        "location": "driveshaft_tunnel",
+    },
+    {
+        "client_id": "engine-bay",
+        "client_name": "Engine Bay",
+        "location": "engine_bay",
+    },
+    {
+        "client_id": "driver-seat",
+        "client_name": "Driver Seat",
+        "location": "driver_seat",
+    },
+)
+
+SCENARIO_KINDS: tuple[str, ...] = (
+    "idle",
+    "steady",
+    "accel",
+    "decel",
+    "oscillate",
+)
+
+FAULT_KINDS: tuple[str, ...] = (
+    "none",
+    "wheel",
+    "driveline",
+    "engine",
+    "random",
+)
+
+LANGUAGE_CHOICES: tuple[str | None, ...] = (None, "en", "EN", "nl", "NL")
+SENSOR_MODELS: tuple[str, ...] = ("ADXL345", "ICM-42688-P", "LSM6DSOX", "unknown")
+
+
+def timestamp_at(offset_s: float) -> str:
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return (base + timedelta(seconds=offset_s)).isoformat().replace("+00:00", "Z")
+
+
+def sample_rate_from_metadata(metadata: Mapping[str, object]) -> int | None:
+    raw = metadata.get("raw_sample_rate_hz")
+    return int(raw) if isinstance(raw, int) else None
+
+
+def coerce_include_samples(case: Mapping[str, object], override: bool | None) -> bool:
+    if override is not None:
+        return override
+    raw = case.get("include_samples")
+    return bool(raw) if isinstance(raw, bool) else False
+
+
+def metadata_strategy(st: Any) -> Any:
+    positive_int = st.integers(min_value=32, max_value=6400)
+    positive_float = st.floats(
+        min_value=0.05, max_value=2.0, allow_nan=False, allow_infinity=False
+    )
+    settings_float = st.floats(
+        min_value=0.1,
+        max_value=10.0,
+        allow_nan=False,
+        allow_infinity=False,
+    )
+    return st.fixed_dictionaries(
+        {
+            "run_id": st.from_regex(r"[a-z0-9][a-z0-9_-]{2,20}", fullmatch=True),
+            "start_time_utc": st.just(timestamp_at(0.0)),
+            "end_time_utc": st.one_of(
+                st.none(),
+                st.just(timestamp_at(60.0)),
+                st.just(timestamp_at(180.0)),
+            ),
+            "sensor_model": st.sampled_from(SENSOR_MODELS),
+            "raw_sample_rate_hz": st.one_of(st.none(), positive_int, st.just(0)),
+            "feature_interval_s": st.one_of(st.none(), positive_float),
+            "fft_window_size_samples": st.one_of(
+                st.none(),
+                st.sampled_from((128, 256, 512, 1024, 2048, 4096)),
+            ),
+            "accel_scale_g_per_lsb": st.one_of(
+                st.none(),
+                st.floats(
+                    min_value=1e-5,
+                    max_value=0.05,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            ),
+            "language": st.one_of(st.none(), st.sampled_from(("en", "nl", "EN", "NL"))),
+            "incomplete_for_order_analysis": st.booleans(),
+            "tire_width_mm": st.floats(
+                min_value=100.0,
+                max_value=355.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            "tire_aspect_pct": st.floats(
+                min_value=25.0,
+                max_value=80.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            "rim_in": st.floats(
+                min_value=13.0,
+                max_value=24.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+            "final_drive_ratio": settings_float,
+            "current_gear_ratio": st.floats(
+                min_value=0.4,
+                max_value=4.8,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        }
+    )
+
+
+def sensor_selection_strategy(st: Any) -> Any:
+    return st.lists(
+        st.sampled_from(SENSOR_FIXTURES),
+        min_size=1,
+        max_size=4,
+        unique_by=lambda sensor: sensor["client_id"],
+    )
+
+
+def speed_for_step(
+    kind: str,
+    step: int,
+    total_steps: int,
+    low_kmh: float,
+    high_kmh: float,
+) -> float:
+    if total_steps <= 1:
+        return low_kmh
+    ratio = step / float(total_steps - 1)
+    if kind == "idle":
+        return 0.0
+    if kind == "steady":
+        return low_kmh
+    if kind == "accel":
+        return low_kmh + ((high_kmh - low_kmh) * ratio)
+    if kind == "decel":
+        return high_kmh - ((high_kmh - low_kmh) * ratio)
+    midpoint = 0.5
+    swing = abs(ratio - midpoint) / midpoint
+    return low_kmh + ((high_kmh - low_kmh) * (1.0 - swing))
+
+
+def build_peak(
+    *,
+    hz: float,
+    amp_g: float,
+    vibration_strength_db_scalar: Any,
+    bucket_for_strength: Any,
+    floor_amp_g: float,
+) -> dict[str, float | str]:
+    strength_db = vibration_strength_db_scalar(
+        peak_band_rms_amp_g=amp_g,
+        floor_amp_g=floor_amp_g,
+    )
+    return {
+        "hz": round(max(0.1, hz), 3),
+        "amp": round(max(1e-6, amp_g), 6),
+        "vibration_strength_db": round(strength_db, 3),
+        "strength_bucket": bucket_for_strength(strength_db),
+    }
+
+
+def order_hz_for_fault(
+    *,
+    fault_kind: str,
+    speed_kmh: float | None,
+    metadata: Mapping[str, object],
+    AnalysisSettingsSnapshot: Any,
+    vehicle_orders_hz: Any,
+) -> float | None:
+    if speed_kmh is None or speed_kmh <= 0.0:
+        return None
+    settings = AnalysisSettingsSnapshot.from_dict(metadata)
+    order_refs = vehicle_orders_hz(speed_mps=speed_kmh / 3.6, settings=settings)
+    if not isinstance(order_refs, Mapping):
+        return None
+    if fault_kind == "wheel":
+        value = order_refs.get("wheel_hz")
+        return float(value) if isinstance(value, int | float) else None
+    if fault_kind == "driveline":
+        value = order_refs.get("drive_hz")
+        return float(value) if isinstance(value, int | float) else None
+    if fault_kind == "engine":
+        value = order_refs.get("engine_hz")
+        return float(value) if isinstance(value, int | float) else None
+    return None
+
+
+def sample_case_strategy(st: Any) -> Any:
+    @st.composite
+    def _build(draw: Any) -> dict[str, object]:
+        metadata = draw(metadata_strategy(st))
+        sensors = draw(sensor_selection_strategy(st))
+        scenario = draw(st.sampled_from(SCENARIO_KINDS))
+        fault_kind = draw(st.sampled_from(FAULT_KINDS))
+        include_samples = draw(st.booleans())
+        lang = draw(st.sampled_from(LANGUAGE_CHOICES))
+        steps = draw(st.integers(min_value=0, max_value=28))
+        dt_s = draw(
+            st.floats(
+                min_value=0.2,
+                max_value=2.5,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        low_speed = draw(
+            st.floats(
+                min_value=10.0,
+                max_value=90.0,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        high_speed = draw(
+            st.floats(
+                min_value=max(low_speed + 5.0, 20.0),
+                max_value=180.0,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        floor_amp_g = draw(
+            st.floats(
+                min_value=0.0005,
+                max_value=0.05,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        base_fault_amp_g = draw(
+            st.floats(
+                min_value=0.002,
+                max_value=0.4,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        diffuse_excitation = draw(st.booleans())
+        missing_speed_ratio = draw(
+            st.floats(
+                min_value=0.0,
+                max_value=0.7,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        blank_location_ratio = draw(
+            st.floats(
+                min_value=0.0,
+                max_value=0.5,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        drop_counter = draw(st.integers(min_value=0, max_value=100))
+        overflow_counter = draw(st.integers(min_value=0, max_value=30))
+        accel_scale = draw(
+            st.floats(
+                min_value=0.005,
+                max_value=0.35,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        background_hz = draw(
+            st.floats(
+                min_value=8.0,
+                max_value=120.0,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        clutter_hz = draw(
+            st.floats(
+                min_value=20.0,
+                max_value=250.0,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+
+        return {
+            "metadata": metadata,
+            "sensors": sensors,
+            "scenario": scenario,
+            "fault_kind": fault_kind,
+            "include_samples": include_samples,
+            "lang": lang,
+            "steps": steps,
+            "dt_s": dt_s,
+            "low_speed": low_speed,
+            "high_speed": high_speed,
+            "floor_amp_g": floor_amp_g,
+            "base_fault_amp_g": base_fault_amp_g,
+            "diffuse_excitation": diffuse_excitation,
+            "missing_speed_ratio": missing_speed_ratio,
+            "blank_location_ratio": blank_location_ratio,
+            "drop_counter": drop_counter,
+            "overflow_counter": overflow_counter,
+            "accel_scale": accel_scale,
+            "background_hz": background_hz,
+            "clutter_hz": clutter_hz,
+        }
+
+    return _build()
+
+
+def materialize_samples(
+    case: Mapping[str, object],
+    *,
+    vibration_strength_db_scalar: Any,
+    bucket_for_strength: Any,
+    AnalysisSettingsSnapshot: Any,
+    vehicle_orders_hz: Any,
+) -> list[dict[str, object]]:
+    metadata = case["metadata"]
+    if not isinstance(metadata, Mapping):
+        raise TypeError("case metadata must be a mapping")
+    sensors = case["sensors"]
+    if not isinstance(sensors, Sequence):
+        raise TypeError("case sensors must be a sequence")
+
+    scenario = str(case["scenario"])
+    fault_kind = str(case["fault_kind"])
+    steps = int(case["steps"])
+    dt_s = float(case["dt_s"])
+    low_speed = float(case["low_speed"])
+    high_speed = float(case["high_speed"])
+    floor_amp_g = float(case["floor_amp_g"])
+    base_fault_amp_g = float(case["base_fault_amp_g"])
+    diffuse_excitation = bool(case["diffuse_excitation"])
+    missing_speed_ratio = float(case["missing_speed_ratio"])
+    blank_location_ratio = float(case["blank_location_ratio"])
+    drop_counter = int(case["drop_counter"])
+    overflow_counter = int(case["overflow_counter"])
+    accel_scale = float(case["accel_scale"])
+    background_hz = float(case["background_hz"])
+    clutter_hz = float(case["clutter_hz"])
+    raw_sample_rate_hz = sample_rate_from_metadata(metadata)
+
+    samples: list[dict[str, object]] = []
+    for step in range(steps):
+        speed_kmh = speed_for_step(scenario, step, steps, low_speed, high_speed)
+        if steps > 0 and (step / max(1, steps)) < missing_speed_ratio:
+            sampled_speed_kmh: float | None = None
+        else:
+            sampled_speed_kmh = round(speed_kmh, 3)
+
+        fault_hz = order_hz_for_fault(
+            fault_kind=fault_kind,
+            speed_kmh=sampled_speed_kmh,
+            metadata=metadata,
+            AnalysisSettingsSnapshot=AnalysisSettingsSnapshot,
+            vehicle_orders_hz=vehicle_orders_hz,
+        )
+        timestamp_offset = step * dt_s
+
+        for sensor_index, sensor in enumerate(sensors):
+            if not isinstance(sensor, Mapping):
+                continue
+            dominance = 1.0
+            if fault_kind != "none" and not diffuse_excitation:
+                dominance = (
+                    1.65 if sensor_index == 0 else (0.55 + (sensor_index * 0.12))
+                )
+
+            base_amp_g = max(1e-6, floor_amp_g * (1.2 + (sensor_index * 0.18)))
+            fault_amp_g = max(1e-6, base_fault_amp_g * dominance)
+            if fault_kind == "none":
+                fault_amp_g = base_amp_g * 1.35
+
+            if scenario == "idle":
+                fault_amp_g *= 0.65
+
+            vibration_strength_db = vibration_strength_db_scalar(
+                peak_band_rms_amp_g=max(base_amp_g, fault_amp_g),
+                floor_amp_g=floor_amp_g,
+            )
+            peaks = [
+                build_peak(
+                    hz=fault_hz or background_hz,
+                    amp_g=max(base_amp_g, fault_amp_g),
+                    vibration_strength_db_scalar=vibration_strength_db_scalar,
+                    bucket_for_strength=bucket_for_strength,
+                    floor_amp_g=floor_amp_g,
+                ),
+                build_peak(
+                    hz=background_hz + (sensor_index * 3.0) + (step % 5),
+                    amp_g=max(1e-6, base_amp_g * 0.85),
+                    vibration_strength_db_scalar=vibration_strength_db_scalar,
+                    bucket_for_strength=bucket_for_strength,
+                    floor_amp_g=floor_amp_g,
+                ),
+                build_peak(
+                    hz=clutter_hz + (sensor_index * 1.5),
+                    amp_g=max(1e-6, base_amp_g * 0.45),
+                    vibration_strength_db_scalar=vibration_strength_db_scalar,
+                    bucket_for_strength=bucket_for_strength,
+                    floor_amp_g=floor_amp_g,
+                ),
+            ]
+
+            sample: dict[str, object] = {
+                "run_id": str(metadata.get("run_id") or ""),
+                "timestamp_utc": timestamp_at(timestamp_offset),
+                "t_s": round(timestamp_offset, 3),
+                "client_id": str(sensor.get("client_id") or ""),
+                "client_name": str(sensor.get("client_name") or ""),
+                "location": (
+                    ""
+                    if (sensor_index / max(1, len(sensors))) < blank_location_ratio
+                    else str(sensor.get("location") or "")
+                ),
+                "sample_rate_hz": raw_sample_rate_hz,
+                "speed_kmh": sampled_speed_kmh,
+                "gps_speed_kmh": sampled_speed_kmh,
+                "speed_source": "gps" if sampled_speed_kmh is not None else "none",
+                "engine_rpm": (
+                    round((sampled_speed_kmh or 0.0) * 35.0, 3)
+                    if fault_kind == "engine" and sampled_speed_kmh is not None
+                    else None
+                ),
+                "engine_rpm_source": (
+                    "estimated_from_speed_and_ratios"
+                    if fault_kind == "engine" and sampled_speed_kmh is not None
+                    else "missing"
+                ),
+                "gear": float(metadata.get("current_gear_ratio") or 0.0) or None,
+                "final_drive_ratio": float(metadata.get("final_drive_ratio") or 0.0)
+                or None,
+                "accel_x_g": round(base_amp_g * (0.8 + accel_scale), 6),
+                "accel_y_g": round(base_amp_g * (0.6 + (accel_scale * 0.5)), 6),
+                "accel_z_g": round(1.0 + base_amp_g * (0.4 + accel_scale), 6),
+                "dominant_freq_hz": round(fault_hz or background_hz, 3),
+                "dominant_axis": "combined",
+                "top_peaks": peaks,
+                "vibration_strength_db": round(vibration_strength_db, 3),
+                "strength_bucket": bucket_for_strength(vibration_strength_db),
+                "strength_peak_amp_g": round(max(base_amp_g, fault_amp_g), 6),
+                "strength_floor_amp_g": round(floor_amp_g, 6),
+                "frames_dropped_total": drop_counter + step,
+                "queue_overflow_drops": overflow_counter + (step // 3),
+            }
+            samples.append(sample)
+    return samples

--- a/tools/dev/fuzz_artifacts.py
+++ b/tools/dev/fuzz_artifacts.py
@@ -1,0 +1,74 @@
+"""Failure artifact writers for fuzz tooling."""
+
+from __future__ import annotations
+
+import json
+import os
+import traceback
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def write_processing_failure_artifact(
+    *,
+    target: str,
+    case: Mapping[str, object] | None,
+    output: Mapping[str, object] | None,
+    exc: BaseException,
+    artifact_dir: Path,
+) -> Path | None:
+    if case is None:
+        return None
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    artifact_path = (
+        artifact_dir / f"{target}-fuzz-failure-{timestamp}-{os.getpid()}.json"
+    )
+    payload: dict[str, object] = {
+        "target": target,
+        "exception_type": type(exc).__name__,
+        "exception_message": str(exc),
+        "traceback": traceback.format_exc(),
+        "case": case,
+        "output": output,
+    }
+    artifact_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False),
+        encoding="utf-8",
+    )
+    return artifact_path
+
+
+def write_analysis_failure_artifact(
+    *,
+    case: Mapping[str, object] | None,
+    summary: Mapping[str, object] | None,
+    exc: BaseException,
+    artifact_dir: Path,
+) -> Path | None:
+    if case is None:
+        return None
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_id = "unknown-run"
+    metadata = case.get("metadata")
+    if isinstance(metadata, Mapping):
+        raw_run_id = metadata.get("run_id")
+        if isinstance(raw_run_id, str) and raw_run_id.strip():
+            run_id = raw_run_id.strip()
+    artifact_path = artifact_dir / (
+        f"analysis-fuzz-failure-{timestamp}-{os.getpid()}-{run_id}.json"
+    )
+    payload: dict[str, object] = {
+        "exception_type": type(exc).__name__,
+        "exception_message": str(exc),
+        "traceback": traceback.format_exc(),
+        "case": case,
+        "summary": summary,
+    }
+    artifact_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False),
+        encoding="utf-8",
+    )
+    return artifact_path

--- a/tools/dev/fuzz_common.py
+++ b/tools/dev/fuzz_common.py
@@ -1,0 +1,39 @@
+"""Shared runtime helpers for fuzz tooling scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from types import ModuleType
+
+
+def load_repo_tooling_support(repo_root: Path) -> ModuleType:
+    helper_path = repo_root / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def terminate_processes(
+    processes: Sequence[subprocess.Popen[str]],
+    *,
+    repo_root: Path,
+) -> None:
+    load_repo_tooling_support(repo_root).terminate_processes(processes)
+
+
+def worker_seed(base_seed: int | None, worker_index: int) -> int | None:
+    if base_seed is None:
+        return None
+    return base_seed + worker_index
+
+
+def worker_prefix(worker_index: int | None) -> str:
+    if worker_index is None:
+        return ""
+    return f"[worker {worker_index}] "

--- a/tools/dev/fuzz_processing_assertions.py
+++ b/tools/dev/fuzz_processing_assertions.py
@@ -1,0 +1,14 @@
+"""Assertion helpers for processing fuzz targets."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+
+def json_no_nan(value: object) -> None:
+    json.dumps(value, ensure_ascii=False, allow_nan=False)
+
+
+def is_sorted_desc(values: Sequence[float]) -> bool:
+    return all(left >= right for left, right in zip(values, values[1:], strict=False))

--- a/tools/dev/fuzz_processing_pipeline.py
+++ b/tools/dev/fuzz_processing_pipeline.py
@@ -4,37 +4,32 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
-import os
 import subprocess
 import sys
 import tempfile
 import threading
 import time
-import traceback
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
+
+from fuzz_artifacts import write_processing_failure_artifact
+from fuzz_common import terminate_processes, worker_prefix, worker_seed
+from fuzz_processing_assertions import is_sorted_desc, json_no_nan
+from fuzz_processing_scenarios import (
+    fft_case_strategy,
+    make_freq_slice,
+    processor_case_strategy,
+    strength_case_strategy,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _load_repo_tooling_support():
-    helper_path = REPO_ROOT / "tools" / "repo_tooling_support.py"
-    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-_repo_tooling_support = _load_repo_tooling_support()
 ARTIFACT_DIR = REPO_ROOT / "artifacts" / "fuzz"
 
 TargetName = Literal["strength", "fft", "processor", "all"]
@@ -121,54 +116,10 @@ def _parse_args() -> FuzzConfig:
     )
 
 
-def _write_failure_artifact(
-    *,
-    target: str,
-    case: Mapping[str, object] | None,
-    output: Mapping[str, object] | None,
-    exc: BaseException,
-    artifact_dir: Path,
-) -> Path | None:
-    if case is None:
-        return None
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-    artifact_path = (
-        artifact_dir / f"{target}-fuzz-failure-{timestamp}-{os.getpid()}.json"
-    )
-    payload: dict[str, object] = {
-        "target": target,
-        "exception_type": type(exc).__name__,
-        "exception_message": str(exc),
-        "traceback": traceback.format_exc(),
-        "case": case,
-        "output": output,
-    }
-    artifact_path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False),
-        encoding="utf-8",
-    )
-    return artifact_path
-
-
-def _json_no_nan(value: object) -> None:
-    json.dumps(value, ensure_ascii=False, allow_nan=False)
-
-
-def _is_sorted_desc(values: Sequence[float]) -> bool:
-    return all(left >= right for left, right in zip(values, values[1:], strict=False))
-
-
 def _float_or_none(value: object) -> float | None:
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return float(value)
     return None
-
-
-def _worker_seed(base_seed: int | None, worker_index: int) -> int | None:
-    if base_seed is None:
-        return None
-    return base_seed + worker_index
 
 
 def _run_local_target(
@@ -183,12 +134,6 @@ def _run_local_target(
     worker_index = config.worker_index if config.worker_index is not None else 0
     total_examples = worker_fn(worker_index, deadline, stop_event)
     return time.monotonic() - start, total_examples
-
-
-def _worker_prefix(worker_index: int | None) -> str:
-    if worker_index is None:
-        return ""
-    return f"[worker {worker_index}] "
 
 
 def _build_worker_command(
@@ -213,245 +158,12 @@ def _build_worker_command(
         str(result_file),
     ]
     if config.seed is not None:
-        cmd.extend(["--seed", str(_worker_seed(config.seed, worker_index))])
+        cmd.extend(["--seed", str(worker_seed(config.seed, worker_index))])
     return cmd
 
 
 def _terminate_processes(processes: Sequence[subprocess.Popen[str]]) -> None:
-    _repo_tooling_support.terminate_processes(processes)
-
-
-def _strength_case_strategy(st: Any) -> Any:
-    @st.composite
-    def _build(draw: Any) -> dict[str, object]:
-        axis_count = draw(st.integers(min_value=0, max_value=3))
-        lengths = draw(
-            st.lists(
-                st.integers(min_value=0, max_value=192),
-                min_size=axis_count,
-                max_size=axis_count,
-            )
-        )
-        axis_spectra = [
-            draw(
-                st.lists(
-                    st.floats(
-                        min_value=-1.0,
-                        max_value=4.0,
-                        allow_nan=False,
-                        allow_infinity=False,
-                    ),
-                    min_size=length,
-                    max_size=length,
-                )
-            )
-            for length in lengths
-        ]
-        axis_count_for_mean = draw(
-            st.one_of(
-                st.none(),
-                st.integers(min_value=1, max_value=4),
-            )
-        )
-        freq_step_hz = draw(
-            st.floats(
-                min_value=0.1, max_value=12.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        start_hz = draw(
-            st.floats(
-                min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        center_idx = draw(
-            st.integers(min_value=0, max_value=max(0, min(lengths or [0]) - 1))
-        )
-        bandwidth_hz = draw(
-            st.floats(
-                min_value=0.05, max_value=8.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        epsilon_g = draw(
-            st.one_of(
-                st.none(),
-                st.floats(
-                    min_value=1e-12,
-                    max_value=0.1,
-                    allow_nan=False,
-                    allow_infinity=False,
-                ),
-            )
-        )
-        return {
-            "axis_spectra": axis_spectra,
-            "axis_count_for_mean": axis_count_for_mean,
-            "freq_step_hz": freq_step_hz,
-            "start_hz": start_hz,
-            "center_idx": center_idx,
-            "bandwidth_hz": bandwidth_hz,
-            "epsilon_g": epsilon_g,
-        }
-
-    return _build()
-
-
-def _fft_case_strategy(st: Any) -> Any:
-    @st.composite
-    def _build(draw: Any) -> dict[str, object]:
-        sample_rate_hz = draw(st.integers(min_value=32, max_value=4096))
-        fft_n = draw(st.sampled_from((32, 64, 128, 256, 512)))
-        spectrum_min_hz = draw(
-            st.floats(
-                min_value=0.0, max_value=40.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        max_band_hz = max(float(sample_rate_hz) / 2.0, spectrum_min_hz + 1.0)
-        spectrum_max_hz = draw(
-            st.floats(
-                min_value=max(spectrum_min_hz + 0.1, 1.0),
-                max_value=max_band_hz,
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        spike_filter_enabled = draw(st.booleans())
-        spike_col = draw(st.integers(min_value=0, max_value=fft_n - 1))
-        spike_axis = draw(st.integers(min_value=0, max_value=2))
-        dc_offset = draw(
-            st.floats(
-                min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        base_block = draw(
-            st.lists(
-                st.lists(
-                    st.floats(
-                        min_value=-8.0,
-                        max_value=8.0,
-                        allow_nan=False,
-                        allow_infinity=False,
-                    ),
-                    min_size=fft_n,
-                    max_size=fft_n,
-                ),
-                min_size=3,
-                max_size=3,
-            )
-        )
-        spike_value = draw(
-            st.floats(
-                min_value=-64.0, max_value=64.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        return {
-            "sample_rate_hz": sample_rate_hz,
-            "fft_n": fft_n,
-            "spectrum_min_hz": spectrum_min_hz,
-            "spectrum_max_hz": spectrum_max_hz,
-            "spike_filter_enabled": spike_filter_enabled,
-            "spike_col": spike_col,
-            "spike_axis": spike_axis,
-            "dc_offset": dc_offset,
-            "base_block": base_block,
-            "spike_value": spike_value,
-        }
-
-    return _build()
-
-
-def _processor_case_strategy(st: Any) -> Any:
-    @st.composite
-    def _build(draw: Any) -> dict[str, object]:
-        sample_rate_hz = draw(st.integers(min_value=64, max_value=800))
-        waveform_seconds = draw(st.integers(min_value=1, max_value=4))
-        waveform_display_hz = draw(st.integers(min_value=1, max_value=120))
-        fft_n = draw(st.sampled_from((32, 64, 128, 256)))
-        spectrum_min_hz = draw(
-            st.floats(
-                min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False
-            )
-        )
-        spectrum_max_hz = draw(
-            st.floats(
-                min_value=max(spectrum_min_hz + 0.5, 5.0),
-                max_value=min(float(sample_rate_hz) / 2.0, 250.0),
-                allow_nan=False,
-                allow_infinity=False,
-            )
-        )
-        accel_scale = draw(
-            st.one_of(
-                st.none(),
-                st.floats(
-                    min_value=1e-5,
-                    max_value=0.05,
-                    allow_nan=False,
-                    allow_infinity=False,
-                ),
-            )
-        )
-        clients = draw(
-            st.lists(
-                st.from_regex(r"[a-z][a-z0-9_-]{1,10}", fullmatch=True),
-                min_size=1,
-                max_size=3,
-                unique=True,
-            )
-        )
-        chunks: list[dict[str, object]] = []
-        for client_id in clients:
-            chunk_count = draw(st.integers(min_value=1, max_value=3))
-            t0_us = 1_000_000
-            for _ in range(chunk_count):
-                row_count = draw(st.integers(min_value=0, max_value=fft_n * 2))
-                rows = draw(
-                    st.lists(
-                        st.lists(
-                            st.floats(
-                                min_value=-32.0,
-                                max_value=32.0,
-                                allow_nan=False,
-                                allow_infinity=False,
-                            ),
-                            min_size=3,
-                            max_size=3,
-                        ),
-                        min_size=row_count,
-                        max_size=row_count,
-                    )
-                )
-                sample_rate_override = draw(
-                    st.one_of(st.none(), st.integers(min_value=1, max_value=4096))
-                )
-                include_t0 = draw(st.booleans())
-                t0_increment = draw(st.integers(min_value=0, max_value=500_000))
-                if include_t0:
-                    t0_us += t0_increment
-                chunks.append(
-                    {
-                        "client_id": client_id,
-                        "rows": rows,
-                        "sample_rate_hz": sample_rate_override,
-                        "t0_us": t0_us if include_t0 else None,
-                    }
-                )
-        return {
-            "sample_rate_hz": sample_rate_hz,
-            "waveform_seconds": waveform_seconds,
-            "waveform_display_hz": waveform_display_hz,
-            "fft_n": fft_n,
-            "spectrum_min_hz": spectrum_min_hz,
-            "spectrum_max_hz": spectrum_max_hz,
-            "accel_scale_g_per_lsb": accel_scale,
-            "clients": clients,
-            "chunks": chunks,
-        }
-
-    return _build()
-
-
-def _make_freq_slice(length: int, *, start_hz: float, step_hz: float) -> list[float]:
-    return [start_hz + (step_hz * idx) for idx in range(length)]
+    terminate_processes(processes, repo_root=REPO_ROOT)
 
 
 def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> dict[str, object]:
@@ -473,7 +185,7 @@ def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> dict[str, 
         current_case: dict[str, object] | None = None
         current_output: dict[str, object] | None = None
         worker_examples = 0
-        worker_seed = _worker_seed(config.seed, worker_index)
+        worker_seed_value = worker_seed(config.seed, worker_index)
 
         @settings(
             max_examples=config.batch_examples,
@@ -487,7 +199,7 @@ def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> dict[str, 
             ),
             phases=(Phase.generate, Phase.target, Phase.shrink),
         )
-        @given(case=_strength_case_strategy(st))
+        @given(case=strength_case_strategy(st))
         def _fuzz(case: dict[str, object]) -> None:
             nonlocal current_case, current_output, worker_examples
             worker_examples += 1
@@ -521,7 +233,7 @@ def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> dict[str, 
             floor_amp = noise_floor_amp_p20_g(combined_spectrum_amp_g=combined)
             assert np.isfinite(floor_amp) and floor_amp >= 0.0
 
-            freq_hz = _make_freq_slice(
+            freq_hz = make_freq_slice(
                 len(combined),
                 start_hz=float(case["start_hz"]),
                 step_hz=float(case["freq_step_hz"]),
@@ -561,20 +273,20 @@ def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> dict[str, 
                 for peak in metrics["top_peaks"]
                 if isinstance(peak, Mapping) and "vibration_strength_db" in peak
             ]
-            assert _is_sorted_desc(peak_strengths), (
+            assert is_sorted_desc(peak_strengths), (
                 "strength peaks not sorted by descending dB"
             )
-            _json_no_nan(metrics)
+            json_no_nan(metrics)
 
-        if worker_seed is not None:
-            _fuzz = seed(worker_seed)(_fuzz)
+        if worker_seed_value is not None:
+            _fuzz = seed(worker_seed_value)(_fuzz)
 
         try:
             while not stop_event.is_set() and time.monotonic() < deadline:
                 _fuzz()
         except BaseException as exc:
             stop_event.set()
-            artifact_path = _write_failure_artifact(
+            artifact_path = write_processing_failure_artifact(
                 target="strength",
                 case=current_case,
                 output=current_output,
@@ -612,7 +324,7 @@ def _run_fft_target(config: FuzzConfig, *, duration_s: float) -> dict[str, objec
         current_case: dict[str, object] | None = None
         current_output: dict[str, object] | None = None
         worker_examples = 0
-        worker_seed = _worker_seed(config.seed, worker_index)
+        worker_seed_value = worker_seed(config.seed, worker_index)
 
         @settings(
             max_examples=config.batch_examples,
@@ -626,7 +338,7 @@ def _run_fft_target(config: FuzzConfig, *, duration_s: float) -> dict[str, objec
             ),
             phases=(Phase.generate, Phase.target, Phase.shrink),
         )
-        @given(case=_fft_case_strategy(st))
+        @given(case=fft_case_strategy(st))
         def _fuzz(case: dict[str, object]) -> None:
             nonlocal current_case, current_output, worker_examples
             worker_examples += 1
@@ -685,17 +397,17 @@ def _run_fft_target(config: FuzzConfig, *, duration_s: float) -> dict[str, objec
             TypeAdapter(VibrationStrengthMetrics).validate_python(
                 result["strength_metrics"]
             )
-            _json_no_nan(current_output)
+            json_no_nan(current_output)
 
-        if worker_seed is not None:
-            _fuzz = seed(worker_seed)(_fuzz)
+        if worker_seed_value is not None:
+            _fuzz = seed(worker_seed_value)(_fuzz)
 
         try:
             while not stop_event.is_set() and time.monotonic() < deadline:
                 _fuzz()
         except BaseException as exc:
             stop_event.set()
-            artifact_path = _write_failure_artifact(
+            artifact_path = write_processing_failure_artifact(
                 target="fft",
                 case=current_case,
                 output=current_output,
@@ -740,7 +452,7 @@ def _run_processor_target(
         current_case: dict[str, object] | None = None
         current_output: dict[str, object] | None = None
         worker_examples = 0
-        worker_seed = _worker_seed(config.seed, worker_index)
+        worker_seed_value = worker_seed(config.seed, worker_index)
 
         @settings(
             max_examples=config.batch_examples,
@@ -754,7 +466,7 @@ def _run_processor_target(
             ),
             phases=(Phase.generate, Phase.target, Phase.shrink),
         )
-        @given(case=_processor_case_strategy(st))
+        @given(case=processor_case_strategy(st))
         def _fuzz(case: dict[str, object]) -> None:
             nonlocal current_case, current_output, worker_examples
             worker_examples += 1
@@ -803,12 +515,12 @@ def _run_processor_target(
             for client_id in clients:
                 metrics = processor.compute_metrics(client_id)
                 TypeAdapter(ClientMetrics).validate_python(metrics)
-                _json_no_nan(metrics)
+                json_no_nan(metrics)
                 metrics_by_client[client_id] = metrics
 
                 spectrum_payload = processor.spectrum_payload(client_id)
                 TypeAdapter(SpectrumSeriesPayload).validate_python(spectrum_payload)
-                _json_no_nan(spectrum_payload)
+                json_no_nan(spectrum_payload)
                 spectrum_by_client[client_id] = spectrum_payload
 
                 xyz = processor.latest_sample_xyz(client_id)
@@ -819,19 +531,19 @@ def _run_processor_target(
             compute_all_result = processor.compute_all(clients)
             for metrics in compute_all_result.values():
                 TypeAdapter(ClientMetrics).validate_python(metrics)
-            _json_no_nan(compute_all_result)
+            json_no_nan(compute_all_result)
 
             multi = processor.multi_spectrum_payload(clients)
             TypeAdapter(SpectraPayload).validate_python(multi)
-            _json_no_nan(multi)
+            json_no_nan(multi)
 
             time_alignment = processor.time_alignment_info(clients)
             TypeAdapter(TimeAlignmentPayload).validate_python(time_alignment)
-            _json_no_nan(time_alignment)
+            json_no_nan(time_alignment)
 
             intake_stats = processor.intake_stats()
             TypeAdapter(IntakeStatsPayload).validate_python(intake_stats)
-            _json_no_nan(intake_stats)
+            json_no_nan(intake_stats)
 
             fresh_clients = processor.clients_with_recent_data(clients, max_age_s=60.0)
             assert set(fresh_clients).issubset(set(clients))
@@ -847,15 +559,15 @@ def _run_processor_target(
                 "fresh_clients": fresh_clients,
             }
 
-        if worker_seed is not None:
-            _fuzz = seed(worker_seed)(_fuzz)
+        if worker_seed_value is not None:
+            _fuzz = seed(worker_seed_value)(_fuzz)
 
         try:
             while not stop_event.is_set() and time.monotonic() < deadline:
                 _fuzz()
         except BaseException as exc:
             stop_event.set()
-            artifact_path = _write_failure_artifact(
+            artifact_path = write_processing_failure_artifact(
                 target="processor",
                 case=current_case,
                 output=current_output,
@@ -881,7 +593,7 @@ def _run_processor_target(
 
 
 def _print_target_summary(config: FuzzConfig, summary: Mapping[str, object]) -> None:
-    prefix = _worker_prefix(config.worker_index)
+    prefix = worker_prefix(config.worker_index)
     print(
         f"{prefix}{str(summary['target']).capitalize()} fuzz passed: "
         f"{float(summary['elapsed_s']):.1f}s with {int(summary['examples'])} randomized examples "

--- a/tools/dev/fuzz_processing_scenarios.py
+++ b/tools/dev/fuzz_processing_scenarios.py
@@ -1,0 +1,238 @@
+"""Hypothesis scenario strategies for processing fuzz targets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def strength_case_strategy(st: Any) -> Any:
+    @st.composite
+    def _build(draw: Any) -> dict[str, object]:
+        axis_count = draw(st.integers(min_value=0, max_value=3))
+        lengths = draw(
+            st.lists(
+                st.integers(min_value=0, max_value=192),
+                min_size=axis_count,
+                max_size=axis_count,
+            )
+        )
+        axis_spectra = [
+            draw(
+                st.lists(
+                    st.floats(
+                        min_value=-1.0,
+                        max_value=4.0,
+                        allow_nan=False,
+                        allow_infinity=False,
+                    ),
+                    min_size=length,
+                    max_size=length,
+                )
+            )
+            for length in lengths
+        ]
+        axis_count_for_mean = draw(
+            st.one_of(
+                st.none(),
+                st.integers(min_value=1, max_value=4),
+            )
+        )
+        freq_step_hz = draw(
+            st.floats(
+                min_value=0.1, max_value=12.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        start_hz = draw(
+            st.floats(
+                min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        center_idx = draw(
+            st.integers(min_value=0, max_value=max(0, min(lengths or [0]) - 1))
+        )
+        bandwidth_hz = draw(
+            st.floats(
+                min_value=0.05, max_value=8.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        epsilon_g = draw(
+            st.one_of(
+                st.none(),
+                st.floats(
+                    min_value=1e-12,
+                    max_value=0.1,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            )
+        )
+        return {
+            "axis_spectra": axis_spectra,
+            "axis_count_for_mean": axis_count_for_mean,
+            "freq_step_hz": freq_step_hz,
+            "start_hz": start_hz,
+            "center_idx": center_idx,
+            "bandwidth_hz": bandwidth_hz,
+            "epsilon_g": epsilon_g,
+        }
+
+    return _build()
+
+
+def fft_case_strategy(st: Any) -> Any:
+    @st.composite
+    def _build(draw: Any) -> dict[str, object]:
+        sample_rate_hz = draw(st.integers(min_value=32, max_value=4096))
+        fft_n = draw(st.sampled_from((32, 64, 128, 256, 512)))
+        spectrum_min_hz = draw(
+            st.floats(
+                min_value=0.0, max_value=40.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        max_band_hz = max(float(sample_rate_hz) / 2.0, spectrum_min_hz + 1.0)
+        spectrum_max_hz = draw(
+            st.floats(
+                min_value=max(spectrum_min_hz + 0.1, 1.0),
+                max_value=max_band_hz,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        spike_filter_enabled = draw(st.booleans())
+        spike_col = draw(st.integers(min_value=0, max_value=fft_n - 1))
+        spike_axis = draw(st.integers(min_value=0, max_value=2))
+        dc_offset = draw(
+            st.floats(
+                min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        base_block = draw(
+            st.lists(
+                st.lists(
+                    st.floats(
+                        min_value=-8.0,
+                        max_value=8.0,
+                        allow_nan=False,
+                        allow_infinity=False,
+                    ),
+                    min_size=fft_n,
+                    max_size=fft_n,
+                ),
+                min_size=3,
+                max_size=3,
+            )
+        )
+        spike_value = draw(
+            st.floats(
+                min_value=-64.0, max_value=64.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        return {
+            "sample_rate_hz": sample_rate_hz,
+            "fft_n": fft_n,
+            "spectrum_min_hz": spectrum_min_hz,
+            "spectrum_max_hz": spectrum_max_hz,
+            "spike_filter_enabled": spike_filter_enabled,
+            "spike_col": spike_col,
+            "spike_axis": spike_axis,
+            "dc_offset": dc_offset,
+            "base_block": base_block,
+            "spike_value": spike_value,
+        }
+
+    return _build()
+
+
+def processor_case_strategy(st: Any) -> Any:
+    @st.composite
+    def _build(draw: Any) -> dict[str, object]:
+        sample_rate_hz = draw(st.integers(min_value=64, max_value=800))
+        waveform_seconds = draw(st.integers(min_value=1, max_value=4))
+        waveform_display_hz = draw(st.integers(min_value=1, max_value=120))
+        fft_n = draw(st.sampled_from((32, 64, 128, 256)))
+        spectrum_min_hz = draw(
+            st.floats(
+                min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False
+            )
+        )
+        spectrum_max_hz = draw(
+            st.floats(
+                min_value=max(spectrum_min_hz + 0.5, 5.0),
+                max_value=min(float(sample_rate_hz) / 2.0, 250.0),
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        accel_scale = draw(
+            st.one_of(
+                st.none(),
+                st.floats(
+                    min_value=1e-5,
+                    max_value=0.05,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            )
+        )
+        clients = draw(
+            st.lists(
+                st.from_regex(r"[a-z][a-z0-9_-]{1,10}", fullmatch=True),
+                min_size=1,
+                max_size=3,
+                unique=True,
+            )
+        )
+        chunks: list[dict[str, object]] = []
+        for client_id in clients:
+            chunk_count = draw(st.integers(min_value=1, max_value=3))
+            t0_us = 1_000_000
+            for _ in range(chunk_count):
+                row_count = draw(st.integers(min_value=0, max_value=fft_n * 2))
+                rows = draw(
+                    st.lists(
+                        st.lists(
+                            st.floats(
+                                min_value=-32.0,
+                                max_value=32.0,
+                                allow_nan=False,
+                                allow_infinity=False,
+                            ),
+                            min_size=3,
+                            max_size=3,
+                        ),
+                        min_size=row_count,
+                        max_size=row_count,
+                    )
+                )
+                sample_rate_override = draw(
+                    st.one_of(st.none(), st.integers(min_value=1, max_value=4096))
+                )
+                include_t0 = draw(st.booleans())
+                t0_increment = draw(st.integers(min_value=0, max_value=500_000))
+                if include_t0:
+                    t0_us += t0_increment
+                chunks.append(
+                    {
+                        "client_id": client_id,
+                        "rows": rows,
+                        "sample_rate_hz": sample_rate_override,
+                        "t0_us": t0_us if include_t0 else None,
+                    }
+                )
+        return {
+            "sample_rate_hz": sample_rate_hz,
+            "waveform_seconds": waveform_seconds,
+            "waveform_display_hz": waveform_display_hz,
+            "fft_n": fft_n,
+            "spectrum_min_hz": spectrum_min_hz,
+            "spectrum_max_hz": spectrum_max_hz,
+            "accel_scale_g_per_lsb": accel_scale,
+            "clients": clients,
+            "chunks": chunks,
+        }
+
+    return _build()
+
+
+def make_freq_slice(length: int, *, start_hz: float, step_hz: float) -> list[float]:
+    return [start_hz + (step_hz * idx) for idx in range(length)]


### PR DESCRIPTION
Closes #3788.

What changed:
- split processing fuzz scenarios into `fuzz_processing_scenarios.py`
- split analysis fuzz scenarios/materializers into `fuzz_analysis_scenarios.py`
- split assertion helpers into focused modules
- split shared worker/process helpers and failure artifact writers out of CLI runners
- added direct tests for scenario, assertion, artifact, and worker helper layers

Why:
- fuzz CLIs were carrying scenario setup, comparisons, artifact output, and runner mechanics in one file
- new fuzz cases should be added without editing long runner scripts

Validation:
- `./.venv/bin/python -m pytest -q apps/server/tests/integration/test_saved_fuzz_corpus_replay.py apps/server/tests/hygiene/test_fuzz_tooling_layers.py`
- tiny fuzz CLI smokes for processing `strength`, `fft`, `processor`, and analysis
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

Risks / edges:
- CLI names and flags stay unchanged
- failure artifact payload keys stay unchanged
- no baseline artifacts regenerated
- docs unchanged because command names and help still work
