### PR TITLE
Replace slow test waits with deterministic hooks

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_runner.py
+++ b/apps/server/tests/use_cases/updates/test_update_runner.py
@@ -35,7 +35,7 @@ class _StaticRunner(CommandRunner):
 class _BlockingStream:
     async def read(self, n: int = -1) -> bytes:
         del n
-        await asyncio.sleep(60)
+        await asyncio.Event().wait()
         return b""
 
 
@@ -46,19 +46,21 @@ class _CancellableProcess:
         self.stdout = _BlockingStream()
         self.stderr = _BlockingStream()
         self.wait_called = asyncio.Event()
+        self._exited = asyncio.Event()
         self.killed = False
 
     def kill(self) -> None:
         self.killed = True
         self.returncode = -9
+        if not self.block_wait:
+            self._exited.set()
 
     async def wait(self) -> int:
         self.wait_called.set()
         if self.block_wait:
-            await asyncio.sleep(60)
+            await asyncio.Event().wait()
         if self.returncode is None:
-            await asyncio.sleep(60)
-        await asyncio.sleep(0)
+            await self._exited.wait()
         return self.returncode if self.returncode is not None else 0
 
 

--- a/apps/ui/tests/api_http.spec.ts
+++ b/apps/ui/tests/api_http.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { apiJson } from "../src/api/http";
+import { scanSettingsObdDevices } from "../src/api/settings";
 import {
   createDeferred,
   installTimerHarness,
@@ -77,6 +78,29 @@ describe("apiJson", () => {
       await expect(request).resolves.toEqual({ ok: true });
       expect(requestedPath).toBe("/timeout/custom");
       expect(requestedMethod).toBe("POST");
+      expect(timerHarness.pendingDelays()).toEqual([]);
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("settings OBD scan uses the extended scan timeout without wall-clock delay", async () => {
+    const timerHarness = installTimerHarness();
+    const response = createDeferred<HttpResponse<{ devices: [] }>>();
+    mswServer.use(
+      http.post(
+        uiTestUrl("/api/settings/obd/scan"),
+        async () => await response.promise,
+      ),
+    );
+
+    try {
+      const request = scanSettingsObdDevices();
+
+      expect(timerHarness.pendingDelays()).toEqual([20_000]);
+
+      response.resolve(HttpResponse.json({ devices: [] }));
+      await expect(request).resolves.toEqual({ devices: [] });
       expect(timerHarness.pendingDelays()).toEqual([]);
     } finally {
       timerHarness.restore();

--- a/apps/ui/tests/regression.settings-obd-scan-timeout.spec.ts
+++ b/apps/ui/tests/regression.settings-obd-scan-timeout.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { createDeferred } from "./async_test_helpers";
 import {
   createSettingsHandlerFromMap,
   gpsStatus,
@@ -7,12 +8,22 @@ import {
   installFakeWebSocket,
 } from "./smoke.helpers";
 
-test("manual OBD scan waits for a slow successful response without surfacing an abort banner", async ({
+test("manual OBD scan renders a successful response without surfacing an abort banner", async ({
   page,
 }) => {
-  test.slow();
-
-  let scanCalls = 0;
+  const scanPayload = {
+    devices: [
+      {
+        mac_address: "0022d9001bb1",
+        name: "OBDLink CX",
+        paired: false,
+        trusted: false,
+        connected: false,
+        rfcomm_channel: null,
+      },
+    ],
+  };
+  const scanResponse = createDeferred<typeof scanPayload>();
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
       "GET /api/settings/language": { language: "en" },
@@ -47,24 +58,7 @@ test("manual OBD scan waits for a slow successful response without surfacing an 
         last_raw_response: null,
         debug_hint: null,
       },
-      "POST /api/settings/obd/scan": async () => {
-        scanCalls += 1;
-        if (scanCalls === 1) {
-          await new Promise((resolve) => setTimeout(resolve, 10_500));
-        }
-        return {
-          devices: [
-            {
-              mac_address: "0022d9001bb1",
-              name: "OBDLink CX",
-              paired: false,
-              trusted: false,
-              connected: false,
-              rfcomm_channel: null,
-            },
-          ],
-        };
-      },
+      "POST /api/settings/obd/scan": async () => await scanResponse.promise,
     }),
   });
   await installFakeWebSocket(page);
@@ -78,9 +72,8 @@ test("manual OBD scan waits for a slow successful response without surfacing an 
   await expect(scanStatus).toContainText(
     "Scanning for Bluetooth OBD adapters...",
   );
-  await expect(scanStatus).toContainText("1 adapter(s) found.", {
-    timeout: 20_000,
-  });
+  scanResponse.resolve(scanPayload);
+  await expect(scanStatus).toContainText("1 adapter(s) found.");
   await expect(page.locator(".speed-source-device__name").first()).toHaveText(
     "OBDLink CX",
   );

--- a/apps/ui/tests/regression.settings.spec.ts
+++ b/apps/ui/tests/regression.settings.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Route } from "@playwright/test";
 
+import { createDeferred } from "./async_test_helpers";
 import {
   bootLiveDashboard,
   cancelPrompt,
@@ -819,6 +820,19 @@ test("manual OBD scan sorts named devices first and background rescans progressi
   page,
 }) => {
   let scanCalls = 0;
+  const refreshedScanPayload = {
+    devices: [
+      {
+        mac_address: "5340ac571177",
+        name: "Pim's iPhone",
+        paired: false,
+        trusted: false,
+        connected: false,
+        rfcomm_channel: null,
+      },
+    ],
+  };
+  const refreshedScan = createDeferred<typeof refreshedScanPayload>();
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
       "GET /api/settings/language": { language: "en" },
@@ -877,19 +891,7 @@ test("manual OBD scan sorts named devices first and background rescans progressi
             ],
           };
         }
-        await new Promise((resolve) => setTimeout(resolve, 2_500));
-        return {
-          devices: [
-            {
-              mac_address: "5340ac571177",
-              name: "Pim's iPhone",
-              paired: false,
-              trusted: false,
-              connected: false,
-              rfcomm_channel: null,
-            },
-          ],
-        };
+        return await refreshedScan.promise;
       },
     }),
   });
@@ -910,6 +912,9 @@ test("manual OBD scan sorts named devices first and background rescans progressi
   await expect
     .poll(() => scanCalls, { timeout: 5_000 })
     .toBeGreaterThanOrEqual(2);
+  await expect(deviceNames.nth(1)).toHaveText("53-40-AC-57-11-77");
+
+  refreshedScan.resolve(refreshedScanPayload);
   await expect(deviceNames.nth(1)).toHaveText("Pim's iPhone");
 });
 


### PR DESCRIPTION
## What changed
- Replaced update-runner fake process sleeps with event-backed blocking fakes.
- Replaced long OBD Playwright route delays with deferred responses.
- Added a unit contract that OBD scans use the 20s API timeout override without waiting in real time.
- Confirmed smoke stays short.

## Why
- Issue #3819 asks to reduce sleep/time-heavy tests where deterministic synchronization exists.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/updates/test_update_runner.py`
- `cd apps/ui && npm run test:unit -- api_http.spec.ts`
- `cd apps/ui && npx playwright test --config=playwright.regression.config.ts --project=laptop-light tests/regression.settings-obd-scan-timeout.spec.ts tests/regression.settings.spec.ts --grep "manual OBD scan|background OBD rescans"`
- `cd apps/ui && npm run test:smoke`
- touched-file ruff and UI format/lint checks
- `make ui-typecheck`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `git diff --check`

## Risks, tradeoffs, edge cases
- Test-only change.
- Kept true timeout coverage at unit level instead of spending 10.5s in Playwright.
- Kept the existing Playwright filename to satisfy test ownership guards.

Closes #3819