### PR TITLE
Clean up brittle UI signal assertions

### DIFF
--- a/apps/ui/tests/maintenance_feature_signal.spec.ts
+++ b/apps/ui/tests/maintenance_feature_signal.spec.ts
@@ -45,6 +45,30 @@ function assertNotContains(
   );
 }
 
+function elementText(element: Element): string {
+  return element.textContent ?? "";
+}
+
+function stageTexts(root: ParentNode): string[] {
+  return Array.from(root.querySelectorAll("li"), elementText);
+}
+
+function requireStageText(root: ParentNode, title: string): string {
+  const stageText = stageTexts(root).find((text) => text.includes(title));
+  assert.ok(stageText, `Expected a stage containing ${JSON.stringify(title)}`);
+  return stageText;
+}
+
+function assertCompletedStageCount(
+  root: ParentNode,
+  expectedCount: number,
+): void {
+  assert.equal(
+    stageTexts(root).filter((text) => text.includes("Complete")).length,
+    expectedCount,
+  );
+}
+
 async function withMaintenanceScope(
   run: (scope: ReturnType<typeof createUiMswTestScope>) => Promise<void>,
 ) {
@@ -215,47 +239,26 @@ async function runEspFlashIdleStateRendersPanels(): Promise<void> {
       feature.startPolling();
       await flushAsyncWork();
 
-      assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.start_readiness.summary_ready",
-      );
-      assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.start_readiness.item.connection_ready",
-      );
+      assertContains(elementText(deps.espFlashStartSummary), "Ready to flash");
+      assertContains(elementText(deps.espFlashStartSummary), "ESP port ready.");
       assert.equal(deps.espFlashStartBtn.disabled, false);
       assert.equal(deps.espFlashCancelBtn.hidden, true);
+      assertContains(elementText(deps.espFlashReadinessPanel), "Ready ports");
       assertContains(
-        deps.espFlashReadinessPanel.innerHTML,
-        "settings.esp_flash.readiness.summary.ready_ports",
+        elementText(deps.espFlashReadinessPanel),
+        "1 port available",
       );
-      assertContains(
-        deps.espFlashReadinessPanel.innerHTML,
-        "settings.esp_flash.readiness.one_port",
-      );
-      assertContains(
-        deps.espFlashReadinessPanel.innerHTML,
-        "settings.esp_flash.auto_detect",
-      );
+      assertContains(elementText(deps.espFlashReadinessPanel), "Auto-detect");
       assertNotContains(
-        deps.espFlashReadinessPanel.innerHTML,
-        "settings.esp_flash.journey_title",
+        elementText(deps.espFlashReadinessPanel),
+        "Flash progress",
       );
-      assertNotContains(
-        deps.espFlashReadinessPanel.innerHTML,
-        "settings.esp_flash.phase.validating",
-      );
+      assertNotContains(elementText(deps.espFlashReadinessPanel), "Validating");
+      assertContains(elementText(deps.espFlashJourneyPanel), "Validating");
+      assertContains(elementText(deps.els.espFlashLogPanel), "Flash log idle");
       assertContains(
-        deps.espFlashJourneyPanel.innerHTML,
-        "settings.esp_flash.phase.validating",
-      );
-      assertContains(
-        deps.els.espFlashLogPanel.innerHTML,
-        "settings.esp_flash.logs_idle_title",
-      );
-      assertContains(
-        deps.els.espFlashHistoryPanel.innerHTML,
-        "settings.esp_flash.history_empty_title",
+        elementText(deps.els.espFlashHistoryPanel),
+        "No flash attempts yet",
       );
     } finally {
       feature.dispose();
@@ -278,13 +281,10 @@ async function runEspFlashNoPortsBlocksAction(): Promise<void> {
       feature.startPolling();
       await flushAsyncWork();
 
+      assertContains(elementText(deps.espFlashStartSummary), "Flash blocked");
       assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.start_readiness.summary_blocked",
-      );
-      assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.start_readiness.item.connection_blocked",
+        elementText(deps.espFlashStartSummary),
+        "No ESP port found.",
       );
       assert.equal(deps.espFlashStartBtn.disabled, true);
       assert.equal(deps.espFlashCancelBtn.hidden, true);
@@ -318,31 +318,21 @@ async function runEspFlashRunningStateHighlightsStage(): Promise<void> {
       feature.startPolling();
       await flushAsyncWork();
 
-      assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.start_readiness.summary_running",
-      );
+      assertContains(elementText(deps.espFlashStartSummary), "Flash running");
       assert.equal(deps.espFlashStartBtn.hidden, true);
       assert.equal(deps.espFlashCancelBtn.hidden, false);
       assertContains(
-        deps.els.espFlashLogPanel.innerHTML,
-        "settings.esp_flash.logs_running_title",
+        elementText(deps.els.espFlashLogPanel),
+        "Flash log running",
       );
