### PR TITLE
Consolidate edge-case test contracts

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed.py
@@ -8,97 +8,58 @@ from test_support.gps import set_gps_snapshot_age
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 
 
-def test_effective_speed_prefers_override_over_gps() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=False)
-    monitor.manual_source_selected = True
-    monitor.set_speed_override_kmh(90.0)
-    assert monitor.effective_speed_mps is not None
-    assert abs(monitor.effective_speed_mps - 25.0) < 1e-9
-
-    monitor.speed_mps = 12.5
-    # override takes priority over GPS when manual source selected
-    assert abs((monitor.effective_speed_mps or 0.0) - 25.0) < 1e-9
-
-
-def test_set_speed_override_zero_sets_stationary() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=False)
-    monitor.set_speed_override_kmh(80.0)
-    assert monitor.override_speed_mps is not None
-
-    # Zero is a valid speed (vehicle is stationary)
-    monitor.set_speed_override_kmh(0.0)
-    assert monitor.override_speed_mps == 0.0
-
-
-def test_manual_selected_with_override_returns_override() -> None:
-    """When manual source is selected and override is set, return override."""
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.manual_source_selected = True
-    monitor.override_speed_mps = 25.0
-    monitor.speed_mps = 30.0
-    set_gps_snapshot_age(monitor)
-
-    assert abs((monitor.effective_speed_mps or 0.0) - 25.0) < 1e-9
-    assert monitor.fallback_active is False
-
-
-def test_manual_selected_no_override_falls_through_to_gps() -> None:
-    """When manual source is selected but no override is set, fall through to GPS."""
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.manual_source_selected = True
-    # No override set
-    monitor.speed_mps = 30.0
-    set_gps_snapshot_age(monitor)
-
-    # Should return GPS speed instead of None
-    assert monitor.effective_speed_mps is not None
-    assert abs((monitor.effective_speed_mps or 0.0) - 30.0) < 1e-9
-
-
-def test_manual_selected_no_override_no_gps_returns_none() -> None:
-    """When manual source selected, no override, no GPS → None."""
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.manual_source_selected = True
-    monitor.speed_mps = None
-
-    assert monitor.effective_speed_mps is None
-
-
-def test_resolve_speed_default_override_has_priority() -> None:
+@pytest.mark.parametrize(
+    (
+        "manual_source_selected",
+        "override_mps",
+        "gps_speed_mps",
+        "gps_age_s",
+        "connection_state",
+        "stale_timeout_s",
+        "expected_speed_mps",
+        "expected_source",
+        "expected_fallback_active",
+    ),
+    [
+        (True, 12.0, 20.0, 0.0, "connected", None, 12.0, "manual", False),
+        (True, None, 30.0, 0.0, "connected", None, 30.0, "gps", False),
+        (True, None, None, None, "connected", None, None, "none", True),
+        (False, 11.0, 22.0, 30.0, "connected", 5.0, 11.0, "fallback_manual", True),
+    ],
+    ids=[
+        "default-manual-override-has-priority",
+        "manual-selected-without-override-uses-fresh-gps",
+        "manual-selected-without-override-and-no-gps-resolves-none",
+        "stale-gps-falls-back-to-manual-override",
+    ],
+)
+def test_resolve_speed_source_contract(
+    manual_source_selected: bool,
+    override_mps: float | None,
+    gps_speed_mps: float | None,
+    gps_age_s: float | None,
+    connection_state: str,
+    stale_timeout_s: float | None,
+    expected_speed_mps: float | None,
+    expected_source: str,
+    expected_fallback_active: bool,
+) -> None:
     monitor = GPSSpeedMonitor(gps_enabled=True)
     assert monitor.manual_source_selected is True
-    monitor.override_speed_mps = 12.0
-    monitor.speed_mps = 20.0
-    set_gps_snapshot_age(monitor)
+    monitor.manual_source_selected = manual_source_selected
+    monitor.override_speed_mps = override_mps
+    monitor.speed_mps = gps_speed_mps
+    monitor.connection_state = connection_state
+    if gps_age_s is not None:
+        set_gps_snapshot_age(monitor, age_s=gps_age_s)
+    if stale_timeout_s is not None:
+        monitor.stale_timeout_s = stale_timeout_s
 
     resolved = monitor.resolve_speed()
