### PR TITLE
Consolidate duplicated backend test setup

### DIFF
--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -34,6 +34,16 @@ def _started_snapshot(logger) -> ActiveRunSnapshot:
     return snapshot
 
 
+def _started_snapshot_with_sample(logger) -> ActiveRunSnapshot:
+    snapshot = _started_snapshot(logger)
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+    return snapshot
+
+
 def test_build_sample_records_uses_only_active_clients(make_logger) -> None:
     logger = make_logger()
 
@@ -301,11 +311,8 @@ def test_finalize_preserves_run_metadata_from_recording_start(
 ) -> None:
     logger = make_logger(settings_reader=mutable_fake_settings, history_db=fake_history_db)
 
-    snapshot = _started_snapshot(logger)
+    snapshot = _started_snapshot_with_sample(logger)
     run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
 
     mutable_fake_settings.values["tire_width_mm"] = 315.0
     logger.stop_recording()
@@ -322,12 +329,7 @@ def test_append_records_surfaces_create_run_failure_in_status(
 ) -> None:
     logger = make_logger(history_db=failing_create_run_db)
 
-    snapshot = _started_snapshot(logger)
-    run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
+    _started_snapshot_with_sample(logger)
     status = logger.status()
 
     assert status.write_error is not None
@@ -341,17 +343,16 @@ def test_append_records_clears_write_error_after_successful_retry(
 ) -> None:
     logger = make_logger(history_db=failing_append_once_db)
 
-    snapshot = _started_snapshot(logger)
-    run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
+    snapshot = _started_snapshot_with_sample(logger)
     failed_status = logger.status()
     assert failed_status.write_error is not None
     assert "history append_samples failed" in str(failed_status.write_error)
 
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
     recovered_status = logger.status()
     assert recovered_status.write_error is None
 
@@ -433,11 +434,8 @@ def test_stop_recording_does_not_block_on_post_analysis(
     )
     logger = make_logger(history_db=history_db.run_repository)
 
-    snapshot = _started_snapshot(logger)
+    snapshot = _started_snapshot_with_sample(logger)
     run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
 
     started = time.monotonic()
     logger.stop_recording()
@@ -472,11 +470,8 @@ def test_post_analysis_unexpected_failure_surfaces_worker_error_status(
     )
     logger = make_logger(history_db=history_db.run_repository)
 
-    snapshot = _started_snapshot(logger)
+    snapshot = _started_snapshot_with_sample(logger)
     run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
 
     logger.stop_recording()
 
