### PR TITLE
Refactor processing sample preparation

### DIFF
--- a/apps/server/tests/infra/processing/test_compute_filtering.py
+++ b/apps/server/tests/infra/processing/test_compute_filtering.py
@@ -56,7 +56,7 @@ def test_compute_reuses_filtered_time_window_for_fft(monkeypatch) -> None:
         fft_calls.append((fft_block.copy(), bool(kwargs["spike_filter_enabled"])))
         return _empty_fft_result()
 
-    monkeypatch.setattr("vibesensor.infra.processing.compute.medfilt3", _fake_medfilt3)
+    monkeypatch.setattr("vibesensor.infra.processing.fft_preparation.medfilt3", _fake_medfilt3)
     monkeypatch.setattr(
         "vibesensor.shared.fft_analysis.compute_fft_spectrum",
         _fake_compute_fft_spectrum,
@@ -101,7 +101,7 @@ def test_compute_filters_short_fft_block_only_once(monkeypatch) -> None:
         fft_calls.append((fft_input.copy(), bool(kwargs["spike_filter_enabled"])))
         return _empty_fft_result()
 
-    monkeypatch.setattr("vibesensor.infra.processing.compute.medfilt3", _fake_medfilt3)
+    monkeypatch.setattr("vibesensor.infra.processing.fft_preparation.medfilt3", _fake_medfilt3)
     monkeypatch.setattr(
         "vibesensor.shared.fft_analysis.compute_fft_spectrum",
         _fake_compute_fft_spectrum,

--- a/apps/server/tests/infra/processing/test_sample_preparation.py
+++ b/apps/server/tests/infra/processing/test_sample_preparation.py
@@ -1,0 +1,110 @@
+"""Focused tests for processing sample-preparation seams."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vibesensor.infra.processing.buffer_mutations import ClientBufferMutator
+from vibesensor.infra.processing.buffers import ClientBuffer
+from vibesensor.infra.processing.fft_preparation import prepare_fft_windows
+from vibesensor.infra.processing.models import MetricsSnapshot, ProcessorConfig
+from vibesensor.infra.processing.sample_validation import normalize_sample_chunk
+from vibesensor.infra.processing.snapshot_window_preparation import prepare_snapshot_windows
+
+
+def _config(**overrides: object) -> ProcessorConfig:
+    base = {
+        "sample_rate_hz": 200,
+        "waveform_seconds": 2,
+        "waveform_display_hz": 50,
+        "fft_n": 4,
+        "spectrum_min_hz": 0.0,
+        "spectrum_max_hz": 100.0,
+        "accel_scale_g_per_lsb": None,
+    }
+    base.update(overrides)
+    return ProcessorConfig(**base)
+
+
+def test_normalize_sample_chunk_scales_to_float32() -> None:
+    raw = np.array([[2, 4, 6]], dtype=np.int16)
+
+    chunk = normalize_sample_chunk(
+        client_id="sensor-1",
+        samples=raw,
+        accel_scale_g_per_lsb=0.5,
+    )
+
+    assert chunk is not None
+    assert chunk.dtype == np.float32
+    np.testing.assert_allclose(chunk, np.array([[1.0, 2.0, 3.0]], dtype=np.float32))
+
+
+def test_normalize_sample_chunk_drops_malformed_shape(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING", logger="vibesensor.infra.processing.sample_validation"):
+        chunk = normalize_sample_chunk(
+            client_id="sensor-bad",
+            samples=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            accel_scale_g_per_lsb=None,
+        )
+
+    assert chunk is None
+    assert "Dropping malformed sample chunk for sensor-bad with shape (3,)" in caplog.text
+
+
+def test_prepare_snapshot_windows_reuses_fft_block_for_short_time_window() -> None:
+    config = _config(sample_rate_hz=8, waveform_seconds=1, fft_n=4)
+    mutator = ClientBufferMutator(config)
+    buf = ClientBuffer(data=np.arange(36, dtype=np.float32).reshape(3, 12), capacity=12)
+    buf.count = 12
+    buf.write_idx = 0
+
+    prepared = prepare_snapshot_windows(
+        buf=buf,
+        config=config,
+        buffer_mutator=mutator,
+        sample_rate_hz=2,
+    )
+
+    assert prepared.time_window.shape == (3, 2)
+    assert prepared.fft_block is not None
+    assert prepared.fft_block.shape == (3, 4)
+    assert np.shares_memory(prepared.time_window, prepared.fft_block)
+    np.testing.assert_array_equal(prepared.time_window, prepared.fft_block[:, -2:])
+
+
+def test_prepare_fft_windows_filters_and_detrends_time_window() -> None:
+    block = np.array(
+        [
+            [1.0, 1.0, 9.0, 1.0, 1.0],
+            [2.0, 2.0, 2.0, 2.0, 2.0],
+            [0.0, 1.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    snapshot = MetricsSnapshot(
+        client_id="sensor-fft",
+        sample_rate_hz=200,
+        ingest_generation=1,
+        time_window=block,
+        fft_block=None,
+    )
+
+    prepared = prepare_fft_windows(snapshot)
+
+    expected_filtered = np.array(
+        [
+            [1.0, 1.0, 1.0, 1.0, 1.0],
+            [2.0, 2.0, 2.0, 2.0, 2.0],
+            [0.0, 0.0, 1.0, 0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    np.testing.assert_allclose(prepared.time_window, expected_filtered)
+    assert prepared.fft_input is None
+    np.testing.assert_allclose(
+        np.mean(prepared.time_window_detrended, axis=1),
+        np.zeros(3),
+        atol=1e-7,
+    )

--- a/apps/server/vibesensor/infra/processing/buffer_store_snapshot.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store_snapshot.py
@@ -9,11 +9,11 @@ from vibesensor.infra.processing.buffers import ClientBuffer
 from vibesensor.infra.processing.models import (
     CachedMetricsHit,
     ClientMetrics,
-    FloatArray,
     MetricsSnapshot,
     ProcessorConfig,
 )
-from vibesensor.infra.processing.snapshot_builder import check_cache_hit, compute_snapshot_window
+from vibesensor.infra.processing.snapshot_builder import check_cache_hit
+from vibesensor.infra.processing.snapshot_window_preparation import prepare_snapshot_windows
 from vibesensor.infra.processing.time_align import analysis_time_range
 from vibesensor.shared.types.analysis_time_range import AnalysisTimeRange
 
@@ -61,30 +61,20 @@ class BufferStoreSnapshotReader:
             if cache_hit is not None:
                 return cache_hit
 
-            window = compute_snapshot_window(
-                count=buf.count,
-                capacity=buf.capacity,
+            prepared_windows = prepare_snapshot_windows(
+                buf=buf,
+                config=self._config,
+                buffer_mutator=self._buffer_mutator,
                 sample_rate_hz=sr,
-                waveform_seconds=self._config.waveform_seconds,
-                fft_n=self._config.fft_n,
             )
-
-            fft_block: FloatArray | None = None
-            if window.needs_separate_fft_block:
-                fft_block = self._buffer_mutator.copy_latest(buf, self._config.fft_n)
-                time_window = fft_block[:, -window.n_time :]
-            else:
-                time_window = self._buffer_mutator.copy_latest(buf, window.n_time)
-                if buf.count >= self._config.fft_n:
-                    fft_block = time_window[:, -self._config.fft_n :]
             return MetricsSnapshot(
                 client_id=client_id,
                 sample_rate_hz=sr,
                 ingest_generation=buf.ingest_generation,
                 buffer_epoch=buf.buffer_epoch,
                 reset_generation=buf.reset_generation,
-                time_window=time_window,
-                fft_block=fft_block,
+                time_window=prepared_windows.time_window,
+                fft_block=prepared_windows.fft_block,
                 analysis_time_range=self._analysis_time_range(buf, sample_rate_hz=sr),
             )
 

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -5,13 +5,14 @@ import time
 
 import numpy as np
 
+from vibesensor.infra.processing.fft_preparation import prepare_fft_windows
 from vibesensor.infra.processing.models import (
     MetricsComputationResult,
     MetricsSnapshot,
     ProcessorConfig,
     SpectrumByAxis,
 )
-from vibesensor.shared.fft_analysis import AXES, SpectralAnalysisComputer, medfilt3
+from vibesensor.shared.fft_analysis import AXES, SpectralAnalysisComputer
 from vibesensor.shared.types.payload_types import AxisMetrics, ClientMetrics
 from vibesensor.shared.types.processing_profile import (
     PROCESSING_FILTER_MEDIAN_3_SAMPLE,
@@ -36,22 +37,11 @@ class SignalMetricsComputer(SpectralAnalysisComputer):
             spectrum_max_hz=config.spectrum_max_hz,
         )
 
-    def _filtered_windows(self, snapshot: MetricsSnapshot) -> tuple[np.ndarray, np.ndarray | None]:
-        fft_block = snapshot.fft_block
-        if fft_block is None:
-            return medfilt3(snapshot.time_window), None
-
-        if snapshot.time_window.shape[1] >= fft_block.shape[1]:
-            filtered_source = medfilt3(snapshot.time_window)
-            return filtered_source, filtered_source[:, -fft_block.shape[1] :]
-
-        filtered_source = medfilt3(fft_block)
-        return filtered_source[:, -snapshot.time_window.shape[1] :], filtered_source
-
     def compute(self, snapshot: MetricsSnapshot) -> MetricsComputationResult:
         t0 = time.monotonic()
-        time_window, fft_input = self._filtered_windows(snapshot)
-        time_window_detrended = time_window - np.mean(time_window, axis=1, keepdims=True)
+        prepared_windows = prepare_fft_windows(snapshot)
+        fft_input = prepared_windows.fft_input
+        time_window_detrended = prepared_windows.time_window_detrended
 
         metrics: ClientMetrics = {}
         if time_window_detrended.size > 0:

--- a/apps/server/vibesensor/infra/processing/fft_preparation.py
+++ b/apps/server/vibesensor/infra/processing/fft_preparation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from vibesensor.infra.processing.models import FloatArray, MetricsSnapshot
+from vibesensor.shared.fft_analysis import medfilt3
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedFftWindows:
+    """Filtered and detrended sample windows for metrics and FFT analysis."""
+
+    time_window: FloatArray
+    fft_input: FloatArray | None
+    time_window_detrended: FloatArray
+
+
+def prepare_fft_windows(snapshot: MetricsSnapshot) -> PreparedFftWindows:
+    """Apply live-processing sample filters and prepare detrended metrics input."""
+    time_window, fft_input = _filtered_windows(snapshot)
+    time_window_detrended = time_window - np.mean(time_window, axis=1, keepdims=True)
+    return PreparedFftWindows(
+        time_window=time_window,
+        fft_input=fft_input,
+        time_window_detrended=time_window_detrended,
+    )
+
+
+def _filtered_windows(snapshot: MetricsSnapshot) -> tuple[FloatArray, FloatArray | None]:
+    fft_block = snapshot.fft_block
+    if fft_block is None:
+        return medfilt3(snapshot.time_window), None
+
+    if snapshot.time_window.shape[1] >= fft_block.shape[1]:
+        filtered_source = medfilt3(snapshot.time_window)
+        return filtered_source, filtered_source[:, -fft_block.shape[1] :]
+
+    filtered_source = medfilt3(fft_block)
+    return filtered_source[:, -snapshot.time_window.shape[1] :], filtered_source

--- a/apps/server/vibesensor/infra/processing/ingest_preparation.py
+++ b/apps/server/vibesensor/infra/processing/ingest_preparation.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-import numpy as np
-
 from vibesensor.infra.processing.buffer_capacity import OverflowResult, evaluate_overflow
 from vibesensor.infra.processing.models import FloatArray, ProcessorConfig
+from vibesensor.infra.processing.sample_validation import normalize_sample_chunk
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,17 +41,12 @@ class IngestChunkPreparer:
         client_id: str,
         samples: FloatArray,
     ) -> FloatArray | None:
-        chunk: FloatArray = np.asarray(samples, dtype=np.float32)
-        if self._accel_scale_g_per_lsb is not None:
-            chunk = chunk * np.float32(self._accel_scale_g_per_lsb)
-        if chunk.ndim != 2 or chunk.shape[1] != 3:
-            LOGGER.warning(
-                "Dropping malformed sample chunk for %s with shape %s",
-                client_id,
-                chunk.shape,
-            )
-            return None
-        return chunk
+        return normalize_sample_chunk(
+            client_id=client_id,
+            samples=samples,
+            accel_scale_g_per_lsb=self._accel_scale_g_per_lsb,
+            logger=LOGGER,
+        )
 
     def apply_overflow_policy(
         self,

--- a/apps/server/vibesensor/infra/processing/sample_validation.py
+++ b/apps/server/vibesensor/infra/processing/sample_validation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from vibesensor.infra.processing.models import FloatArray
+
+LOGGER = logging.getLogger(__name__)
+
+
+def normalize_sample_chunk(
+    *,
+    client_id: str,
+    samples: FloatArray,
+    accel_scale_g_per_lsb: float | None,
+    logger: logging.Logger = LOGGER,
+) -> FloatArray | None:
+    """Return an ``(N, 3)`` float32 sample chunk or ``None`` when malformed."""
+    chunk: FloatArray = np.asarray(samples, dtype=np.float32)
+    if accel_scale_g_per_lsb is not None:
+        chunk = chunk * np.float32(accel_scale_g_per_lsb)
+    if chunk.ndim != 2 or chunk.shape[1] != 3:
+        logger.warning(
+            "Dropping malformed sample chunk for %s with shape %s",
+            client_id,
+            chunk.shape,
+        )
+        return None
+    return chunk

--- a/apps/server/vibesensor/infra/processing/snapshot_window_preparation.py
+++ b/apps/server/vibesensor/infra/processing/snapshot_window_preparation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.infra.processing.buffer_mutations import ClientBufferMutator
+from vibesensor.infra.processing.buffers import ClientBuffer
+from vibesensor.infra.processing.models import FloatArray, ProcessorConfig
+from vibesensor.infra.processing.snapshot_builder import compute_snapshot_window
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedSnapshotWindows:
+    """Copied sample windows ready for metrics snapshot construction."""
+
+    time_window: FloatArray
+    fft_block: FloatArray | None
+
+
+def prepare_snapshot_windows(
+    *,
+    buf: ClientBuffer,
+    config: ProcessorConfig,
+    buffer_mutator: ClientBufferMutator,
+    sample_rate_hz: int,
+) -> PreparedSnapshotWindows:
+    """Copy the latest time-domain and FFT windows from a locked client buffer."""
+    window = compute_snapshot_window(
+        count=buf.count,
+        capacity=buf.capacity,
+        sample_rate_hz=sample_rate_hz,
+        waveform_seconds=config.waveform_seconds,
+        fft_n=config.fft_n,
+    )
+
+    fft_block: FloatArray | None = None
+    if window.needs_separate_fft_block:
+        fft_block = buffer_mutator.copy_latest(buf, config.fft_n)
+        time_window = fft_block[:, -window.n_time :]
+    else:
+        time_window = buffer_mutator.copy_latest(buf, window.n_time)
+        if buf.count >= config.fft_n:
+            fft_block = time_window[:, -config.fft_n :]
+    return PreparedSnapshotWindows(time_window=time_window, fft_block=fft_block)


### PR DESCRIPTION
## What changed
- Split incoming sample validation and scaling into `sample_validation.py`.
- Split compute snapshot time/FFT window copying into `snapshot_window_preparation.py`.
- Split FFT-ready filtering and detrending into `fft_preparation.py`.
- Updated processing tests to cover validation, buffer window extraction, and FFT preparation directly.

## Why
Processing sample preparation was still spread across ingest, snapshot, and compute owners. The new seams make each phase testable without running the full processing loop.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/infra/processing`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks, tradeoffs, edge cases
- No FFT/window parameters changed.
- Runtime metrics, diagnostics, and payload contracts are preserved.
- Existing `SignalProcessor` and `SignalBufferStore` APIs stay stable.

Closes #3793