-    assert resolved.speed_mps == 12.0
-    assert resolved.source == "manual"
-    assert resolved.fallback_active is False
 
-
-def test_resolve_speed_stale_gps_falls_back_to_manual_override() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.manual_source_selected = False
-    monitor.speed_mps = 22.0
-    set_gps_snapshot_age(monitor, age_s=30.0)
-    monitor.override_speed_mps = 11.0
-    monitor.connection_state = "connected"
-    monitor.stale_timeout_s = 5.0
-
-    resolved = monitor.resolve_speed()
-    assert resolved.speed_mps == 11.0
-    assert resolved.source == "fallback_manual"
-    assert resolved.fallback_active is True
-
-
-def test_set_fallback_settings_clamps_timeout() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.set_fallback_settings(stale_timeout_s=0.1)
-    assert monitor.stale_timeout_s == 3.0
-
-    monitor.set_fallback_settings(stale_timeout_s=999.0)
-    assert monitor.stale_timeout_s == 120.0
+    assert resolved.speed_mps == expected_speed_mps
+    assert resolved.source == expected_source
+    assert resolved.fallback_active is expected_fallback_active
 
 
 @pytest.mark.parametrize("invalid_kmh", [-1.0, math.inf, math.nan], ids=["negative", "inf", "nan"])

--- a/apps/server/tests/adapters/gps/test_gps_speed_extended.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_extended.py
@@ -7,33 +7,30 @@ from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 
-# -- effective_speed_mps -------------------------------------------------------
 
-
-def test_gps_used_as_fallback_when_no_override() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.speed_mps = 10.0
-    set_gps_snapshot_age(monitor)  # mark GPS data as fresh
-    assert monitor.effective_speed_mps == 10.0
-
-
-def test_override_has_priority_over_gps() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor.speed_mps = 10.0
-    monitor.override_speed_mps = 25.0
-    assert monitor.effective_speed_mps == 25.0
-
-
-def test_override_used_when_no_gps() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=False)
-    monitor.manual_source_selected = True
-    monitor.override_speed_mps = 25.0
-    assert monitor.effective_speed_mps == 25.0
-
-
-def test_effective_none_when_nothing_set() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=False)
-    assert monitor.effective_speed_mps is None
+@pytest.mark.parametrize(
+    ("gps_enabled", "gps_speed_mps", "manual_selected", "override_mps", "expected_mps"),
+    [
+        pytest.param(True, 10.0, True, None, 10.0, id="fresh-gps-used-without-override"),
+        pytest.param(True, 10.0, True, 25.0, 25.0, id="manual-override-beats-gps"),
+        pytest.param(False, None, True, 25.0, 25.0, id="manual-override-used-without-gps"),
+        pytest.param(False, None, True, None, None, id="nothing-set-resolves-none"),
+    ],
+)
+def test_effective_speed_contract(
+    gps_enabled: bool,
+    gps_speed_mps: float | None,
+    manual_selected: bool,
+    override_mps: float | None,
+    expected_mps: float | None,
+) -> None:
+    monitor = GPSSpeedMonitor(gps_enabled=gps_enabled)
+    monitor.manual_source_selected = manual_selected
+    monitor.override_speed_mps = override_mps
+    monitor.speed_mps = gps_speed_mps
+    if gps_speed_mps is not None:
+        set_gps_snapshot_age(monitor)
+    assert monitor.effective_speed_mps == expected_mps
 
 
 # -- set_speed_override_kmh ---------------------------------------------------
