### PR TITLE
Reduce brittle style and layout pinning tests

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from collections import Counter
-
 from vibesensor.adapters.pdf.pdf_diagram_render import car_location_diagram
 
 
-def test_car_diagram_shell_uses_contoured_paths_and_detail_polygons() -> None:
+def test_car_diagram_shell_renders_vehicle_context_without_primitive_pinning() -> None:
     diagram = car_location_diagram(
         [],
         {
@@ -21,8 +19,9 @@ def test_car_diagram_shell_uses_contoured_paths_and_detail_polygons() -> None:
         diagram_height=252.0,
     )
 
-    shape_counts = Counter(type(item).__name__ for item in diagram.contents)
+    item_types = {type(item).__name__ for item in diagram.contents}
+    text_items = {str(item.text) for item in diagram.contents if hasattr(item, "text")}
 
-    assert shape_counts["Path"] >= 4
-    assert shape_counts["Polygon"] >= 4
-    assert shape_counts["Rect"] >= 4
+    assert "Path" in item_types
+    assert "Polygon" in item_types
+    assert {"DIAGRAM_LABEL_FRONT", "DIAGRAM_LABEL_REAR"} <= text_items

--- a/apps/server/tests/adapters/pdf/test_report_style_tokens.py
+++ b/apps/server/tests/adapters/pdf/test_report_style_tokens.py
@@ -1,4 +1,4 @@
-"""Focused PDF style-token regressions for report chrome branding."""
+"""Stable PDF style-token contracts for report chrome branding."""
 
 from __future__ import annotations
 
@@ -12,6 +12,8 @@ from vibesensor.adapters.pdf.pdf_style import (
 
 
 def test_pdf_theme_tokens_align_with_website_palette() -> None:
+    """PDF reports intentionally share the website's stable brand palette."""
+
     assert REPORT_COLORS["brand"] == "#7c3aed"
     assert REPORT_COLORS["brand_surface"] == "#ede9fe"
     assert REPORT_COLORS["warning"] == "#b7791f"
@@ -22,6 +24,8 @@ def test_pdf_theme_tokens_align_with_website_palette() -> None:
 
 
 def test_pdf_typography_and_radius_shift_toward_website_chrome() -> None:
+    """PDF report chrome keeps compact type and card radius as a design contract."""
+
     assert FS_TITLE == 13
     assert FS_H2 == 10
     assert FS_CARD_TITLE == 9.0

--- a/apps/ui/tests/regression.bootstrap.spec.ts
+++ b/apps/ui/tests/regression.bootstrap.spec.ts
@@ -6,8 +6,6 @@ import {
   fulfillJson,
   installCommonRoutes,
   installFakeWebSocket,
-  readSemanticSurfaceStyles,
-  readSemanticToneStyles,
   requestPath,
 } from "./smoke.helpers";
 
@@ -113,15 +111,11 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
 
   await page.goto("/");
   await expect(page.locator("#loggingChecklist")).toBeVisible();
-  const passStyles = await readSemanticSurfaceStyles(
+  await expect(
     page
       .locator('.capture-readiness__item[data-readiness-state="pass"]')
       .first(),
-    "--capture-readiness-pass-surface",
-    "--capture-readiness-pass-border",
-  );
-  expect(passStyles.backgroundColor).toBe(passStyles.expectedBackgroundColor);
-  expect(passStyles.borderColor).toBe(passStyles.expectedBorderColor);
+  ).toContainText(/live sensor.*streaming cleanly/i);
 
   captureReadiness = buildCaptureReadiness({
     isReady: false,
@@ -141,32 +135,16 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
   await page.reload();
   await expect(page.locator("#loggingChecklist")).toBeVisible();
 
-  const expectations = [
-    {
-      locator: page
-        .locator('.capture-readiness__item[data-readiness-state="warn"]')
-        .first(),
-      surfaceVar: "--capture-readiness-warn-surface",
-      borderVar: "--capture-readiness-warn-border",
-    },
-    {
-      locator: page
-        .locator('.capture-readiness__item[data-readiness-state="fail"]')
-        .first(),
-      surfaceVar: "--capture-readiness-fail-surface",
-      borderVar: "--capture-readiness-fail-border",
-    },
-  ] as const;
-
-  for (const expectation of expectations) {
-    const styles = await readSemanticSurfaceStyles(
-      expectation.locator,
-      expectation.surfaceVar,
-      expectation.borderVar,
-    );
-    expect(styles.backgroundColor).toBe(styles.expectedBackgroundColor);
-    expect(styles.borderColor).toBe(styles.expectedBorderColor);
-  }
+  await expect(
+    page
+      .locator('.capture-readiness__item[data-readiness-state="warn"]')
+      .first(),
+  ).toContainText(/fresh live speed update/i);
+  await expect(
+    page
+      .locator('.capture-readiness__item[data-readiness-state="fail"]')
+      .first(),
+  ).toContainText(/live speed sample/i);
   const banner = page.locator(".app-error-banner");
   await banner.evaluate((element) => {
     if (!(element instanceof HTMLElement)) {
@@ -177,30 +155,8 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
     element.textContent = "Attention needed";
   });
 
-  const bannerStyles = await readSemanticToneStyles(banner, {
-    surfaceVar: "--warning-surface",
-    borderVar: "--warning-border",
-    textVar: "--warning-text",
-  });
-  const bannerBorderColor = await banner.evaluate((element) => {
-    const probe = document.createElement("div");
-    probe.style.borderBottom = "1px solid var(--warning-border)";
-    probe.style.position = "absolute";
-    probe.style.visibility = "hidden";
-    probe.style.pointerEvents = "none";
-    document.body.appendChild(probe);
-    const result = {
-      actual: getComputedStyle(element).borderBottomColor,
-      expected: getComputedStyle(probe).borderBottomColor,
-    };
-    probe.remove();
-    return result;
-  });
-  expect(bannerStyles.backgroundColor).toBe(
-    bannerStyles.expectedBackgroundColor,
-  );
-  expect(bannerBorderColor.actual).toBe(bannerBorderColor.expected);
-  expect(bannerStyles.color).toBe(bannerStyles.expectedColor);
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("Attention needed");
 });
 
 test("ui bootstrap regression: tabs, ws state, recording, history", async ({

--- a/apps/ui/tests/regression.car-wizard.spec.ts
+++ b/apps/ui/tests/regression.car-wizard.spec.ts
@@ -363,36 +363,11 @@ test("completes the library branch on a short mobile screen without losing the f
   await expect(page.locator("#wizardProgressText")).toContainText(
     "Step 5 of 5",
   );
+  await expect(wizard).toBeVisible();
   await expect(page.locator("#wizardActionHint")).toContainText(
     "Choose a library gearbox or edit the manual specs to finish.",
   );
   await expect(page.locator("#wizardManualAddBtn")).toBeDisabled();
-
-  const box = await wizard.boundingBox();
-  if (!box) {
-    throw new Error("Expected mobile wizard to have a bounding box");
-  }
-  expect(Math.round(box.x)).toBe(0);
-  expect(Math.round(box.y)).toBe(0);
-  expect(Math.abs(Math.round(box.width) - 390)).toBeLessThanOrEqual(1);
-
-  const overflowMetrics = await wizard.evaluate((wizardElement) => {
-    const steps = wizardElement.querySelector<HTMLElement>(".wizard-steps");
-    if (!steps) {
-      throw new Error("Expected wizard steps container");
-    }
-    const stepsStyle = window.getComputedStyle(steps);
-    return {
-      stepsOverflowY: stepsStyle.overflowY,
-      wizardClientHeight: Math.round(wizardElement.clientHeight),
-      wizardScrollHeight: Math.round(wizardElement.scrollHeight),
-    };
-  });
-
-  expect(overflowMetrics.stepsOverflowY).toBe("auto");
-  expect(overflowMetrics.wizardScrollHeight).toBeLessThanOrEqual(
-    overflowMetrics.wizardClientHeight + 2,
-  );
 
   await page.locator("#wizardGearboxList .wiz-opt").click();
 

--- a/apps/ui/tests/regression.cars.spec.ts
+++ b/apps/ui/tests/regression.cars.spec.ts
@@ -436,7 +436,6 @@ test("shows a live warning state until an active car is selected, then clears it
     "Choose the active car before recording.",
   );
   await expect(liveSummary).toContainText("none is active for the next run");
-  await expect(page.locator("#loggingSummary")).toHaveCSS("text-align", "left");
   await expect(page.locator("#startLoggingBtn")).toBeHidden();
   await expect(page.locator("#startLoggingBtn")).toBeDisabled();
   await expect.poll(() => startCalls).toBe(0);

--- a/apps/ui/tests/regression.history-layout.spec.ts
+++ b/apps/ui/tests/regression.history-layout.spec.ts
@@ -74,43 +74,9 @@ test("history uses mobile run cards and keeps the primary action readable on nar
   await expect(row.locator(".history-row__diagnosis")).toContainText(
     "Duration: 12.3 s",
   );
-
-  const metrics = await row.evaluate((element) => {
-    const diagnosisTitle = element.querySelector<HTMLElement>(
-      ".history-row__diagnosis-title",
-    );
-    const diagnosisMeta = element.querySelector<HTMLElement>(
-      ".history-row__diagnosis-meta",
-    );
-    const button = element.querySelector<HTMLElement>(
-      '[data-run-toggle="details"]',
-    );
-    if (!diagnosisTitle || !diagnosisMeta || !button) {
-      throw new Error("history row content is missing");
-    }
-    const lineMetrics = (el: HTMLElement) => {
-      const style = getComputedStyle(el);
-      const fontSize = Number.parseFloat(style.fontSize) || 16;
-      const lineHeight = Number.parseFloat(style.lineHeight) || fontSize * 1.2;
-      return {
-        lines: Math.round(el.getBoundingClientRect().height / lineHeight),
-      };
-    };
-    return {
-      buttonWidth: Math.round(button.getBoundingClientRect().width),
-      diagnosisTitleLines: lineMetrics(diagnosisTitle).lines,
-      diagnosisMetaLines: lineMetrics(diagnosisMeta).lines,
-    };
-  });
-
-  expect(metrics.buttonWidth).toBeGreaterThanOrEqual(140);
-  expect(metrics.diagnosisTitleLines).toBeLessThanOrEqual(2);
-  expect(metrics.diagnosisMetaLines).toBeLessThanOrEqual(3);
-  const rowDisplay = await row.evaluate(
-    (element) => getComputedStyle(element).display,
-  );
-  expect(rowDisplay).toBe("grid");
   await expect(toggle).toContainText("Open diagnosis");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
 });
 
 test("history empty state stays action-oriented on narrow screens", async ({

--- a/apps/ui/tests/regression.realtime-logging-summary.spec.ts
+++ b/apps/ui/tests/regression.realtime-logging-summary.spec.ts
@@ -51,9 +51,6 @@ test("keeps the no-car Live CTA stable while repeated websocket payloads arrive"
   const addCarButton = liveSummary.getByRole("button", { name: "Add a car" });
   await expect(addCarButton).toBeVisible();
   await expect(page.locator("#spectrumPanelRoot")).toBeHidden();
-  expect(
-    await page.locator(".dashboard-grid").getAttribute("data-layout"),
-  ).toBeNull();
 
   await page.evaluate(() => {
     const summary = document.querySelector<HTMLElement>("#loggingSummary");

--- a/apps/ui/tests/regression.settings-alignment.spec.ts
+++ b/apps/ui/tests/regression.settings-alignment.spec.ts
@@ -30,7 +30,7 @@ const readyStrengthMetrics = {
   top_peaks: [],
 };
 
-test("settings desktop journey keeps analysis controls and car actions aligned", async ({
+test("settings desktop journey keeps analysis controls and car actions reachable", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
@@ -74,37 +74,16 @@ test("settings desktop journey keeps analysis controls and car actions aligned",
   await page.locator("#tab-settings").click();
 
   await page.locator('[data-settings-tab="analysisTab"]').click();
-  const speedLabel = page.locator('label[for="speedUncertaintyInput"]');
-  const tireLabel = page.locator('label[for="tireDiameterUncertaintyInput"]');
-  const finalDriveLabel = page.locator(
-    'label[for="finalDriveUncertaintyInput"]',
-  );
-  await expect(speedLabel).toBeVisible();
-  await expect(tireLabel).toBeVisible();
-  await expect(finalDriveLabel).toBeVisible();
-
-  const [speedLabelBox, tireLabelBox, speedTop, tireTop, finalDriveTop] =
-    await Promise.all([
-      speedLabel.boundingBox(),
-      tireLabel.boundingBox(),
-      page
-        .locator("#speedUncertaintyInput")
-        .evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-      page
-        .locator("#tireDiameterUncertaintyInput")
-        .evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-      page
-        .locator("#finalDriveUncertaintyInput")
-        .evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-    ]);
-
-  if (!speedLabelBox || !tireLabelBox) {
-    throw new Error("Expected uncertainty labels to have layout boxes");
-  }
-
-  expect(tireLabelBox.height).toBeGreaterThan(speedLabelBox.height);
-  expect(Math.abs(speedTop - tireTop)).toBeLessThanOrEqual(1);
-  expect(Math.abs(finalDriveTop - tireTop)).toBeLessThanOrEqual(1);
+  await expect(
+    page.locator('label[for="speedUncertaintyInput"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('label[for="tireDiameterUncertaintyInput"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('label[for="finalDriveUncertaintyInput"]'),
+  ).toBeVisible();
+  await expect(page.locator("#saveAnalysisBtn")).toBeVisible();
 
   await page.locator('[data-settings-tab="carTab"]').click();
 
@@ -118,20 +97,8 @@ test("settings desktop journey keeps analysis controls and car actions aligned",
   await expect(activeRow.locator(".car-activate-btn")).toHaveCount(0);
   await expect(inactiveRow.locator(".car-activate-btn")).toHaveCount(1);
 
-  const [activeDeleteRight, inactiveDeleteRight] = await Promise.all([
-    activeDeleteButton.evaluate((el) => {
-      const { right } = el.getBoundingClientRect();
-      return Math.round(right);
-    }),
-    inactiveDeleteButton.evaluate((el) => {
-      const { right } = el.getBoundingClientRect();
-      return Math.round(right);
-    }),
-  ]);
-
-  expect(Math.abs(activeDeleteRight - inactiveDeleteRight)).toBeLessThanOrEqual(
-    1,
-  );
+  await expect(activeRow).toContainText("Active");
+  await expect(inactiveRow.locator(".car-activate-btn")).toBeEnabled();
 });
 
 test("dashboard desktop journey keeps summary stats and sensor cards readable", async ({
@@ -242,60 +209,18 @@ test("dashboard desktop journey keeps summary stats and sensor cards readable", 
   });
   await page.goto("/");
 
-  const dataFreshnessStat = page.locator("#liveDataFreshness");
   const strongestSignalStat = page.locator("#liveStrongestSignal");
-  const dataFreshnessLabel = dataFreshnessStat.locator(".stat__label");
-  const strongestSignalLabel = strongestSignalStat.locator(".stat__label");
-  const dataFreshnessValue = dataFreshnessStat.locator("[data-value]");
+  const dataFreshnessValue = page.locator("#liveDataFreshness [data-value]");
   const strongestSignalValue = strongestSignalStat.locator("[data-value]");
   const speedValue = page.locator("#speed");
 
   await expect(strongestSignalStat).not.toHaveClass(/stat--spotlight/);
-  await expect(strongestSignalLabel).toHaveText("Strongest signal");
+  await expect(strongestSignalStat.locator(".stat__label")).toHaveText(
+    "Strongest signal",
+  );
   await expect(dataFreshnessValue).toBeVisible();
   await expect(strongestSignalValue).toBeVisible();
   await expect(speedValue).toBeVisible();
-
-  const [
-    dataFreshnessLabelTop,
-    strongestSignalLabelTop,
-    speedLabelTop,
-    dataFreshnessValueTop,
-    strongestSignalValueTop,
-    speedValueTop,
-  ] = await Promise.all([
-    dataFreshnessLabel.evaluate((el) =>
-      Math.round(el.getBoundingClientRect().top),
-    ),
-    strongestSignalLabel.evaluate((el) =>
-      Math.round(el.getBoundingClientRect().top),
-    ),
-    speedValue.evaluate((el) =>
-      Math.round(
-        (el.previousElementSibling as HTMLElement).getBoundingClientRect().top,
-      ),
-    ),
-    dataFreshnessValue.evaluate((el) =>
-      Math.round(el.getBoundingClientRect().top),
-    ),
-    strongestSignalValue.evaluate((el) =>
-      Math.round(el.getBoundingClientRect().top),
-    ),
-    speedValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-  ]);
-
-  expect(
-    Math.abs(dataFreshnessLabelTop - strongestSignalLabelTop),
-  ).toBeLessThanOrEqual(1);
-  expect(Math.abs(speedLabelTop - strongestSignalLabelTop)).toBeLessThanOrEqual(
-    1,
-  );
-  expect(
-    Math.abs(dataFreshnessValueTop - strongestSignalValueTop),
-  ).toBeLessThanOrEqual(1);
-  expect(Math.abs(speedValueTop - strongestSignalValueTop)).toBeLessThanOrEqual(
-    1,
-  );
 
   await expect(page.locator(".site-header__status")).toBeHidden();
   await expect(page.locator("#loggingStatus")).toBeHidden();
@@ -312,41 +237,6 @@ test("dashboard desktop journey keeps summary stats and sensor cards readable", 
   await expect(frontCard).toHaveText("Front Left Wheel");
   await expect(engineCard).toHaveText("Engine Bay");
   await expect(unassignedCard).toHaveText("Gamma Probe");
-
-  const [frontOffset, engineOffset, unassignedOffset] = await Promise.all([
-    frontCard.locator(".live-sensor-card__header strong").evaluate((el) => {
-      const card = el.closest(".live-sensor-card");
-      if (!(card instanceof HTMLElement)) {
-        throw new Error("Expected live sensor card container");
-      }
-      return Math.round(
-        el.getBoundingClientRect().left - card.getBoundingClientRect().left,
-      );
-    }),
-    engineCard.locator(".live-sensor-card__header strong").evaluate((el) => {
-      const card = el.closest(".live-sensor-card");
-      if (!(card instanceof HTMLElement)) {
-        throw new Error("Expected live sensor card container");
-      }
-      return Math.round(
-        el.getBoundingClientRect().left - card.getBoundingClientRect().left,
-      );
-    }),
-    unassignedCard
-      .locator(".live-sensor-card__header strong")
-      .evaluate((el) => {
-        const card = el.closest(".live-sensor-card");
-        if (!(card instanceof HTMLElement)) {
-          throw new Error("Expected live sensor card container");
-        }
-        return Math.round(
-          el.getBoundingClientRect().left - card.getBoundingClientRect().left,
-        );
-      }),
-  ]);
-
-  expect(Math.abs(frontOffset - engineOffset)).toBeLessThanOrEqual(1);
-  expect(Math.abs(frontOffset - unassignedOffset)).toBeLessThanOrEqual(1);
 
   await page.locator("#tab-history").click();
   await expect(page.locator(".site-header__status")).toBeVisible();

--- a/apps/ui/tests/regression.update.spec.ts
+++ b/apps/ui/tests/regression.update.spec.ts
@@ -208,14 +208,7 @@ test("settings internet tab and updater show USB internet when usable", async ({
     "Starting a USB-internet update keeps the hotspot up",
   );
   await page.locator("#updateTransportWifiRadio").focus();
-  await expect(page.locator("#updateTransportChoiceWifi")).toHaveCSS(
-    "outline-style",
-    "solid",
-  );
-  await expect(page.locator("#updateTransportChoiceWifi")).toHaveCSS(
-    "outline-width",
-    "2px",
-  );
+  await expect(page.locator("#updateTransportWifiRadio")).toBeFocused();
   await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
     "data-choice-state",
     "active",

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page, type Route } from "@playwright/test";
+import { expect, type Page, type Route } from "@playwright/test";
 import type { LoggingStatusPayload } from "../src/api/types";
 import { EXPECTED_SCHEMA_VERSION } from "../src/contracts/ws_payload_types";
 
@@ -272,73 +272,6 @@ function defaultSettingsPayload(path: string): Record<string, unknown> {
     return { cars: [], active_car_id: null };
   }
   return {};
-}
-
-export type SemanticSurfaceStyles = {
-  backgroundColor: string;
-  borderColor: string;
-  expectedBackgroundColor: string;
-  expectedBorderColor: string;
-};
-
-export type SemanticToneStyles = {
-  backgroundColor: string;
-  borderColor: string;
-  color: string;
-  expectedBackgroundColor: string;
-  expectedBorderColor: string;
-  expectedColor: string;
-};
-
-export async function readSemanticToneStyles(
-  locator: Locator,
-  vars: {
-    surfaceVar: string;
-    borderVar?: string;
-    textVar?: string;
-  },
-): Promise<SemanticToneStyles> {
-  return locator.evaluate((element, vars) => {
-    const probe = document.createElement("div");
-    probe.style.background = `var(${vars.surfaceVar})`;
-    probe.style.border = vars.borderVar
-      ? `1px solid var(${vars.borderVar})`
-      : "1px solid transparent";
-    probe.style.color = vars.textVar ? `var(${vars.textVar})` : "inherit";
-    probe.style.position = "absolute";
-    probe.style.visibility = "hidden";
-    probe.style.pointerEvents = "none";
-    document.body.appendChild(probe);
-    const elementStyles = getComputedStyle(element);
-    const probeStyles = getComputedStyle(probe);
-    const result = {
-      backgroundColor: elementStyles.backgroundColor,
-      borderColor: elementStyles.borderTopColor,
-      color: elementStyles.color,
-      expectedBackgroundColor: probeStyles.backgroundColor,
-      expectedBorderColor: probeStyles.borderTopColor,
-      expectedColor: probeStyles.color,
-    };
-    probe.remove();
-    return result;
-  }, vars);
-}
-
-export async function readSemanticSurfaceStyles(
-  locator: Locator,
-  surfaceVar: string,
-  borderVar: string,
-): Promise<SemanticSurfaceStyles> {
-  const styles = await readSemanticToneStyles(locator, {
-    surfaceVar,
-    borderVar,
-  });
-  return {
-    backgroundColor: styles.backgroundColor,
-    borderColor: styles.borderColor,
-    expectedBackgroundColor: styles.expectedBackgroundColor,
-    expectedBorderColor: styles.expectedBorderColor,
-  };
 }
 
 export async function activateWizardCloseButton(page: Page): Promise<void> {


### PR DESCRIPTION
Closes #3814.

What changed:
- Removed incidental CSS variable/color, focus-outline CSS, text-align, bounding-box, display, line-count, button-width, alignment-offset, data-layout, and PDF primitive-count assertions.
- Replaced them with semantic checks for visible copy, focus, enabled actions, ARIA expansion, stable CTA identity, and meaningful PDF diagram context.
- Kept exact PDF palette/type/radius checks because they are stable report design contracts, and documented that in the tests.

Why:
- Harmless UI and PDF polish should not fail tests when user-visible behavior and regression coverage remain intact.

Validation:
- Affected UI regression subset: 21 passed.
- Remaining car-wizard/logging regression subset: 5 passed.
- Affected PDF tests: 47 passed.
- npm run test:smoke: 5 passed.
- npm run test:regression: 63 passed.
- make ui-typecheck.
- cd apps/ui && npm run build.
- PATH="$PWD/.venv/bin:$PATH" make lint.
- make typecheck-backend.
- make plan-validation.
- git diff --check.

Risks / edge cases:
- Exact CSS and primitive-count alarms are intentionally gone. Visual screenshots and semantic UI/PDF assertions remain the guardrail.
- Spectrum CSS variable cache tests remain exact because they test cache invalidation mechanics with fake values, not visual layout.