### PR TITLE
Refactor update workflow planning and execution

### DIFF
--- a/apps/server/tests/use_cases/updates/test_firmware_refresh_execution.py
+++ b/apps/server/tests/use_cases/updates/test_firmware_refresh_execution.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vibesensor.shared.exceptions import UpdateReleaseError
+from vibesensor.use_cases.updates.firmware import FirmwareRefreshResult
+from vibesensor.use_cases.updates.firmware_refresh_execution import (
+    RefreshFirmwareExecutionCoordinator,
+)
+from vibesensor.use_cases.updates.models import UpdateExecutionOutcome, UpdatePhase
+from vibesensor.use_cases.updates.run_models import (
+    PlannedUpdateRun,
+    PreparedUpdateRun,
+    RefreshFirmwarePlan,
+)
+
+
+def _coordinator() -> tuple[
+    RefreshFirmwareExecutionCoordinator,
+    MagicMock,
+    MagicMock,
+]:
+    completion = MagicMock()
+    completion.complete_success = AsyncMock()
+    firmware_refresher = MagicMock()
+    firmware_refresher.refresh_esp_firmware = AsyncMock(
+        return_value=FirmwareRefreshResult.success(),
+    )
+    return (
+        RefreshFirmwareExecutionCoordinator(
+            completion=completion,
+            firmware_refresher=firmware_refresher,
+        ),
+        completion,
+        firmware_refresher,
+    )
+
+
+def _refresh_workflow(prepared_transport: object) -> tuple[PlannedUpdateRun, RefreshFirmwarePlan]:
+    plan = RefreshFirmwarePlan(
+        latest_tag="server-v2026.4.3",
+    )
+    return (
+        PlannedUpdateRun(
+            prepared=PreparedUpdateRun(
+                prepared_transport=prepared_transport,
+            ),
+            execution_plan=plan,
+        ),
+        plan,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() -> None:
+    coordinator, completion, firmware_refresher = _coordinator()
+    prepared_transport = MagicMock()
+    workflow, plan = _refresh_workflow(prepared_transport)
+
+    completed = await coordinator.execute(workflow, plan)
+
+    assert completed == UpdateExecutionOutcome.refresh_only
+    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
+        pinned_tag="server-v2026.4.3",
+    )
+    completion.complete_success.assert_awaited_once_with(
+        prepared_transport,
+        message="No server update needed; ESP firmware checked",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
+    coordinator, completion, firmware_refresher = _coordinator()
+    workflow, plan = _refresh_workflow(MagicMock())
+    firmware_refresher.refresh_esp_firmware.return_value = FirmwareRefreshResult.failure(
+        message="ESP firmware cache refresh failed (exit 1)",
+        detail="cache unavailable",
+    )
+
+    with pytest.raises(UpdateReleaseError, match="ESP firmware cache refresh failed") as excinfo:
+        await coordinator.execute(workflow, plan)
+
+    assert excinfo.value.phase == UpdatePhase.downloading.value
+    assert excinfo.value.detail == "cache unavailable"
+    assert (
+        excinfo.value.log_message
+        == "ESP firmware refresh failed; refresh-only update did not complete"
+    )
+    completion.complete_success.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/test_server_release_execution.py
+++ b/apps/server/tests/use_cases/updates/test_server_release_execution.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from test_support.update_status import build_update_status_harness
 
 from vibesensor.use_cases.updates.firmware import FirmwareRefreshResult
-from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
+from vibesensor.use_cases.updates.models import (
+    UpdateExecutionOutcome,
+    UpdatePhase,
+    UpdateRequest,
+    UpdateTransport,
+)
+from vibesensor.use_cases.updates.run_models import (
+    InstallServerReleasePlan,
+    PlannedUpdateRun,
+    PreparedUpdateRun,
+)
 from vibesensor.use_cases.updates.server_release_execution import (
     ServerReleaseExecutionCoordinator,
 )
@@ -58,6 +69,17 @@ class _RecordingDeployment:
         self.deployed_release = staged_release
 
 
+def _workflow(release: object, prepared_transport: object) -> tuple[PlannedUpdateRun, object]:
+    plan = InstallServerReleasePlan(release=release)
+    return (
+        PlannedUpdateRun(
+            prepared=PreparedUpdateRun(prepared_transport=prepared_transport),
+            execution_plan=plan,
+        ),
+        plan,
+    )
+
+
 @pytest.mark.asyncio
 async def test_execute_deploys_staged_release_after_successful_refresh(tmp_path: Path) -> None:
     status = _build_status_tracker(tmp_path / "update-state.json")
@@ -65,18 +87,28 @@ async def test_execute_deploys_staged_release_after_successful_refresh(tmp_path:
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
     firmware_refresher = _StaticFirmwareRefresher(FirmwareRefreshResult.success())
     deployment = _RecordingDeployment()
+    completion = MagicMock()
+    completion.complete_success = AsyncMock()
     coordinator = ServerReleaseExecutionCoordinator(
+        completion=completion,
         stager=_StaticStager(staged_release),
         firmware_refresher=firmware_refresher,
         deployment=deployment,
         status=status,
     )
+    prepared_transport = object()
+    workflow, plan = _workflow(release, prepared_transport)
 
-    await coordinator.execute(release)
+    result = await coordinator.execute(workflow, plan)
 
+    assert result == UpdateExecutionOutcome.installed
     assert firmware_refresher.pinned_tags == ["server-v2026.4.4"]
     assert deployment.deployed_release is staged_release
     assert status.status.issues == []
+    completion.complete_success.assert_awaited_once_with(
+        prepared_transport,
+        message="Update completed successfully",
+    )
 
 
 @pytest.mark.asyncio
@@ -91,17 +123,22 @@ async def test_execute_records_firmware_refresh_failure_and_still_deploys(tmp_pa
         ),
     )
     deployment = _RecordingDeployment()
+    completion = MagicMock()
+    completion.complete_success = AsyncMock()
     coordinator = ServerReleaseExecutionCoordinator(
+        completion=completion,
         stager=_StaticStager(staged_release),
         firmware_refresher=firmware_refresher,
         deployment=deployment,
         status=status,
     )
+    workflow, plan = _workflow(release, object())
 
-    await coordinator.execute(release)
+    await coordinator.execute(workflow, plan)
 
     assert deployment.deployed_release is staged_release
     assert firmware_refresher.pinned_tags == ["server-v2026.4.4"]
     assert status.status.issues[-1].message == "ESP firmware cache refresh failed (exit 4)"
     assert status.status.issues[-1].detail == "download timed out"
     assert "ESP firmware refresh failed; continuing with existing cache" in status.status.log_tail
+    completion.complete_success.assert_awaited_once()

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -72,15 +72,15 @@ def _build_manager_with_cancellation_cleanup(
     tracker = build_update_status_tracker(state_store=state_store)
     reporter = UpdateTerminalStateReporter(status=tracker)
     prepared_transport = SimpleNamespace(cleanup_after_update=AsyncMock())
+
+    async def plan_with_cancellation(_request, *, on_prepared=None):
+        prepared = PreparedUpdateRun(prepared_transport=prepared_transport)
+        if on_prepared is not None:
+            on_prepared(prepared)
+        raise asyncio.CancelledError
+
     workflow = UpdateWorkflow(
-        preparation=SimpleNamespace(
-            prepare=AsyncMock(
-                return_value=PreparedUpdateRun(prepared_transport=prepared_transport),
-            )
-        ),
-        release_planner=SimpleNamespace(
-            plan=AsyncMock(side_effect=asyncio.CancelledError()),
-        ),
+        planner=SimpleNamespace(plan=AsyncMock(side_effect=plan_with_cancellation)),
         workflow_executor=SimpleNamespace(execute=AsyncMock()),
         finalizer=UpdateWorkflowFinalizer(
             transport_coordinator=UpdateTransportCoordinator(

--- a/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
@@ -6,8 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vibesensor.shared.exceptions import UpdateReleaseError
-from vibesensor.use_cases.updates.firmware import FirmwareRefreshResult
-from vibesensor.use_cases.updates.models import UpdateExecutionOutcome, UpdatePhase
+from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
     PlannedUpdateRun,
@@ -21,26 +20,19 @@ def _executor() -> tuple[
     UpdateWorkflowExecutor,
     MagicMock,
     MagicMock,
-    MagicMock,
 ]:
-    completion = MagicMock()
-    completion.complete_success = AsyncMock()
+    refresh_execution = MagicMock()
+    refresh_execution.execute = AsyncMock(return_value=UpdateExecutionOutcome.refresh_only)
     server_release_execution = MagicMock()
-    server_release_execution.execute = AsyncMock(return_value=None)
-    firmware_refresher = MagicMock()
-    firmware_refresher.refresh_esp_firmware = AsyncMock(
-        return_value=FirmwareRefreshResult.success(),
-    )
+    server_release_execution.execute = AsyncMock(return_value=UpdateExecutionOutcome.installed)
     executor = UpdateWorkflowExecutor(
-        completion=completion,
+        refresh_execution=refresh_execution,
         server_release_execution=server_release_execution,
-        firmware_refresher=firmware_refresher,
     )
     return (
         executor,
-        completion,
+        refresh_execution,
         server_release_execution,
-        firmware_refresher,
     )
 
 
@@ -51,12 +43,11 @@ def _prepared_run(prepared_transport: object) -> PreparedUpdateRun:
 
 
 @pytest.mark.asyncio
-async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() -> None:
+async def test_execute_refresh_plan_dispatches_to_refresh_execution() -> None:
     (
         executor,
-        completion,
+        refresh_execution,
         server_release_execution,
-        firmware_refresher,
     ) = _executor()
     prepared_transport = MagicMock()
     workflow = PlannedUpdateRun(
@@ -69,101 +60,72 @@ async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() 
     completed = await executor.execute(workflow)
 
     assert completed == UpdateExecutionOutcome.refresh_only
-    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
-        pinned_tag="server-v2026.4.3",
-    )
-    completion.complete_success.assert_awaited_once_with(
-        prepared_transport,
-        message="No server update needed; ESP firmware checked",
-    )
+    refresh_execution.execute.assert_awaited_once_with(workflow, workflow.execution_plan)
     server_release_execution.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
+async def test_execute_refresh_plan_propagates_refresh_execution_failure() -> None:
     (
         executor,
-        completion,
+        refresh_execution,
         server_release_execution,
-        firmware_refresher,
     ) = _executor()
-    prepared_transport = MagicMock()
     workflow = PlannedUpdateRun(
-        prepared=_prepared_run(prepared_transport),
+        prepared=_prepared_run(MagicMock()),
         execution_plan=RefreshFirmwarePlan(
             latest_tag="server-v2026.4.3",
         ),
     )
-    firmware_refresher.refresh_esp_firmware.return_value = FirmwareRefreshResult.failure(
-        message="ESP firmware cache refresh failed (exit 1)",
-        detail="cache unavailable",
-    )
+    refresh_execution.execute.side_effect = UpdateReleaseError("refresh failed")
 
-    with pytest.raises(UpdateReleaseError, match="ESP firmware cache refresh failed") as excinfo:
+    with pytest.raises(UpdateReleaseError, match="refresh failed"):
         await executor.execute(workflow)
 
-    assert excinfo.value.phase == UpdatePhase.downloading.value
-    assert excinfo.value.detail == "cache unavailable"
-    assert (
-        excinfo.value.log_message
-        == "ESP firmware refresh failed; refresh-only update did not complete"
-    )
-    completion.complete_success.assert_not_awaited()
+    refresh_execution.execute.assert_awaited_once_with(workflow, workflow.execution_plan)
     server_release_execution.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_execute_install_plan_runs_server_release_execution_before_completion() -> None:
+async def test_execute_install_plan_dispatches_to_server_release_execution() -> None:
     (
         executor,
-        completion,
+        refresh_execution,
         server_release_execution,
-        firmware_refresher,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
-    prepared_transport = MagicMock()
-
-    completed = await executor.execute(
-        PlannedUpdateRun(
-            prepared=_prepared_run(prepared_transport),
-            execution_plan=InstallServerReleasePlan(
-                release=release,
-            ),
+    workflow = PlannedUpdateRun(
+        prepared=_prepared_run(MagicMock()),
+        execution_plan=InstallServerReleasePlan(
+            release=release,
         ),
     )
 
+    completed = await executor.execute(workflow)
+
     assert completed == UpdateExecutionOutcome.installed
-    server_release_execution.execute.assert_awaited_once_with(release)
-    completion.complete_success.assert_awaited_once_with(
-        prepared_transport,
-        message="Update completed successfully",
-    )
-    firmware_refresher.refresh_esp_firmware.assert_not_awaited()
+    server_release_execution.execute.assert_awaited_once_with(workflow, workflow.execution_plan)
+    refresh_execution.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_execute_install_plan_propagates_release_execution_failure_before_completion() -> (
-    None
-):
+async def test_execute_install_plan_propagates_release_execution_failure() -> None:
     (
         executor,
-        completion,
+        refresh_execution,
         server_release_execution,
-        _firmware_refresher,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
-    prepared_transport = MagicMock()
+    workflow = PlannedUpdateRun(
+        prepared=_prepared_run(MagicMock()),
+        execution_plan=InstallServerReleasePlan(
+            release=release,
+        ),
+    )
     server_release_execution.execute.side_effect = UpdateReleaseError("install failed")
 
     with pytest.raises(UpdateReleaseError, match="install failed"):
-        await executor.execute(
-            PlannedUpdateRun(
-                prepared=_prepared_run(prepared_transport),
-                execution_plan=InstallServerReleasePlan(
-                    release=release,
-                ),
-            ),
-        )
+        await executor.execute(workflow)
 
-    server_release_execution.execute.assert_awaited_once_with(release)
-    completion.complete_success.assert_not_awaited()
+    server_release_execution.execute.assert_awaited_once_with(workflow, workflow.execution_plan)
+    refresh_execution.execute.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/test_update_workflow_planner.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_planner.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vibesensor.shared.exceptions import UpdatePreparationError
+from vibesensor.use_cases.updates.models import UpdateRequest, UpdateTransport
+from vibesensor.use_cases.updates.run_models import PlannedUpdateRun, PreparedUpdateRun
+from vibesensor.use_cases.updates.workflow_planner import UpdateWorkflowPlanner
+
+
+def _request() -> UpdateRequest:
+    return UpdateRequest(
+        transport=UpdateTransport.wifi,
+        ssid="TestNet",
+        password="pass123",
+    )
+
+
+def _planner() -> tuple[UpdateWorkflowPlanner, MagicMock, MagicMock, PreparedUpdateRun]:
+    prepared = PreparedUpdateRun(prepared_transport=object())
+    planning_result = MagicMock(spec=PlannedUpdateRun)
+    preparation = MagicMock()
+    preparation.prepare = AsyncMock(return_value=prepared)
+    release_planner = MagicMock()
+    release_planner.plan = AsyncMock(return_value=planning_result)
+    return (
+        UpdateWorkflowPlanner(
+            preparation=preparation,
+            release_planner=release_planner,
+        ),
+        preparation,
+        release_planner,
+        prepared,
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_prepares_transport_before_release_planning() -> None:
+    planner, preparation, release_planner, prepared = _planner()
+    request = _request()
+    observed: list[PreparedUpdateRun] = []
+
+    result = await planner.plan(request, on_prepared=observed.append)
+
+    assert result is release_planner.plan.return_value
+    assert observed == [prepared]
+    preparation.prepare.assert_awaited_once_with(request)
+    release_planner.plan.assert_awaited_once_with(prepared)
+
+
+@pytest.mark.asyncio
+async def test_plan_stops_before_release_planning_when_preparation_fails() -> None:
+    planner, preparation, release_planner, _prepared = _planner()
+    preparation.prepare.side_effect = UpdatePreparationError("validation failed")
+
+    with pytest.raises(UpdatePreparationError, match="validation failed"):
+        await planner.plan(_request())
+
+    release_planner.plan.assert_not_awaited()

--- a/apps/server/vibesensor/use_cases/updates/firmware_refresh_execution.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware_refresh_execution.py
@@ -1,0 +1,47 @@
+"""Execution boundary for refresh-only update plans."""
+
+from __future__ import annotations
+
+from vibesensor.shared.exceptions import UpdateReleaseError
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
+from vibesensor.use_cases.updates.firmware import FirmwareRefresher
+from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
+from vibesensor.use_cases.updates.run_models import PlannedUpdateRun, RefreshFirmwarePlan
+
+__all__ = ["RefreshFirmwareExecutionCoordinator"]
+
+
+class RefreshFirmwareExecutionCoordinator:
+    """Execute the no-server-update path by refreshing firmware and finalizing success."""
+
+    __slots__ = ("_completion", "_firmware_refresher")
+
+    def __init__(
+        self,
+        *,
+        completion: UpdateCompletionCoordinator,
+        firmware_refresher: FirmwareRefresher,
+    ) -> None:
+        self._completion = completion
+        self._firmware_refresher = firmware_refresher
+
+    async def execute(
+        self,
+        workflow: PlannedUpdateRun,
+        plan: RefreshFirmwarePlan,
+    ) -> UpdateExecutionOutcome:
+        refresh_result = await self._firmware_refresher.refresh_esp_firmware(
+            pinned_tag=plan.latest_tag,
+        )
+        if not refresh_result.succeeded:
+            raise UpdateReleaseError(
+                refresh_result.message,
+                phase=refresh_result.phase,
+                detail=refresh_result.detail,
+                log_message="ESP firmware refresh failed; refresh-only update did not complete",
+            )
+        await self._completion.complete_success(
+            workflow.prepared.prepared_transport,
+            message="No server update needed; ESP firmware checked",
+        )
+        return UpdateExecutionOutcome.refresh_only

--- a/apps/server/vibesensor/use_cases/updates/server_release_execution.py
+++ b/apps/server/vibesensor/use_cases/updates/server_release_execution.py
@@ -4,38 +4,53 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
+from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.release_deployment import (
     UpdateReleaseDeploymentCoordinator,
 )
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
+from vibesensor.use_cases.updates.run_models import InstallServerReleasePlan, PlannedUpdateRun
 
 if TYPE_CHECKING:
-    from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
     from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 __all__ = ["ServerReleaseExecutionCoordinator"]
 
 
 class ServerReleaseExecutionCoordinator:
-    """Own staged release download, firmware refresh policy, and deployment handoff."""
+    """Own staged release download, firmware refresh policy, deployment, and success."""
 
-    __slots__ = ("_deployment", "_firmware_refresher", "_stager", "_status")
+    __slots__ = (
+        "_completion",
+        "_deployment",
+        "_firmware_refresher",
+        "_stager",
+        "_status",
+    )
 
     def __init__(
         self,
         *,
+        completion: UpdateCompletionCoordinator,
         stager: ServerReleaseStager,
         firmware_refresher: FirmwareRefresher,
         deployment: UpdateReleaseDeploymentCoordinator,
         status: UpdateStatusTracker,
     ) -> None:
+        self._completion = completion
         self._stager = stager
         self._firmware_refresher = firmware_refresher
         self._deployment = deployment
         self._status = status
 
-    async def execute(self, release: ReleaseInfo) -> None:
+    async def execute(
+        self,
+        workflow: PlannedUpdateRun,
+        plan: InstallServerReleasePlan,
+    ) -> UpdateExecutionOutcome:
+        release = plan.release
         async with self._stager.stage(release) as staged_release:
             refresh_result = await self._firmware_refresher.refresh_esp_firmware(
                 pinned_tag=staged_release.release.tag,
@@ -50,3 +65,8 @@ class ServerReleaseExecutionCoordinator:
                     "ESP firmware refresh failed; continuing with existing cache",
                 )
             await self._deployment.deploy(staged_release)
+        await self._completion.complete_success(
+            workflow.prepared.prepared_transport,
+            message="Update completed successfully",
+        )
+        return UpdateExecutionOutcome.installed

--- a/apps/server/vibesensor/use_cases/updates/workflow.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow.py
@@ -7,10 +7,9 @@ from dataclasses import dataclass
 
 from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.models import UpdateRequest
-from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
-from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
 from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
+from vibesensor.use_cases.updates.workflow_planner import UpdateWorkflowPlanner
 
 __all__ = ["UpdateWorkflow"]
 
@@ -19,8 +18,7 @@ __all__ = ["UpdateWorkflow"]
 class UpdateWorkflow:
     """Run one update request through the canonical workflow lifecycle."""
 
-    preparation: UpdatePreparationCoordinator
-    release_planner: UpdateReleasePlanner
+    planner: UpdateWorkflowPlanner
     workflow_executor: UpdateWorkflowExecutor
     finalizer: UpdateWorkflowFinalizer
 
@@ -30,9 +28,13 @@ class UpdateWorkflow:
         request: UpdateRequest,
     ) -> None:
         prepared: PreparedUpdateRun | None = None
+
+        def remember_prepared(value: PreparedUpdateRun) -> None:
+            nonlocal prepared
+            prepared = value
+
         try:
-            prepared = await self.preparation.prepare(request)
-            planned = await self.release_planner.plan(prepared)
+            planned = await self.planner.plan(request, on_prepared=remember_prepared)
             await self.workflow_executor.execute(planned)
         finally:
             await self.finalizer.finalize(

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -1,10 +1,10 @@
-"""Release-execution boundary for update workflows."""
+"""Execution dispatcher for planned update workflows."""
 
 from __future__ import annotations
 
-from vibesensor.shared.exceptions import UpdateReleaseError
-from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
-from vibesensor.use_cases.updates.firmware import FirmwareRefresher
+from vibesensor.use_cases.updates.firmware_refresh_execution import (
+    RefreshFirmwareExecutionCoordinator,
+)
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
@@ -19,20 +19,18 @@ __all__ = ["UpdateWorkflowExecutor"]
 
 
 class UpdateWorkflowExecutor:
-    """Execute a prepared release plan while delegating side effects to focused collaborators."""
+    """Dispatch a prepared release plan to the focused execution collaborator."""
 
-    __slots__ = ("_completion", "_firmware_refresher", "_server_release_execution")
+    __slots__ = ("_refresh_execution", "_server_release_execution")
 
     def __init__(
         self,
         *,
-        completion: UpdateCompletionCoordinator,
+        refresh_execution: RefreshFirmwareExecutionCoordinator,
         server_release_execution: ServerReleaseExecutionCoordinator,
-        firmware_refresher: FirmwareRefresher,
     ) -> None:
-        self._completion = completion
+        self._refresh_execution = refresh_execution
         self._server_release_execution = server_release_execution
-        self._firmware_refresher = firmware_refresher
 
     async def execute(
         self,
@@ -55,21 +53,7 @@ class UpdateWorkflowExecutor:
         workflow: PlannedUpdateRun,
         plan: RefreshFirmwarePlan,
     ) -> UpdateExecutionOutcome:
-        refresh_result = await self._firmware_refresher.refresh_esp_firmware(
-            pinned_tag=plan.latest_tag,
-        )
-        if not refresh_result.succeeded:
-            raise UpdateReleaseError(
-                refresh_result.message,
-                phase=refresh_result.phase,
-                detail=refresh_result.detail,
-                log_message="ESP firmware refresh failed; refresh-only update did not complete",
-            )
-        await self._completion.complete_success(
-            workflow.prepared.prepared_transport,
-            message="No server update needed; ESP firmware checked",
-        )
-        return UpdateExecutionOutcome.refresh_only
+        return await self._refresh_execution.execute(workflow, plan)
 
     async def _execute_install(
         self,
@@ -77,9 +61,4 @@ class UpdateWorkflowExecutor:
         workflow: PlannedUpdateRun,
         plan: InstallServerReleasePlan,
     ) -> UpdateExecutionOutcome:
-        await self._server_release_execution.execute(plan.release)
-        await self._completion.complete_success(
-            workflow.prepared.prepared_transport,
-            message="Update completed successfully",
-        )
-        return UpdateExecutionOutcome.installed
+        return await self._server_release_execution.execute(workflow, plan)

--- a/apps/server/vibesensor/use_cases/updates/workflow_planner.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_planner.py
@@ -1,0 +1,32 @@
+"""Request-scoped planning boundary for update workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from vibesensor.use_cases.updates.models import UpdateRequest
+from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
+from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
+from vibesensor.use_cases.updates.run_models import PlannedUpdateRun, PreparedUpdateRun
+
+__all__ = ["UpdateWorkflowPlanner"]
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateWorkflowPlanner:
+    """Prepare transport and choose release work before side-effectful execution."""
+
+    preparation: UpdatePreparationCoordinator
+    release_planner: UpdateReleasePlanner
+
+    async def plan(
+        self,
+        request: UpdateRequest,
+        *,
+        on_prepared: Callable[[PreparedUpdateRun], None] | None = None,
+    ) -> PlannedUpdateRun:
+        prepared = await self.preparation.prepare(request)
+        if on_prepared is not None:
+            on_prepared(prepared)
+        return await self.release_planner.plan(prepared)

--- a/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING
 from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
+from vibesensor.use_cases.updates.firmware_refresh_execution import (
+    RefreshFirmwareExecutionCoordinator,
+)
 from vibesensor.use_cases.updates.installer import UpdateInstaller
 from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
 from vibesensor.use_cases.updates.release_deployment import (
@@ -29,6 +32,7 @@ from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport.runtime import UpdateTransportRuntime
 from vibesensor.use_cases.updates.workflow import UpdateWorkflow
 from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
+from vibesensor.use_cases.updates.workflow_planner import UpdateWorkflowPlanner
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.updates.status import UpdateTerminalStateReporter
@@ -48,17 +52,19 @@ def build_update_workflow(
         config.release_fetcher_config,
     )
     return UpdateWorkflow(
-        preparation=_build_preparation(
-            commands=core.commands,
-            status=core.status,
-            transport=transport,
-            config=config,
-        ),
-        release_planner=UpdateReleasePlanner(
-            status=core.status,
-            current_version_provider=core.current_version_provider,
-            resolver=ServerReleaseResolver(
-                release_fetcher=release_fetcher,
+        planner=UpdateWorkflowPlanner(
+            preparation=_build_preparation(
+                commands=core.commands,
+                status=core.status,
+                transport=transport,
+                config=config,
+            ),
+            release_planner=UpdateReleasePlanner(
+                status=core.status,
+                current_version_provider=core.current_version_provider,
+                resolver=ServerReleaseResolver(
+                    release_fetcher=release_fetcher,
+                ),
             ),
         ),
         workflow_executor=_build_workflow_executor(
@@ -109,23 +115,28 @@ def _build_workflow_executor(
         repo=config.repo,
         timeout_s=execution_config.firmware_refresh_timeout_s,
     )
+    completion = UpdateCompletionCoordinator(
+        restart_scheduler=UpdateRestartScheduler(
+            commands=commands,
+            status=status,
+            service_name=execution_config.service_name,
+            restart_unit=execution_config.restart_unit,
+        ),
+        reporter=reporter,
+        status=status,
+    )
     installer = UpdateInstaller(
         commands=commands,
         status=status,
         config=config.installer_config,
     )
     return UpdateWorkflowExecutor(
-        completion=UpdateCompletionCoordinator(
-            restart_scheduler=UpdateRestartScheduler(
-                commands=commands,
-                status=status,
-                service_name=execution_config.service_name,
-                restart_unit=execution_config.restart_unit,
-            ),
-            reporter=reporter,
-            status=status,
+        refresh_execution=RefreshFirmwareExecutionCoordinator(
+            completion=completion,
+            firmware_refresher=firmware_refresher,
         ),
         server_release_execution=ServerReleaseExecutionCoordinator(
+            completion=completion,
             stager=ServerReleaseStager(
                 status=status,
                 release_fetcher=release_fetcher,
@@ -137,5 +148,4 @@ def _build_workflow_executor(
             ),
             status=status,
         ),
-        firmware_refresher=firmware_refresher,
     )


### PR DESCRIPTION
Closes #3790

## What changed
- Added `UpdateWorkflowPlanner` for request preparation plus release planning.
- Added `RefreshFirmwareExecutionCoordinator` for refresh-only firmware runs.
- Made `UpdateWorkflowExecutor` dispatch only.
- Moved server-release success finalization into server-release execution.
- Preserved prepared-transport cleanup when planning is cancelled after transport preparation.

## Why
Update planning, transport readiness, firmware refresh, and install execution were still coupled in the request workflow and generic executor. The new seams make planning and execution paths testable without changing updater behavior.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/updates/test_update_workflow_planner.py apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/use_cases/updates/test_update_workflow_executor.py apps/server/tests/use_cases/updates/test_firmware_refresh_execution.py apps/server/tests/use_cases/updates/test_server_release_execution.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/updates/`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks / tradeoffs
- Internal constructor seams changed, so focused tests were updated with the new collaborators.
- No update UX, API/status payload, transport, rollback, install order, or firmware policy changes intended.

## Follow-ups
None.