-      const html = deps.espFlashJourneyPanel.innerHTML;
-      assert.match(
-        html,
-        /<li(?=[^>]*data-stage-phase="flashing")(?=[^>]*data-stage-state="active")(?=[^>]*aria-current="step")[^>]*>/,
+      const activeStage = deps.espFlashJourneyPanel.querySelector(
+        "li[aria-current='step']",
       );
-      assertContains(
-        deps.espFlashReadinessPanel.innerHTML,
-        "settings.esp_flash.readiness.current_step",
-      );
-      assert.equal(html.match(/data-stage-state="done"/g)?.length ?? 0, 3);
-      assert.equal(
-        html.match(/<span class="maintenance-stage__marker">✓<\/span>/g)
-          ?.length ?? 0,
-        3,
-      );
+      assert.ok(activeStage);
+      assertContains(elementText(activeStage), "Flashing");
+      assertContains(elementText(activeStage), "Active");
+      assertContains(elementText(deps.espFlashReadinessPanel), "Current step");
+      assertCompletedStageCount(deps.espFlashJourneyPanel, 3);
     } finally {
       feature.dispose();
     }
@@ -382,34 +372,28 @@ async function runEspFlashFailedRefreshKeepsStoppedStage(): Promise<void> {
       feature.startPolling();
       await flushAsyncWork();
 
-      const html = deps.espFlashJourneyPanel.innerHTML;
-      assert.match(
-        html,
-        /<li(?=[^>]*data-stage-phase="flashing")(?=[^>]*data-stage-state="attention")[^>]*>/,
+      const stoppedStage = requireStageText(
+        deps.espFlashJourneyPanel,
+        "Flashing",
+      );
+      assertContains(stoppedStage, "Needs attention");
+      assertContains(elementText(deps.espFlashStartSummary), "Flash recovery");
+      assertContains(
+        elementText(deps.espFlashStartSummary),
+        "Reconnect the ESP and retry flashing.",
+      );
+      assert.equal(deps.espFlashStartBtn.textContent, "Retry flash");
+      assertContains(
+        elementText(deps.els.espFlashLogPanel),
+        "Flash log failed",
       );
       assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.recovery.title",
-      );
-      assertContains(
-        deps.espFlashStartSummary.innerHTML,
-        "settings.esp_flash.recovery.flashing.detail",
-      );
-      assert.equal(
-        deps.espFlashStartBtn.textContent,
-        "settings.esp_flash.retry",
-      );
-      assertContains(
-        deps.els.espFlashLogPanel.innerHTML,
-        "settings.esp_flash.logs_failed_title",
-      );
-      assertContains(
-        deps.els.espFlashHistoryPanel.innerHTML,
+        elementText(deps.els.espFlashHistoryPanel),
         "serial port disconnected",
       );
-      assert.equal(html.match(/data-stage-state="done"/g)?.length ?? 0, 3);
+      assertCompletedStageCount(deps.espFlashJourneyPanel, 3);
       assertContains(
-        deps.espFlashReadinessPanel.innerHTML,
+        elementText(deps.espFlashReadinessPanel),
         "serial port disconnected",
       );
     } finally {
@@ -521,50 +505,25 @@ async function runUpdateUsbTransportFlow(): Promise<void> {
       assert.equal(deps.updateWifiFields.hidden, true);
       assert.equal(deps.updateStartBtn.disabled, false);
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.readiness.item.connection_usb_ready",
+        elementText(deps.updateReadinessSummary),
+        "USB internet ready on usb0.",
       );
       assert.equal(
         deps.updateDetailsCaption.textContent,
-        "settings.update.details_caption_usb",
+        "USB internet details",
       );
       assert.equal(
         deps.updateTransportNote.textContent,
-        "settings.update.preflight_note_usb",
+        "USB internet will be used for update checks.",
       );
       assert.equal(
         deps.updateUsbTransportSummary.textContent,
-        "settings.update.transport.usb_summary_interface",
+        "USB interface usb0",
       );
-      assert.equal(
-        deps.updateTransportChoiceWifi.getAttribute("data-selected"),
-        null,
-      );
-      assert.equal(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
-        null,
-      );
-      assert.equal(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
-        null,
-      );
-      assert.equal(
-        deps.updateTransportChoiceUsb.getAttribute("data-selected"),
-        "true",
-      );
-      assert.equal(
-        deps.updateTransportChoiceUsb.getAttribute("data-choice-state"),
-        "active",
-      );
-      assert.equal(
-        deps.updateTransportChoiceUsb.getAttribute("data-choice-badge"),
-        "settings.update.transport.selected_badge",
-      );
-      assert.equal(
-        deps.updateTransportChoiceUsb.getAttribute("data-disabled"),
-        null,
-      );
-      assertContains(deps.internetStatusPanel.innerHTML, "usb0");
+      assert.equal(deps.updateTransportWifiRadio.checked, false);
+      assert.equal(deps.updateTransportUsbRadio.checked, true);
+      assert.equal(deps.updateTransportUsbRadio.disabled, false);
+      assertContains(elementText(deps.internetStatusPanel), "usb0");
 
       deps.updateStartBtn.click();
       await flushAsyncWork();
@@ -597,76 +556,53 @@ async function runUpdateIdleStatusRendersPanels(): Promise<void> {
       await flushAsyncWork();
 
       assertContains(
-        deps.els.updateStatusPanel.innerHTML,
-        "settings.update.journey_title",
+        elementText(deps.els.updateStatusPanel),
+        "Update progress",
       );
-      assertContains(
-        deps.els.updateStatusPanel.innerHTML,
-        "settings.update.phase.validating",
-      );
+      assertContains(elementText(deps.els.updateStatusPanel), "Validating");
       assertNotContains(
-        deps.els.updateStatusPanel.innerHTML,
-        "settings.update.issues_empty_title",
+        elementText(deps.els.updateStatusPanel),
+        "No update issues",
       );
       assertContains(
-        deps.els.updateStatusPanel.innerHTML,
-        "settings.update.log_empty_title",
+        elementText(deps.els.updateStatusPanel),
+        "No update log yet",
       );
       assertContains(
-        deps.els.updateOverviewPanel.innerHTML,
-        "settings.update.current_status_title",
+        elementText(deps.els.updateOverviewPanel),
+        "Current update status",
       );
       assertContains(
-        deps.els.updateOverviewPanel.innerHTML,
-        "settings.update.current_status_summary.ready",
+        elementText(deps.els.updateOverviewPanel),
+        "Update service ready",
       );
-      assertContains(deps.els.updateOverviewPanel.innerHTML, "1.2.3");
+      assertContains(elementText(deps.els.updateOverviewPanel), "1.2.3");
       assertContains(
-        deps.els.updateOverviewPanel.innerHTML,
-        "settings.update.health_card_title",
+        elementText(deps.els.updateOverviewPanel),
+        "Update health",
       );
+      assertContains(elementText(deps.internetStatusPanel), "USB internet");
       assertContains(
-        deps.internetStatusPanel.innerHTML,
-        "settings.internet.card_title",
-      );
-      assertContains(
-        deps.internetStatusPanel.innerHTML,
-        "settings.internet.summary.not_detected",
+        elementText(deps.internetStatusPanel),
+        "No USB internet detected",
       );
       assert.equal(deps.updateTransportOptions.hidden, false);
-      assert.equal(
-        deps.updateTransportChoiceWifi.getAttribute("data-selected"),
-        "true",
-      );
-      assert.equal(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
-        "active",
-      );
-      assert.equal(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
-        "settings.update.transport.selected_badge",
-      );
-      assert.equal(
-        deps.updateTransportChoiceUsb.getAttribute("data-disabled"),
-        "true",
-      );
+      assert.equal(deps.updateTransportWifiRadio.checked, true);
+      assert.equal(deps.updateTransportUsbRadio.checked, false);
       assert.equal(deps.updateTransportUsbRadio.disabled, true);
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.readiness.summary_ready",
+        elementText(deps.updateReadinessSummary),
+        "Ready to update",
       );
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.readiness.item.connection_wifi_ready",
+        elementText(deps.updateReadinessSummary),
+        "Wi-Fi connection ready.",
       );