@@ -604,12 +599,7 @@ def test_stop_recording_continues_when_raw_capture_finalize_degrades(
 
     scheduled: list[str] = []
     logger = make_logger(history_db=fake_history_db)
-    snapshot = _started_snapshot(logger)
-    logger._sample_flush.append_records(
-        snapshot.run_id,
-        snapshot.start_time_utc,
-        snapshot.start_mono_s,
-    )
+    snapshot = _started_snapshot_with_sample(logger)
     logger._raw_capture = SimpleNamespace(
         finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
             status="timeout",
@@ -721,12 +711,7 @@ def test_stop_recording_persists_finalization_stages_in_history_metadata(
 
     history_db = create_history_persistence_adapters(tmp_path / "history.db")
     logger = make_logger(history_db=history_db_factory(history_db.run_repository))
-    snapshot = _started_snapshot(logger)
-    logger._sample_flush.append_records(
-        snapshot.run_id,
-        snapshot.start_time_utc,
-        snapshot.start_mono_s,
-    )
+    snapshot = _started_snapshot_with_sample(logger)
     logger._raw_capture = SimpleNamespace(
         finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
             status=raw_capture_status,
@@ -759,12 +744,7 @@ def test_late_raw_capture_finalize_schedules_post_analysis_after_metadata_update
     history_db = create_history_persistence_adapters(tmp_path / "history.db")
     scheduled: list[str] = []
     logger = make_logger(history_db=history_db.run_repository)
-    snapshot = _started_snapshot(logger)
-    logger._sample_flush.append_records(
-        snapshot.run_id,
-        snapshot.start_time_utc,
-        snapshot.start_mono_s,
-    )
+    snapshot = _started_snapshot_with_sample(logger)
     logger._raw_capture = SimpleNamespace(
         finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
             status="timeout",
@@ -796,12 +776,7 @@ def test_permanent_raw_capture_finalize_failure_schedules_with_degraded_metadata
 
     scheduled: list[str] = []
     logger = make_logger(history_db=fake_history_db)
-    snapshot = _started_snapshot(logger)
-    logger._sample_flush.append_records(
-        snapshot.run_id,
-        snapshot.start_time_utc,
-        snapshot.start_mono_s,
-    )
+    snapshot = _started_snapshot_with_sample(logger)
     logger._raw_capture = SimpleNamespace(
         finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
             status="failed",
@@ -832,11 +807,8 @@ def test_post_analysis_uses_run_language_from_metadata(
         language_reader=SimpleNamespace(language="nl"),
     )
 
-    snapshot = _started_snapshot(logger)
+    snapshot = _started_snapshot_with_sample(logger)
     run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
 
     def _analysis_runner(run):
         assert run.run_id == snapshot.run_id
@@ -926,11 +898,8 @@ def test_db_persists_when_jsonl_disabled(make_logger, tmp_path: Path) -> None:
     history_db = create_history_persistence_adapters(tmp_path / "history.db")
     logger = make_logger(history_db=history_db.run_repository, persist_history_db=True)
 
-    snapshot = _started_snapshot(logger)
+    snapshot = _started_snapshot_with_sample(logger)
     run_id = snapshot.run_id
-    start_time_utc = snapshot.start_time_utc
-    start_mono = snapshot.start_mono_s
-    logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
     logger.stop_recording()
 
     assert history_db.run_repository.get_run(run_id) is not None

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -26,6 +26,41 @@ from vibesensor.use_cases.updates.releases.release_validation import (
 _BLOCKED_RELEASE_VALIDATION_OPTIONAL_DEPS = ("httpx", "msgspec", "pydantic", "tenacity")
 
 
+def _firmware_manifest(
+    *,
+    name: str | None = "esp32dev",
+    segments: list[dict[str, str]] | None = None,
+) -> dict[str, object]:
+    environment: dict[str, object] = {}
+    if name is not None:
+        environment["name"] = name
+    environment["segments"] = segments if segments is not None else []
+    return {"generated_from": "deadbeef", "environments": [environment]}
+
+
+def _firmware_segment(*, sha256: str | None = None) -> dict[str, str]:
+    return {
+        "file": "esp32dev/firmware.bin",
+        "offset": "0x10000",
+        "sha256": sha256 if sha256 is not None else hashlib.sha256(b"firmware").hexdigest(),
+    }
+
+
+def _write_firmware_dist(
+    tmp_path: Path,
+    *,
+    manifest: dict[str, object],
+    firmware_bytes: bytes | None = b"firmware",
+) -> Path:
+    dist_dir = tmp_path / "dist"
+    env_dir = dist_dir / "esp32dev"
+    env_dir.mkdir(parents=True)
+    if firmware_bytes is not None:
+        (env_dir / "firmware.bin").write_bytes(firmware_bytes)
+    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return dist_dir
+
+
 def test_build_release_smoke_config_rewrites_runtime_paths(tmp_path: Path) -> None:
     config_path = build_release_smoke_config(
         SERVER_ROOT / "config.dev.yaml",
@@ -50,39 +85,20 @@ def test_build_release_smoke_config_rewrites_runtime_paths(tmp_path: Path) -> No
 
 
 def test_validate_firmware_dist_accepts_generated_manifest(tmp_path: Path) -> None:
-    dist_dir = tmp_path / "dist"
-    env_dir = dist_dir / "esp32dev"
-    env_dir.mkdir(parents=True)
-    firmware_bin = env_dir / "firmware.bin"
-    firmware_bin.write_bytes(b"firmware")
-    manifest = {
-        "generated_from": "deadbeef",
-        "environments": [
-            {
-                "name": "esp32dev",
-                "segments": [
-                    {
-                        "file": "esp32dev/firmware.bin",
-                        "offset": "0x10000",
-                        "sha256": hashlib.sha256(b"firmware").hexdigest(),
-                    },
-                ],
-            },
-        ],
-    }
-    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+    dist_dir = _write_firmware_dist(
+        tmp_path,
+        manifest=_firmware_manifest(segments=[_firmware_segment()]),
+    )
 
     assert validate_firmware_dist(dist_dir) == []
 
 
 def test_validate_firmware_dist_reports_missing_firmware_bin(tmp_path: Path) -> None:
-    dist_dir = tmp_path / "dist"
-    dist_dir.mkdir(parents=True)
-    manifest = {
-        "generated_from": "deadbeef",
-        "environments": [{"name": "esp32dev", "segments": []}],
-    }
-    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+    dist_dir = _write_firmware_dist(
+        tmp_path,
+        manifest=_firmware_manifest(),
+        firmware_bytes=None,
+    )
 
     errors = validate_firmware_dist(dist_dir)
     assert any("must contain at least one segment" in error for error in errors)
@@ -99,25 +115,10 @@ def test_validate_firmware_dist_reports_invalid_manifest_json(tmp_path: Path) ->
 
 
 def test_validate_firmware_dist_reports_missing_environment_name(tmp_path: Path) -> None:
-    dist_dir = tmp_path / "dist"
-    env_dir = dist_dir / "esp32dev"
-    env_dir.mkdir(parents=True)
-    (env_dir / "firmware.bin").write_bytes(b"firmware")
-    manifest = {
-        "generated_from": "deadbeef",
-        "environments": [
-            {
-                "segments": [
-                    {
-                        "file": "esp32dev/firmware.bin",
-                        "offset": "0x10000",
-                        "sha256": hashlib.sha256(b"firmware").hexdigest(),
-                    },
-                ],
-            },
-        ],
-    }
-    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+    dist_dir = _write_firmware_dist(
+        tmp_path,
+        manifest=_firmware_manifest(name=None, segments=[_firmware_segment()]),
+    )
 
     errors = validate_firmware_dist(dist_dir)
 
@@ -125,26 +126,10 @@ def test_validate_firmware_dist_reports_missing_environment_name(tmp_path: Path)
 
 
 def test_validate_firmware_dist_reports_checksum_mismatch(tmp_path: Path) -> None:
-    dist_dir = tmp_path / "dist"
-    env_dir = dist_dir / "esp32dev"
-    env_dir.mkdir(parents=True)
-    (env_dir / "firmware.bin").write_bytes(b"firmware")
-    manifest = {
-        "generated_from": "deadbeef",
-        "environments": [
-            {
-                "name": "esp32dev",
-                "segments": [
-                    {
-                        "file": "esp32dev/firmware.bin",
-                        "offset": "0x10000",
-                        "sha256": "0" * 64,
-                    },
-                ],
-            },
-        ],
-    }
-    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+    dist_dir = _write_firmware_dist(
+        tmp_path,
+        manifest=_firmware_manifest(segments=[_firmware_segment(sha256="0" * 64)]),
+    )
 
     errors = validate_firmware_dist(dist_dir)
 


### PR DESCRIPTION
## What changed
- Added small local builders for firmware validation test manifests and dist layout.
- Added a local started-run-with-sample helper for repeated run-recorder test setup.
- Kept per-test differences explicit; no autouse fixtures or broad fixture framework.

## Why
- Issue #3817 asks to reduce duplicated backend test builders and setup blocks without hiding behavior behind opaque mega-fixtures.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/updates/releases/test_release_validation.py`
- `./.venv/bin/ruff format --check apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/updates/releases/test_release_validation.py && ./.venv/bin/ruff check apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/updates/releases/test_release_validation.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks, tradeoffs, edge cases
- Test-only change.
- Helpers stay local because reuse is specific to these files.
- Did not extract settings or route helpers where existing local setup was already small or intentionally explicit.

Closes #3817