@@ -146,23 +143,23 @@ async def test_run_cancellation_waits_writer_close_once(
     assert monitor.speed_mps is None
 
 
-def test_speed_mps_setter_replaces_timestamp_without_preserving_stale_value(
+@pytest.mark.parametrize(
+    ("new_speed_mps", "expected_snapshot"),
+    [
+        pytest.param(7.5, (7.5, 42.0), id="sets-speed-with-current-timestamp"),
+        pytest.param(None, (None, None), id="clears-speed-and-timestamp"),
+    ],
+)
+def test_speed_mps_setter_updates_snapshot(
     monkeypatch: pytest.MonkeyPatch,
+    new_speed_mps: float | None,
+    expected_snapshot: tuple[float | None, float | None],
 ) -> None:
     monitor = GPSSpeedMonitor(gps_enabled=True)
     monitor._speed_snapshot = (10.0, 5.0)
 
     monkeypatch.setattr("vibesensor.adapters.gps.gps_transport.time.monotonic", lambda: 42.0)
 
-    monitor.speed_mps = 7.5
+    monitor.speed_mps = new_speed_mps
 
-    assert monitor._speed_snapshot == (7.5, 42.0)
-
-
-def test_speed_mps_setter_clears_timestamp_when_speed_clears() -> None:
-    monitor = GPSSpeedMonitor(gps_enabled=True)
-    monitor._speed_snapshot = (10.0, 5.0)
-
-    monitor.speed_mps = None
-
-    assert monitor._speed_snapshot == (None, None)
+    assert monitor._speed_snapshot == expected_snapshot

--- a/apps/server/tests/adapters/gps/test_gps_speed_status.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_status.py
@@ -106,64 +106,57 @@ class TestStatusSnapshot:
 
 
 class TestFallback:
-    def test_fresh_gps_no_fallback(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.speed_mps = 10.0
-        set_gps_snapshot_age(m)
-        assert m.effective_speed_mps == pytest.approx(10.0)
-        assert m.fallback_active is False
-
-    def test_stale_gps_triggers_manual_fallback(self) -> None:
-        """When GPS is primary and stale, a manual override becomes the fallback."""
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.manual_source_selected = False
-        m.speed_mps = 10.0
-        set_gps_snapshot_age(m, age_s=999)
-        m.override_speed_mps = 25.0
-        assert m.effective_speed_mps == pytest.approx(25.0)
-        assert m.fallback_active is True
-
-    def test_stale_gps_no_override_returns_none(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.speed_mps = 10.0
-        set_gps_snapshot_age(m, age_s=999)
-        # No override set
-        assert m.effective_speed_mps is None
-        assert m.fallback_active is True
-
-    def test_disconnected_with_override_returns_override(self) -> None:
-        """With manual source selected, override takes priority."""
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.manual_source_selected = True
-        m.connection_state = "disconnected"
-        m.override_speed_mps = 25.0
-        assert m.effective_speed_mps == pytest.approx(25.0)
-        assert m.fallback_active is False
-
-    def test_disconnected_no_override_returns_none(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.connection_state = "disconnected"
-        assert m.effective_speed_mps is None
-        assert m.fallback_active is True
-
-    def test_override_always_wins(self) -> None:
-        """When override_speed_mps is set AND speed_source is manual, override takes priority."""
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.manual_source_selected = True
-        m.override_speed_mps = 25.0
-        m.speed_mps = 10.0
-        set_gps_snapshot_age(m)
-        assert m.effective_speed_mps == pytest.approx(25.0)
-
-    def test_default_override_wins(self) -> None:
-        """Default state (manual_source_selected=True) prioritizes override."""
+    @pytest.mark.parametrize(
+        (
+            "connection_state",
+            "manual_source_selected",
+            "gps_speed_mps",
+            "gps_age_s",
+            "override_mps",
+            "expected_speed_mps",
+            "expected_fallback_active",
+        ),
+        [
+            ("connected", True, 10.0, 0.0, None, 10.0, False),
+            ("connected", False, 10.0, 999.0, 25.0, 25.0, True),
+            ("connected", True, 10.0, 999.0, None, None, True),
+            ("disconnected", True, None, None, 25.0, 25.0, False),
+            ("disconnected", True, None, None, None, None, True),
+            ("connected", True, 10.0, 0.0, 25.0, 25.0, False),
+        ],
+        ids=[
+            "fresh-gps-no-fallback",
+            "stale-gps-uses-manual-fallback",
+            "stale-gps-without-override-resolves-none",
+            "manual-override-beats-disconnected-gps",
+            "disconnected-gps-without-override-resolves-none",
+            "default-manual-override-beats-fresh-gps",
+        ],
+    )
+    def test_effective_speed_fallback_contract(
+        self,
+        connection_state: str,
+        manual_source_selected: bool,
+        gps_speed_mps: float | None,
+        gps_age_s: float | None,
+        override_mps: float | None,
+        expected_speed_mps: float | None,
+        expected_fallback_active: bool,
+    ) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         assert m.manual_source_selected is True
-        m.override_speed_mps = 25.0
-        m.speed_mps = 10.0
-        set_gps_snapshot_age(m)
-        assert m.effective_speed_mps == pytest.approx(25.0)
-        assert m.fallback_active is False
+        m.connection_state = connection_state
+        m.manual_source_selected = manual_source_selected
+        m.speed_mps = gps_speed_mps
+        if gps_age_s is not None:
+            set_gps_snapshot_age(m, age_s=gps_age_s)
+        m.override_speed_mps = override_mps
+
+        if expected_speed_mps is None:
+            assert m.effective_speed_mps is None
+        else:
+            assert m.effective_speed_mps == pytest.approx(expected_speed_mps)
+        assert m.fallback_active is expected_fallback_active
 
     def test_stale_timeout_respected(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
@@ -186,30 +179,29 @@ class TestFallback:
 
 
 class TestSetFallbackSettings:
-    def test_default_values(self) -> None:
+    @pytest.mark.parametrize(
+        ("initial_timeout_s", "update_timeout_s", "expected_timeout_s"),
+        [
+            pytest.param(None, None, DEFAULT_STALE_TIMEOUT_S, id="default-value"),
+            pytest.param(None, 30.0, 30.0, id="explicit-timeout"),
+            pytest.param(None, 0.5, MIN_STALE_TIMEOUT_S, id="clamped-low"),
+            pytest.param(None, 999.0, MAX_STALE_TIMEOUT_S, id="clamped-high"),
+            pytest.param(42.0, None, 42.0, id="none-update-is-noop"),
+        ],
+    )
+    def test_stale_timeout_settings_contract(
+        self,
+        initial_timeout_s: float | None,
+        update_timeout_s: float | None,
+        expected_timeout_s: float,
+    ) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
-        assert m.stale_timeout_s == DEFAULT_STALE_TIMEOUT_S
+        if initial_timeout_s is not None:
+            m.stale_timeout_s = initial_timeout_s
 
-    def test_set_stale_timeout(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.set_fallback_settings(stale_timeout_s=30.0)
-        assert m.stale_timeout_s == 30.0
+        m.set_fallback_settings(stale_timeout_s=update_timeout_s)
 
-    def test_stale_timeout_clamped_low(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.set_fallback_settings(stale_timeout_s=0.5)
-        assert m.stale_timeout_s == MIN_STALE_TIMEOUT_S
-
-    def test_stale_timeout_clamped_high(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.set_fallback_settings(stale_timeout_s=999.0)
-        assert m.stale_timeout_s == MAX_STALE_TIMEOUT_S
-
-    def test_none_args_are_noop(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        m.stale_timeout_s = 42.0
-        m.set_fallback_settings(stale_timeout_s=None)
-        assert m.stale_timeout_s == 42.0
+        assert m.stale_timeout_s == expected_timeout_s
 
 
 # ---------------------------------------------------------------------------
@@ -218,19 +210,20 @@ class TestSetFallbackSettings:
 
 
 class TestIsGpsStale:
-    def test_no_update_ts_is_stale(self) -> None:
+    @pytest.mark.parametrize(
+        ("age_s", "expected_stale"),
+        [
+            pytest.param(None, True, id="no-update-timestamp-is-stale"),
+            pytest.param(0.0, False, id="fresh-update-is-not-stale"),
+            pytest.param(DEFAULT_STALE_TIMEOUT_S + 1, True, id="old-update-is-stale"),
+        ],
+    )
+    def test_gps_stale_contract(self, age_s: float | None, expected_stale: bool) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
-        assert m._is_gps_stale() is True
+        if age_s is not None:
+            set_gps_snapshot_age(m, age_s=age_s)
 
-    def test_fresh_update_not_stale(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        set_gps_snapshot_age(m)
-        assert m._is_gps_stale() is False
-
-    def test_old_update_is_stale(self) -> None:
-        m = GPSSpeedMonitor(gps_enabled=True)
-        set_gps_snapshot_age(m, age_s=m.stale_timeout_s + 1)
-        assert m._is_gps_stale() is True
+        assert m._is_gps_stale() is expected_stale
 
 
 # ---------------------------------------------------------------------------
@@ -243,17 +236,21 @@ class TestSpeedSourceConfigFallback:
         cfg = SpeedSourceConfig.default()
         assert cfg.stale_timeout_s == 10.0
 
-    def test_from_dict_camel_case(self) -> None:
-        cfg = SpeedSourceConfig.from_dict(
-            {"speedSource": "gps", "staleTimeoutS": 30},
-        )
-        assert cfg.stale_timeout_s == 30.0
-
-    def test_from_dict_clamps_timeout(self) -> None:
-        cfg = SpeedSourceConfig.from_dict({"staleTimeoutS": 0.1})
-        assert cfg.stale_timeout_s == 3.0
-        cfg = SpeedSourceConfig.from_dict({"staleTimeoutS": 999})
-        assert cfg.stale_timeout_s == 120.0
+    @pytest.mark.parametrize(
+        ("payload", "expected_timeout_s"),
+        [
+            pytest.param({"speedSource": "gps", "staleTimeoutS": 30}, 30.0, id="camel-case"),
+            pytest.param({"staleTimeoutS": 0.1}, 3.0, id="clamped-low"),
+            pytest.param({"staleTimeoutS": 999}, 120.0, id="clamped-high"),
+        ],
+    )
+    def test_from_dict_stale_timeout_contract(
+        self,
+        payload: dict[str, object],
+        expected_timeout_s: float,
+    ) -> None:
+        cfg = SpeedSourceConfig.from_dict(payload)
+        assert cfg.stale_timeout_s == expected_timeout_s
 
     def test_to_dict_includes_stale_timeout(self) -> None:
         cfg = SpeedSourceConfig.default()

--- a/apps/server/tests/adapters/gps/test_speed_validation.py
+++ b/apps/server/tests/adapters/gps/test_speed_validation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import math
 
+import pytest
+
 from vibesensor.adapters.gps.speed_validation import (
     DEFAULT_SPEED_VALIDATION_CONFIG,
     SpeedSampleVerdict,
@@ -16,26 +18,29 @@ from vibesensor.adapters.gps.speed_validation import (
 class TestIsSpeedPlausible:
     """Plausibility gate for GPS speed samples."""
 
-    def test_normal_speed_accepted(self) -> None:
-        assert is_speed_plausible(30.0) is True
-
-    def test_zero_speed_accepted(self) -> None:
-        assert is_speed_plausible(0.0) is True
-
-    def test_max_speed_accepted(self) -> None:
-        assert is_speed_plausible(DEFAULT_SPEED_VALIDATION_CONFIG.max_speed_mps) is True
-
-    def test_over_max_rejected(self) -> None:
-        assert is_speed_plausible(151.0) is False
-
-    def test_negative_rejected(self) -> None:
-        assert is_speed_plausible(-1.0) is False
-
-    def test_nan_rejected(self) -> None:
-        assert is_speed_plausible(math.nan) is False
-
-    def test_inf_rejected(self) -> None:
-        assert is_speed_plausible(math.inf) is False
+    @pytest.mark.parametrize(
+        ("speed_mps", "expected"),
+        [
+            (30.0, True),
+            (0.0, True),
+            (DEFAULT_SPEED_VALIDATION_CONFIG.max_speed_mps, True),
+            (151.0, False),
+            (-1.0, False),
+            (math.nan, False),
+            (math.inf, False),
+        ],
+        ids=[
+            "normal-speed-accepted",
+            "zero-speed-accepted",
+            "max-speed-accepted",
+            "over-max-rejected",
+            "negative-rejected",
+            "nan-rejected",
+            "inf-rejected",
+        ],
+    )
+    def test_default_plausibility_contract(self, speed_mps: float, expected: bool) -> None:
+        assert is_speed_plausible(speed_mps) is expected
 
     def test_custom_config(self) -> None:
         cfg = SpeedValidationConfig(max_speed_mps=50.0)
@@ -46,42 +51,88 @@ class TestIsSpeedPlausible:
 class TestEvaluateSpeedSample:
     """Zero-speed transition confirmation logic."""
 
-    def test_nonzero_speed_always_accepted(self) -> None:
-        verdict = evaluate_speed_sample(10.0, prev_speed=50.0, current_streak=2)
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=0)
+    @pytest.mark.parametrize(
+        ("speed_mps", "prev_speed", "current_streak", "expected"),
+        [
+            (
+                10.0,
+                50.0,
+                2,
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=0),
+            ),
+            (
+                0.0,
+                0.3,
+                0,
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=0),
+            ),
+            (
+                0.0,
+                5.0,
+                0,
+                SpeedSampleVerdict(accepted=False, zero_speed_streak=1),
+            ),
+            (
+                0.0,
+                5.0,
+                1,
+                SpeedSampleVerdict(accepted=False, zero_speed_streak=2),
+            ),
+            (
+                0.0,
+                5.0,
+                2,
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=3),
+            ),
+            (
+                0.0,
+                None,
+                0,
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=0),
+            ),
+            (
+                0.0,
+                True,
+                0,
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=0),
+            ),
+        ],
+        ids=[
+            "nonzero-always-accepted",
+            "zero-after-low-speed-accepted-immediately",
+            "zero-after-high-speed-first-sample-rejected",
+            "zero-after-high-speed-second-sample-rejected",
+            "zero-after-high-speed-third-sample-accepted",
+            "zero-with-no-previous-speed-accepted",
+            "bool-previous-speed-is-not-numeric",
+        ],
+    )
+    def test_default_zero_transition_contract(
+        self,
+        speed_mps: float,
+        prev_speed: float | None | bool,
+        current_streak: int,
+        expected: SpeedSampleVerdict,
+    ) -> None:
+        verdict = evaluate_speed_sample(speed_mps, prev_speed, current_streak)  # type: ignore[arg-type]
+        assert verdict == expected
 
-    def test_zero_after_low_speed_accepted_immediately(self) -> None:
-        verdict = evaluate_speed_sample(0.0, prev_speed=0.3, current_streak=0)
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=0)
-
-    def test_zero_after_high_speed_first_sample_rejected(self) -> None:
-        verdict = evaluate_speed_sample(0.0, prev_speed=5.0, current_streak=0)
-        assert verdict == SpeedSampleVerdict(accepted=False, zero_speed_streak=1)
-
-    def test_zero_after_high_speed_second_sample_rejected(self) -> None:
-        verdict = evaluate_speed_sample(0.0, prev_speed=5.0, current_streak=1)
-        assert verdict == SpeedSampleVerdict(accepted=False, zero_speed_streak=2)
-
-    def test_zero_after_high_speed_third_sample_accepted(self) -> None:
-        verdict = evaluate_speed_sample(0.0, prev_speed=5.0, current_streak=2)
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=3)
-
-    def test_zero_with_none_prev_accepted(self) -> None:
-        verdict = evaluate_speed_sample(0.0, prev_speed=None, current_streak=0)
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=0)
-
-    def test_zero_with_bool_prev_accepted(self) -> None:
-        """Bool values must not be treated as numeric previous speeds."""
-        verdict = evaluate_speed_sample(0.0, prev_speed=True, current_streak=0)  # type: ignore[arg-type]
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=0)
-
-    def test_custom_confirm_samples(self) -> None:
-        cfg = SpeedValidationConfig(zero_confirm_samples=1)
-        verdict = evaluate_speed_sample(0.0, prev_speed=5.0, current_streak=0, config=cfg)
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=1)
-
-    def test_custom_threshold(self) -> None:
-        cfg = SpeedValidationConfig(zero_drop_prev_threshold_mps=10.0)
-        # prev_speed=5.0 is below threshold, so zero is accepted immediately
-        verdict = evaluate_speed_sample(0.0, prev_speed=5.0, current_streak=0, config=cfg)
-        assert verdict == SpeedSampleVerdict(accepted=True, zero_speed_streak=0)
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            (
+                SpeedValidationConfig(zero_confirm_samples=1),
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=1),
+            ),
+            (
+                SpeedValidationConfig(zero_drop_prev_threshold_mps=10.0),
+                SpeedSampleVerdict(accepted=True, zero_speed_streak=0),
+            ),
+        ],
+        ids=["custom-confirm-samples", "custom-previous-speed-threshold"],
+    )
+    def test_custom_zero_transition_config(
+        self, config: SpeedValidationConfig, expected: SpeedSampleVerdict
+    ) -> None:
+        verdict = evaluate_speed_sample(0.0, prev_speed=5.0, current_streak=0, config=config)
+        assert verdict == expected