-      assert.equal(
-        deps.updateDetailsCaption.textContent,
-        "settings.update.details_caption_wifi",
-      );
+      assert.equal(deps.updateDetailsCaption.textContent, "Wi-Fi details");
       assert.equal(deps.updateStartBtn.disabled, false);
       assert.equal(
         deps.updateUsbTransportSummary.textContent,
-        "settings.update.transport.usb_summary_unavailable",
+        "USB internet unavailable",
       );
     } finally {
       feature.dispose();
@@ -706,16 +642,13 @@ async function runUpdateDegradedHealthBlocksStart(): Promise<void> {
       await flushAsyncWork();
 
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.readiness.item.health_blocked",
+        elementText(deps.updateReadinessSummary),
+        "Health blocks update start.",
       );
+      assertContains(elementText(deps.els.updateOverviewPanel), "Subsystems");
       assertContains(
-        deps.els.updateOverviewPanel.innerHTML,
-        "settings.update.health.subsystems",
-      );
-      assertContains(
-        deps.els.updateOverviewPanel.innerHTML,
-        "recorder: settings.update.health.subsystem_state.unhealthy (persistence_write_error)",
+        elementText(deps.els.updateOverviewPanel),
+        "recorder: Unhealthy (persistence_write_error)",
       );
       assert.equal(deps.updateStartBtn.disabled, true);
     } finally {
@@ -744,18 +677,17 @@ async function runUpdateRunningStateHighlightsStage(): Promise<void> {
       feature.startPolling();
       await flushAsyncWork();
 
-      const html = deps.els.updateStatusPanel.innerHTML;
-      assertContains(html, "settings.update.log_running_title");
-      assert.match(
-        html,
-        /<li(?=[^>]*data-stage-phase="installing")(?=[^>]*data-stage-state="active")(?=[^>]*aria-current="step")[^>]*>/,
+      assertContains(
+        elementText(deps.els.updateStatusPanel),
+        "Update log running",
       );
-      assert.equal(html.match(/data-stage-state="done"/g)?.length ?? 0, 5);
-      assert.equal(
-        html.match(/<span class="maintenance-stage__marker">✓<\/span>/g)
-          ?.length ?? 0,
-        5,
+      const activeStage = deps.els.updateStatusPanel.querySelector(
+        "li[aria-current='step']",
       );
+      assert.ok(activeStage);
+      assertContains(elementText(activeStage), "Installing");
+      assertContains(elementText(activeStage), "Active");
+      assertCompletedStageCount(deps.els.updateStatusPanel, 5);
     } finally {
       feature.dispose();
     }
@@ -784,8 +716,8 @@ async function runUpdatePersistedSsidRehydratesInput(): Promise<void> {
 
       assert.equal(deps.updateSsidInput.value, "Workshop Wi-Fi");
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.readiness.summary_ready",
+        elementText(deps.updateReadinessSummary),
+        "Ready to update",
       );
       assert.equal(deps.updateStartBtn.disabled, false);
     } finally {
@@ -854,32 +786,41 @@ async function runUpdateFailedStateSurfacesRecovery(): Promise<void> {
       feature.startPolling();
       await flushAsyncWork();
 
-      const html = deps.els.updateStatusPanel.innerHTML;
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.recovery.title",
+        elementText(deps.updateReadinessSummary),
+        "Update recovery",
       );
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.recovery.wifi.title",
+        elementText(deps.updateReadinessSummary),
+        "Restore network connection",
       );
       assertContains(
-        deps.updateReadinessSummary.innerHTML,
-        "settings.update.recovery.wifi.detail",
+        elementText(deps.updateReadinessSummary),
+        "Reconnect Wi-Fi or use USB internet.",
       );
-      assert.equal(deps.updateStartBtn.textContent, "settings.update.retry");
-      assertContains(html, "settings.update.issues");
-      assertContains(html, "settings.update.attempt_title");
-      assertContains(html, "settings.update.log_failed_title");
-      assertContains(html, "Hotspot restart timed out");
+      assert.equal(deps.updateStartBtn.textContent, "Retry update");
+      assertContains(elementText(deps.els.updateStatusPanel), "Update issues");
       assertContains(
-        html,
+        elementText(deps.els.updateStatusPanel),
+        "Latest update attempt",
+      );
+      assertContains(
+        elementText(deps.els.updateStatusPanel),
+        "Update log failed",
+      );
+      assertContains(
+        elementText(deps.els.updateStatusPanel),
+        "Hotspot restart timed out",
+      );
+      assertContains(
+        elementText(deps.els.updateStatusPanel),
         "NetworkManager is still reconnecting to the uplink.",
       );
-      assert.match(
-        html,
-        /<li(?=[^>]*data-stage-phase="restoring_hotspot")(?=[^>]*data-stage-state="attention")[^>]*>/,
+      const stoppedStage = requireStageText(
+        deps.els.updateStatusPanel,
+        "Restoring hotspot",
       );
+      assertContains(stoppedStage, "Needs attention");
     } finally {
       feature.dispose();
     }

--- a/apps/ui/tests/maintenance_feature_test_support.ts
+++ b/apps/ui/tests/maintenance_feature_test_support.ts
@@ -7,6 +7,7 @@ import type { EspFlashFeatureDeps } from "../src/app/features/esp_flash_feature"
 import { createEspFlashFeature } from "../src/app/features/esp_flash_feature";
 import type { UpdateFeatureDeps } from "../src/app/features/update_feature";
 import { createUpdateFeature } from "../src/app/features/update_feature";
+import { type ReadonlySignal, signal } from "../src/app/ui_signals";
 import type {
   EspFlashPanelActionHandlers,
   EspFlashPanelRenderModel,
@@ -22,9 +23,8 @@ import type {
   UpdatePanelRenderModel,
   UpdatePanelView,
 } from "../src/app/views/update_panel";
-import { signal, type ReadonlySignal } from "../src/app/ui_signals";
-import { flushAsyncWork } from "./async_test_helpers";
 import type { TimerHarness } from "./async_test_helpers";
+import { flushAsyncWork } from "./async_test_helpers";
 import { installMountedDomGlobals } from "./dom_render_test_support";
 import {
   createEspFlashPort,
@@ -39,6 +39,102 @@ import { createTestQueryClient } from "./query_client_test_support";
 type FeatureServices = UpdateFeatureDeps["services"];
 
 const activeMaintenanceCleanups: Array<() => void> = [];
+const MAINTENANCE_TEST_TRANSLATIONS: Readonly<Record<string, string>> = {
+  "maintenance.readiness.blocked": "Blocked",
+  "maintenance.readiness.ready": "Ready",
+  "maintenance.readiness.running": "Running",
+  "maintenance.stage_state.active": "Active",
+  "maintenance.stage_state.attention": "Needs attention",
+  "maintenance.stage_state.done": "Complete",
+  "maintenance.stage_state.upcoming": "Upcoming",
+  "settings.esp_flash.auto_detect": "Auto-detect",
+  "settings.esp_flash.history_empty_title": "No flash attempts yet",
+  "settings.esp_flash.journey.detail.done": "Confirm flash finished.",
+  "settings.esp_flash.journey.detail.erasing": "Erase old firmware.",
+  "settings.esp_flash.journey.detail.flashing": "Write firmware.",
+  "settings.esp_flash.journey.detail.preparing": "Prepare the device.",
+  "settings.esp_flash.journey.detail.validating": "Validate the selected port.",
+  "settings.esp_flash.journey_terminal.failed": "Flash failed.",
+  "settings.esp_flash.journey_title": "Flash progress",
+  "settings.esp_flash.logs_failed_title": "Flash log failed",
+  "settings.esp_flash.logs_idle_title": "Flash log idle",
+  "settings.esp_flash.logs_running_title": "Flash log running",
+  "settings.esp_flash.phase.done": "Done",
+  "settings.esp_flash.phase.erasing": "Erasing",
+  "settings.esp_flash.phase.flashing": "Flashing",
+  "settings.esp_flash.phase.preparing": "Preparing",
+  "settings.esp_flash.phase.validating": "Validating",
+  "settings.esp_flash.readiness.current_step": "Current step",
+  "settings.esp_flash.readiness.one_port": "1 port available",
+  "settings.esp_flash.readiness.summary.ready_ports": "Ready ports",
+  "settings.esp_flash.recovery.flashing.detail":
+    "Reconnect the ESP and retry flashing.",
+  "settings.esp_flash.recovery.title": "Flash recovery",
+  "settings.esp_flash.retry": "Retry flash",
+  "settings.esp_flash.start": "Start flash",
+  "settings.esp_flash.start_readiness.item.connection_blocked":
+    "No ESP port found.",
+  "settings.esp_flash.start_readiness.item.connection_ready": "ESP port ready.",
+  "settings.esp_flash.start_readiness.summary_blocked": "Flash blocked",
+  "settings.esp_flash.start_readiness.summary_ready": "Ready to flash",
+  "settings.esp_flash.start_readiness.summary_running": "Flash running",
+  "settings.internet.card_title": "USB internet",
+  "settings.internet.summary.not_detected": "No USB internet detected",
+  "settings.update.attempt_title": "Latest update attempt",
+  "settings.update.current_status_summary.ready": "Update service ready",
+  "settings.update.current_status_title": "Current update status",
+  "settings.update.details_caption_usb": "USB internet details",
+  "settings.update.details_caption_wifi": "Wi-Fi details",
+  "settings.update.health.subsystem_state.unhealthy": "Unhealthy",
+  "settings.update.health.subsystems": "Subsystems",
+  "settings.update.health_card_title": "Update health",
+  "settings.update.issues": "Update issues",
+  "settings.update.issues_empty_title": "No update issues",
+  "settings.update.journey.detail.checking": "Check for a release.",
+  "settings.update.journey.detail.connecting_usb_internet": "Use USB internet.",
+  "settings.update.journey.detail.connecting_wifi": "Connect to Wi-Fi.",
+  "settings.update.journey.detail.done": "Finish update.",
+  "settings.update.journey.detail.downloading": "Download update.",
+  "settings.update.journey.detail.installing": "Install update.",
+  "settings.update.journey.detail.restoring_hotspot": "Restore hotspot.",
+  "settings.update.journey.detail.stopping_hotspot": "Stop hotspot.",
+  "settings.update.journey.detail.validating": "Validate update request.",
+  "settings.update.journey_intro": "Update progress details",
+  "settings.update.journey_title": "Update progress",
+  "settings.update.log_empty_title": "No update log yet",
+  "settings.update.log_failed_title": "Update log failed",
+  "settings.update.log_running_title": "Update log running",
+  "settings.update.phase.checking": "Checking",
+  "settings.update.phase.connecting_usb_internet": "Connecting USB internet",
+  "settings.update.phase.connecting_wifi": "Connecting Wi-Fi",
+  "settings.update.phase.done": "Done",
+  "settings.update.phase.downloading": "Downloading",
+  "settings.update.phase.installing": "Installing",
+  "settings.update.phase.restoring_hotspot": "Restoring hotspot",
+  "settings.update.phase.stopping_hotspot": "Stopping hotspot",
+  "settings.update.phase.validating": "Validating",
+  "settings.update.preflight_note_usb":
+    "USB internet will be used for update checks.",
+  "settings.update.readiness.item.connection_usb_ready":
+    "USB internet ready on {interface}.",
+  "settings.update.readiness.item.connection_wifi_ready":
+    "Wi-Fi connection ready.",
+  "settings.update.readiness.item.health_blocked":
+    "Health blocks update start.",
+  "settings.update.readiness.summary_ready": "Ready to update",
+  "settings.update.recovery.title": "Update recovery",
+  "settings.update.recovery.wifi.detail":
+    "Reconnect Wi-Fi or use USB internet.",
+  "settings.update.recovery.wifi.title": "Restore network connection",
+  "settings.update.retry": "Retry update",
+  "settings.update.start": "Start update",
+  "settings.update.transport.selected_badge": "Selected",
+  "settings.update.transport.usb_summary_interface":
+    "USB interface {interface}",
+  "settings.update.transport.usb_summary_unavailable":
+    "USB internet unavailable",
+  "settings.update.transport.wifi_summary": "Use Wi-Fi for the update.",
+};
 
 function requireElement<T extends Element = HTMLElement>(
   root: ParentNode,
@@ -126,8 +222,19 @@ function createFeatureServices(): FeatureServices {
   return {
     requestConfirmation: async () => true,
     showError: () => {},
-    t: (key: string) => key,
+    t: (key: string, vars?: Record<string, unknown>) =>
+      translateMaintenanceTestText(key, vars),
   };
+}
+
+function translateMaintenanceTestText(
+  key: string,
+  vars?: Record<string, unknown>,
+): string {
+  const template = MAINTENANCE_TEST_TRANSLATIONS[key] ?? key;
+  return template.replaceAll(/\{([a-zA-Z0-9_]+)\}/g, (_, name: string) =>
+    String(vars?.[name] ?? ""),
+  );
 }
 
 function createFeatureNavigationHarness(defaultTabId: string) {

--- a/apps/ui/tests/signal_view_reference.spec.ts
+++ b/apps/ui/tests/signal_view_reference.spec.ts
@@ -5,9 +5,9 @@ import {
   computed,
   effect,
   effectOnChange,
+  type ReadonlySignal,
   signal,
   useSignalProperties,
-  type ReadonlySignal,
 } from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewBridge,
@@ -25,9 +25,28 @@ function requireElement<T extends Element = HTMLElement>(
   return element;
 }
 
+function assertElementContainsText(
+  root: ParentNode,
+  selector: string,
+  expected: string,
+): void {
+  const text = requireElement(root, selector).textContent ?? "";
+  assert.ok(
+    text.includes(expected),
+    `Expected ${selector} text ${JSON.stringify(text)} to contain ${JSON.stringify(expected)}`,
+  );
+}
+
+function requireTabButton(root: ParentNode, label: string): HTMLElement {
+  const tab = Array.from(
+    root.querySelectorAll<HTMLElement>('[role="tab"]'),
+  ).find((element) => (element.textContent ?? "").includes(label));
+  assert.ok(tab, `Expected tab labeled ${JSON.stringify(label)}`);
+  return tab;
+}
+
 async function runDirectSignalBindingReferenceTest(): Promise<void> {
   const buttonText = signal("Idle");
-  const variant = signal("muted");
   const disabled = signal(true);
   let renderCount = 0;
 
@@ -39,7 +58,6 @@ async function runDirectSignalBindingReferenceTest(): Promise<void> {
         return h(
           "button",
           {
-            "data-variant": variant,
             disabled,
             id: "signalBindingButton",
             type: "button",
@@ -62,17 +80,14 @@ async function runDirectSignalBindingReferenceTest(): Promise<void> {
     );
     assert.equal(renderCount, 1);
     assert.equal(button.textContent, "Idle");
-    assert.equal(button.getAttribute("data-variant"), "muted");
     assert.equal(button.disabled, true);
 
     buttonText.value = "Running";
-    variant.value = "warn";
     disabled.value = false;
     await harness.flush();
 
     assert.equal(renderCount, 1);
     assert.equal(button.textContent, "Running");
-    assert.equal(button.getAttribute("data-variant"), "warn");
     assert.equal(button.disabled, false);
   } finally {
     harness.cleanup();
@@ -163,16 +178,8 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     harness.view.speedText.value = speedText;
     await harness.flush();
 
-    assert.equal(
-      requireElement(harness.host, "#liveConnectedSensors [data-value]")
-        .textContent,
-      "2 / 4",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveStrongestSignal [data-value]")
-        .textContent,
-      "68 dB",
-    );
+    assertElementContainsText(harness.host, "#liveConnectedSensors", "2 / 4");
+    assertElementContainsText(harness.host, "#liveStrongestSignal", "68 dB");
     assert.equal(requireElement(harness.host, "#speed").textContent, "43 km/h");
     assert.equal(
       requireElement(harness.host, "#liveRunHealth").textContent,
@@ -200,86 +207,30 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
 
     await harness.flush();
 
-    assert.equal(
-      requireElement(harness.host, "#liveConnectedSensors [data-value]")
-        .textContent,
-      "4 / 4",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveRecordingState [data-value]")
-        .textContent,
-      "Recording",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveDataFreshness [data-value]")
-        .textContent,
-      "Live",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveStrongestSignal [data-value]")
-        .textContent,
-      "82 dB",
-    );
+    assertElementContainsText(harness.host, "#liveConnectedSensors", "4 / 4");
+    assertElementContainsText(harness.host, "#liveRecordingState", "Recording");
+    assertElementContainsText(harness.host, "#liveDataFreshness", "Live");
+    assertElementContainsText(harness.host, "#liveStrongestSignal", "82 dB");
     assert.equal(
       requireElement(harness.host, "#liveRunHealth").textContent,
       "Recording",
     );
-    assert.equal(
-      requireElement(harness.host, "#liveRunHealth").getAttribute(
-        "data-variant",
-      ),
-      "warn",
-    );
-    assert.match(
-      requireElement(harness.host, "#liveActiveCar [data-value]").textContent ??
-        "",
-      /Choose a car/,
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveActiveCar [data-value]").getAttribute(
-        "data-variant",
-      ),
-      "warn",
-    );
-    assert.equal(
-      harness.host.querySelectorAll("[data-strongest='true']").length,
-      1,
-    );
+    assertElementContainsText(harness.host, "#liveActiveCar", "Choose a car");
     assert.match(harness.host.textContent ?? "", /Front Left/);
     assert.doesNotMatch(harness.host.textContent ?? "", /No sensors/i);
 
     harness.view.model.value = reboundModel;
     await harness.flush();
 
-    assert.equal(
-      requireElement(harness.host, "#liveConnectedSensors [data-value]")
-        .textContent,
-      "1 / 1",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveRecordingState [data-value]")
-        .textContent,
-      "Paused",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveDataFreshness [data-value]")
-        .textContent,
-      "Buffered",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveStrongestSignal [data-value]")
-        .textContent,
-      "54 dB",
-    );
+    assertElementContainsText(harness.host, "#liveConnectedSensors", "1 / 1");
+    assertElementContainsText(harness.host, "#liveRecordingState", "Paused");
+    assertElementContainsText(harness.host, "#liveDataFreshness", "Buffered");
+    assertElementContainsText(harness.host, "#liveStrongestSignal", "54 dB");
     assert.equal(
       requireElement(harness.host, "#liveRunHealth").textContent,
       "Paused",
     );
-    assert.match(
-      requireElement(harness.host, "#liveActiveCar [data-value]").textContent ??
-        "",
-      /Support Van/,
-    );
+    assertElementContainsText(harness.host, "#liveActiveCar", "Support Van");
     assert.match(harness.host.textContent ?? "", /Rear Right/);
     assert.doesNotMatch(harness.host.textContent ?? "", /Front Left/);
 
@@ -287,31 +238,15 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     strongestSignalText.value = "99 dB";
     await harness.flush();
 
-    assert.equal(
-      requireElement(harness.host, "#liveConnectedSensors [data-value]")
-        .textContent,
-      "1 / 1",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveStrongestSignal [data-value]")
-        .textContent,
-      "54 dB",
-    );
+    assertElementContainsText(harness.host, "#liveConnectedSensors", "1 / 1");
+    assertElementContainsText(harness.host, "#liveStrongestSignal", "54 dB");
 
     reboundConnectedSensorsText.value = "2 / 2";
     reboundStrongestSignalText.value = "61 dB";
     await harness.flush();
 
-    assert.equal(
-      requireElement(harness.host, "#liveConnectedSensors [data-value]")
-        .textContent,
-      "2 / 2",
-    );
-    assert.equal(
-      requireElement(harness.host, "#liveStrongestSignal [data-value]")
-        .textContent,
-      "61 dB",
-    );
+    assertElementContainsText(harness.host, "#liveConnectedSensors", "2 / 2");
+    assertElementContainsText(harness.host, "#liveStrongestSignal", "61 dB");
   } finally {
     harness.cleanup();
   }
@@ -342,11 +277,9 @@ async function runEffectOnChangeReferenceTest(): Promise<void> {
 async function runSignalPropertiesHelperReferenceTest(): Promise<void> {
   const badgeText = signal("Idle");
   const hidden = signal(true);
-  const tone = signal<"muted" | "ok">("muted");
   const model = computed(() => ({
     hidden: hidden.value,
     text: badgeText.value,
-    tone: tone.value,
   }));
   let renderCount = 0;
 
@@ -355,10 +288,9 @@ async function runSignalPropertiesHelperReferenceTest(): Promise<void> {
     return (host) => {
       function SignalPropertiesView() {
         renderCount += 1;
-        const { hidden, text, tone } = useSignalProperties(model, [
+        const { hidden, text } = useSignalProperties(model, [
           "hidden",
           "text",
-          "tone",
         ] as const);
         return h(
           "div",
@@ -366,7 +298,6 @@ async function runSignalPropertiesHelperReferenceTest(): Promise<void> {
           h(
             "span",
             {
-              "data-variant": tone,
               hidden,
               id: "signalPropertiesBadge",
             },
@@ -389,17 +320,14 @@ async function runSignalPropertiesHelperReferenceTest(): Promise<void> {
     );
     assert.equal(renderCount, 1);
     assert.equal(badge.textContent, "Idle");
-    assert.equal(badge.getAttribute("data-variant"), "muted");
     assert.equal(badge.hidden, true);
 
     badgeText.value = "Ready";
     hidden.value = false;
-    tone.value = "ok";
     await harness.flush();
 
     assert.equal(renderCount, 1);
     assert.equal(badge.textContent, "Ready");
-    assert.equal(badge.getAttribute("data-variant"), "ok");
     assert.equal(badge.hidden, false);
   } finally {
     harness.cleanup();
@@ -436,10 +364,7 @@ async function runSettingsShellReferenceTest(): Promise<void> {
     assert.deepEqual(observedTabs, ["analysisTab"]);
     assert.equal(shellView.activeTabId.value, "analysisTab");
     assert.equal(
-      requireElement(
-        harness.host,
-        '[data-settings-tab="analysisTab"]',
-      ).getAttribute("aria-selected"),
+      requireTabButton(harness.host, "Analysis").getAttribute("aria-selected"),
       "true",
     );
     assert.equal(requireElement(harness.host, "#analysisTab").hidden, false);


### PR DESCRIPTION
Closes #3839

What changed:
- Replaced maintenance feature `innerHTML` and untranslated i18n-key assertions with readable rendered-text checks.
- Removed direct assertions against internal stage and transport-card `data-*` markers while keeping action, readiness, recovery, and stage-state coverage.
- Simplified signal reference tests so they verify signal-driven rendered behavior, not internal styling attributes.
- Added small test-only maintenance translations so these specs assert user-facing copy instead of key strings.

Why:
- These tests were pinning implementation markup and selector internals.
- The useful contract is that the UI shows the right state and drives the right actions.

Validation:
- `cd apps/ui && npm run test:unit -- maintenance_feature_signal.spec.ts signal_view_reference.spec.ts`
- `cd apps/ui && npm run typecheck:tests`
- `make ui-typecheck`
- `make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/plan_validation.py --run`

Risks / edges:
- Copy checks now depend on the test translator for these maintenance specs.
- Stage progress is still covered by active/current stage text and completed stage counts, not internal data attributes.

Follow-ups:
- None for this issue.