--- a/apps/server/tests/adapters/http/test_safe_filename.py
+++ b/apps/server/tests/adapters/http/test_safe_filename.py
@@ -13,19 +13,18 @@ class TestSafeFilename:
     @pytest.mark.parametrize(
         ("input_name", "expected"),
         [
-            ("run-2026-01-01_abc", "run-2026-01-01_abc"),
-            ("", "download"),
-            ("///", "___"),
+            pytest.param("run-2026-01-01_abc", "run-2026-01-01_abc", id="safe-name-kept"),
+            pytest.param("", "download", id="empty-name-uses-download"),
+            pytest.param("///", "___", id="path-separators-replaced"),
+            pytest.param(
+                "run/with spaces & $pecial",
+                "run_with_spaces____pecial",
+                id="special-characters-replaced",
+            ),
         ],
     )
-    def test_exact_output(self, input_name: str, expected: str) -> None:
+    def test_normalization_contract(self, input_name: str, expected: str) -> None:
         assert _safe_filename(input_name) == expected
-
-    def test_special_chars_replaced(self) -> None:
-        result = _safe_filename("run/with spaces & $pecial")
-        assert "/" not in result
-        assert " " not in result
-        assert "$" not in result
 
     def test_long_name_truncated(self) -> None:
         result = _safe_filename("a" * 500)


### PR DESCRIPTION
## What changed
- Grouped GPS speed source, fallback, stale timeout, staleness, config parsing, speed plausibility, zero-transition, and speed setter edge cases into named parametrized contracts.
- Grouped safe filename normalization edge cases under one named contract.
- Removed duplicated GPS wrapper coverage already covered by focused contracts.
- Left API path identifier validation and speed resolution policy tests separate because they already assert distinct route/service/schema and policy seams.

## Why
- Issue #3820 asks to reduce repetitive tiny edge-case tests without losing boundary coverage.

## Validation
- Candidate slice collected 88 tests instead of 92.
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/gps/test_gps_speed.py apps/server/tests/adapters/gps/test_gps_speed_extended.py apps/server/tests/adapters/gps/test_gps_speed_status.py apps/server/tests/adapters/gps/test_speed_validation.py apps/server/tests/adapters/gps/test_speed_resolution_policy.py apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/adapters/http/test_safe_filename.py`
- touched-file ruff format/check
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`

## Risks, tradeoffs, edge cases
- Test-only change.
- Param tables use explicit IDs so failures still name the scenario.
- No meaningful boundary cases intentionally removed; duplicate wrapper assertions were removed where focused contracts cover the same behavior.

Closes #3820