### PR TITLE
Consolidate CI hygiene test contracts

### DIFF
--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -1,8 +1,10 @@
-"""Guard: workflow-backed CI manifest expands backend shard matrix variants."""
+"""Guard meaningful local-CI manifest contracts without pinning CI topology."""
 
 from __future__ import annotations
 
 import importlib.util
+import re
+import shlex
 import sys
 
 from tests._paths import REPO_ROOT
@@ -19,149 +21,57 @@ def _load_ci_manifest_module():
     return module
 
 
-def test_backend_shard_matrix_expands_to_logical_local_jobs() -> None:
-    module = _load_ci_manifest_module()
-
-    backend_shard_jobs = tuple(
-        job_name for job_name in module.all_job_names() if job_name.startswith("backend-tests")
-    )
-    assert backend_shard_jobs == (
-        "backend-tests-1",
-        "backend-tests-2",
-        "backend-tests-3",
-        "backend-tests-4",
-        "backend-tests-5",
-    )
+def _backend_shard_index(job_name: str) -> int:
+    match = re.fullmatch(r"backend-tests-(\d+)", job_name)
+    assert match is not None, f"unexpected backend shard job name: {job_name}"
+    return int(match.group(1))
 
 
-def test_backend_shard_matrix_preserves_shard_specific_commands() -> None:
-    module = _load_ci_manifest_module()
-
-    job = module.ci_workflow_jobs()["backend-tests-3"]
-    commands = [
-        spec.command
-        for spec in job.local_runnable_steps("python")
-        if spec.label == "Backend tests shard 3/5"
-    ]
-    assert len(commands) == 1
-    assert "env " in commands[0]
-    assert "VIBESENSOR_BACKEND_XDIST_WORKERS=3" in commands[0]
-    assert "VIBESENSOR_BACKEND_SHARD_TIMEOUT_S=780" in commands[0]
-    assert "--shards 5" in commands[0]
-    assert "--shard-index 3" in commands[0]
-    assert "backend-tests-3.xml" in commands[0]
-
-
-def test_backend_quality_jobs_are_split_into_focused_gates() -> None:
-    module = _load_ci_manifest_module()
-
-    job_names = set(module.all_job_names())
-    assert "ci-scope" not in job_names
-    assert "ui-build-artifact" not in job_names
-    assert "backend-quality" not in job_names
-    assert {
-        "backend-lint",
-        "repo-hygiene",
-        "backend-static-guards",
-        "backend-preflight",
-        "docs-lint",
-        "backend-contract-drift",
-    }.issubset(job_names)
-
-
-def test_contributing_docs_reference_focused_backend_ci_gates() -> None:
-    module = _load_ci_manifest_module()
-    job_names = set(module.all_job_names())
-    contributing_text = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
-
-    assert "backend-quality" not in contributing_text
-    focused_gate_names = {
-        "backend-lint",
-        "repo-hygiene",
-        "backend-static-guards",
-        "backend-preflight",
-        "docs-lint",
-        "backend-contract-drift",
-    }
-    assert focused_gate_names.issubset(job_names)
-    for gate_name in focused_gate_names:
-        assert gate_name in contributing_text
-
-
-def test_ci_fast_jobs_are_lint_docs_static_and_typecheck_gates() -> None:
-    module = _load_ci_manifest_module()
-
-    fast_jobs = set(module.ci_fast_job_names())
-
-    assert {
-        "backend-lint",
-        "repo-hygiene",
-        "shell-lint",
-        "backend-static-guards",
-        "backend-preflight",
-        "docs-lint",
-        "backend-contract-drift",
-        "backend-typecheck",
-        "frontend-quality",
-        "frontend-typecheck",
-    } == fast_jobs
-    assert not any(job_name.startswith("backend-tests-") for job_name in fast_jobs)
-    assert {
-        "ui-unit",
-        "ui-smoke",
-        "release-smoke",
-        "firmware-native-tests",
-        "e2e",
-    }.isdisjoint(fast_jobs)
-
-
-def test_ci_lite_jobs_are_non_docker_blocking_jobs_except_e2e() -> None:
-    module = _load_ci_manifest_module()
-
-    lite_jobs = set(module.ci_lite_job_names())
-
-    assert "e2e" not in lite_jobs
-    assert {
-        "backend-tests-1",
-        "backend-tests-2",
-        "backend-tests-3",
-        "backend-tests-4",
-        "backend-tests-5",
-        "ui-smoke",
-        "release-smoke",
-        "firmware-native-tests",
-    }.issubset(lite_jobs)
-
-
-def test_workflow_manifest_preserves_local_job_needs() -> None:
+def test_backend_shard_matrix_expands_to_runnable_logical_local_jobs() -> None:
     module = _load_ci_manifest_module()
 
     jobs = module.ci_workflow_jobs()
+    backend_shard_jobs = sorted(
+        (job_name for job_name in jobs if job_name.startswith("backend-tests-")),
+        key=_backend_shard_index,
+    )
 
-    assert jobs["ui-unit"].needs == ("frontend-typecheck",)
-    assert jobs["ui-smoke"].needs == ("frontend-typecheck",)
-    assert set(jobs["firmware-native-tests"].needs) == {
-        "backend-lint",
-        "repo-hygiene",
-        "backend-static-guards",
-        "backend-preflight",
-        "docs-lint",
-        "backend-contract-drift",
-    }
-    assert set(jobs["release-smoke"].needs) == {
-        "backend-lint",
-        "repo-hygiene",
-        "backend-static-guards",
-        "backend-preflight",
-        "docs-lint",
-        "backend-contract-drift",
-        "backend-typecheck",
-        "frontend-quality",
-        "frontend-typecheck",
-    }
-    assert "ci-scope" not in jobs["release-smoke"].needs
-    assert "ui-build-artifact" not in jobs["release-smoke"].needs
-    assert jobs["release-smoke"].workflow_only_needs == ("ui-build-artifact",)
+    assert backend_shard_jobs, "backend shard matrix did not expand for local runner"
+    assert [_backend_shard_index(job_name) for job_name in backend_shard_jobs] == list(
+        range(1, len(backend_shard_jobs) + 1)
+    )
+    for job_name in backend_shard_jobs:
+        shard_index = _backend_shard_index(job_name)
+        commands = [
+            shlex.split(spec.command)
+            for spec in jobs[job_name].local_runnable_steps("python")
+            if "tools/tests/run_backend_parallel.py" in spec.command
+        ]
+        assert len(commands) == 1
+        command = commands[0]
+        assert "--shards" in command
+        assert command[command.index("--shards") + 1] == str(len(backend_shard_jobs))
+        assert "--shard-index" in command
+        assert command[command.index("--shard-index") + 1] == str(shard_index)
+        assert any(token.endswith(f"backend-tests-{shard_index}.xml") for token in command)
+
+
+def test_manifest_public_job_sets_exclude_workflow_only_and_expensive_fast_jobs() -> None:
+    module = _load_ci_manifest_module()
+
+    all_jobs = set(module.all_job_names())
+    fast_jobs = set(module.ci_fast_job_names())
+    lite_jobs = set(module.ci_lite_job_names())
+
+    assert {"ci-scope", "ui-build-artifact"}.isdisjoint(all_jobs)
+    assert fast_jobs < all_jobs
+    assert lite_jobs < all_jobs
+    assert not any(job_name.startswith("backend-tests-") for job_name in fast_jobs)
+    assert {"ui-unit", "ui-smoke", "release-smoke", "firmware-native-tests", "e2e"}.isdisjoint(
+        fast_jobs
+    )
+    assert "e2e" not in lite_jobs
+    assert any(job_name.startswith("backend-tests-") for job_name in lite_jobs)
 
 
 def test_release_smoke_local_manifest_builds_ui_static_instead_of_downloading_artifact() -> None:
@@ -173,6 +83,7 @@ def test_release_smoke_local_manifest_builds_ui_static_instead_of_downloading_ar
     assert any("tools/tests/run_release_smoke.py" in command for command in runnable_commands)
     assert all("--skip-ui-build" not in command for command in runnable_commands)
     assert all("ui-static.tar.gz" not in command for command in runnable_commands)
+    assert job.workflow_only_needs == ("ui-build-artifact",)
 
 
 def test_skipped_external_actions_are_explicit_and_substituted() -> None:
@@ -206,16 +117,23 @@ def test_common_local_jobs_declare_shared_workspace_write_sets() -> None:
     module = _load_ci_manifest_module()
 
     jobs = module.ci_workflow_jobs()
-    assert set(jobs["frontend-typecheck"].workspace_write_sets) == {"ui-generated-contracts"}
-    assert set(jobs["backend-contract-drift"].workspace_write_sets) == {"ui-generated-contracts"}
-    assert set(jobs["release-smoke"].workspace_write_sets) == {
-        "ui-generated-contracts",
-        "ui-dist",
+    write_sets_by_job = {job_name: set(job.workspace_write_sets) for job_name, job in jobs.items()}
+    jobs_by_write_set: dict[str, set[str]] = {}
+    for job_name, write_sets in write_sets_by_job.items():
+        for write_set in write_sets:
+            jobs_by_write_set.setdefault(write_set, set()).add(job_name)
+
+    assert jobs_by_write_set["ui-generated-contracts"] >= {
+        "frontend-typecheck",
+        "backend-contract-drift",
+        "release-smoke",
+    }
+    assert jobs_by_write_set["ui-test-results"] >= {"ui-unit", "ui-smoke"}
+    assert {
         "server-static",
         "server-dist",
         "release-smoke-artifacts",
-    }
-    assert set(jobs["ui-smoke"].workspace_write_sets) == {"ui-test-results"}
+    }.issubset(write_sets_by_job["release-smoke"])
 
 
 def test_shell_lint_declares_host_shellcheck_prerequisite() -> None:

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -105,25 +105,21 @@ def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path: Path)
     }
 
 
-def test_main_uses_default_single_shard_and_default_workers(monkeypatch, tmp_path: Path) -> None:
+def test_main_builds_pytest_command_for_selected_backend_shard(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     module = _load_run_backend_parallel_module()
     monkeypatch.delenv(module._XDIST_WORKERS_ENV, raising=False)
     captured, emitted = _install_main_fakes(module, monkeypatch, tmp_path)
 
     assert module.main([]) == 0
 
-    assert captured["cmd"] == [
-        sys.executable,
-        "-m",
-        "pytest",
-        "-q",
-        "-n",
-        "3",
-        "--tb=short",
-        "--junitxml",
-        str(tmp_path / "backend-tests-1.xml"),
-        "apps/server/tests/app/test_app_main.py",
-    ]
+    command = captured["cmd"]
+    assert command[:4] == [sys.executable, "-m", "pytest", "-q"]
+    assert command[command.index("-n") + 1] == "3"
+    assert command[command.index("--junitxml") + 1] == str(tmp_path / "backend-tests-1.xml")
+    assert "apps/server/tests/app/test_app_main.py" in command
     assert any("running shard 1/1" in line for line in emitted)
 
 

--- a/apps/server/tests/hygiene/test_workflow_backend_env_cache.py
+++ b/apps/server/tests/hygiene/test_workflow_backend_env_cache.py
@@ -1,4 +1,4 @@
-"""Guard the shared backend CI setup action's installed-environment cache contract."""
+"""Guard the shared backend CI setup action's cache and interpreter contracts."""
 
 from __future__ import annotations
 
@@ -17,91 +17,90 @@ def _load_yaml(path: Path) -> dict[str, object]:
     return loaded
 
 
-def test_setup_backend_caches_repo_virtualenv_with_explicit_invalidation_inputs() -> None:
+def _action_steps() -> list[dict[str, object]]:
+    setup_backend = _load_yaml(_SETUP_BACKEND)
+    steps = setup_backend["runs"]["steps"]
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _named_step(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+    return next(step for step in steps if step.get("name") == name)
+
+
+def _step_by_id(steps: list[dict[str, object]], step_id: str) -> dict[str, object]:
+    return next(step for step in steps if step.get("id") == step_id)
+
+
+def test_setup_backend_exports_repo_virtualenv_python_path() -> None:
     setup_backend = _load_yaml(_SETUP_BACKEND)
 
     outputs = setup_backend["outputs"]
     assert isinstance(outputs, dict)
     assert outputs["python-path"]["value"] == "${{ steps.backend-python.outputs.python-path }}"
 
-    steps = setup_backend["runs"]["steps"]
-    assert isinstance(steps, list)
+    backend_python_run = _step_by_id(_action_steps(), "backend-python")["run"]
+    assert isinstance(backend_python_run, str)
+    assert "${GITHUB_WORKSPACE}/.venv/bin/python" in backend_python_run
+    assert "GITHUB_PATH" in backend_python_run
+    assert "VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv" in backend_python_run
+    assert "python-path=${backend_python}" in backend_python_run
 
-    cache_step = next(
-        step for step in steps if isinstance(step, dict) and step.get("id") == "backend-venv-cache"
-    )
+
+def test_setup_backend_cache_has_explicit_repo_invalidation_without_restore_keys() -> None:
+    steps = _action_steps()
+    cache_step = _step_by_id(steps, "backend-venv-cache")
+
     assert cache_step["uses"] == "actions/cache@v5"
     cache_with = cache_step["with"]
     assert isinstance(cache_with, dict)
     assert cache_with["path"] == ".venv"
+    assert "restore-keys" not in cache_with
+
     cache_key = cache_with["key"]
     assert isinstance(cache_key, str)
     assert "backend-venv" in cache_key
     assert "runner.os" in cache_key
     assert "runner.arch" in cache_key
-    assert ".python-version" in cache_key
-    assert "apps/server/pyproject.toml" in cache_key
-    assert ".github/actions/setup-python/action.yml" in cache_key
-    assert ".github/actions/setup-backend/action.yml" in cache_key
-    assert "restore-keys" not in cache_with
+    for path in (
+        ".python-version",
+        "apps/server/pyproject.toml",
+        ".github/actions/setup-python/action.yml",
+        ".github/actions/setup-backend/action.yml",
+    ):
+        assert path in cache_key
+        assert (REPO_ROOT / path).exists()
 
-    hit_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Report backend virtualenv cache hit"
-    )
+    hit_step = _named_step(steps, "Report backend virtualenv cache hit")
     assert hit_step["if"] == "${{ steps.backend-venv-cache.outputs.cache-hit == 'true' }}"
-
-    miss_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Report backend virtualenv cache miss"
-    )
+    miss_step = _named_step(steps, "Report backend virtualenv cache miss")
     assert miss_step["if"] == "${{ steps.backend-venv-cache.outputs.cache-hit != 'true' }}"
 
-    prepare_retry_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Prepare retry helper"
-    )
-    prepare_retry_run = prepare_retry_step["run"]
+
+def test_setup_backend_rebuilds_cache_misses_with_retry_helper() -> None:
+    steps = _action_steps()
+
+    prepare_retry_run = _named_step(steps, "Prepare retry helper")["run"]
     assert isinstance(prepare_retry_run, str)
     assert prepare_retry_run.count("retry_command()") == 1
-    assert 'cat > "${retry_helper}"' in prepare_retry_run
 
-    install_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Install dependencies"
-    )
+    install_step = _named_step(steps, "Install dependencies")
     assert install_step["if"] == "${{ steps.backend-venv-cache.outputs.cache-hit != 'true' }}"
     install_run = install_step["run"]
     assert isinstance(install_run, str)
     assert 'source "${RUNNER_TEMP}/setup-backend-retry.sh"' in install_run
-    assert "retry_command()" not in install_run
-    assert "rm -rf .venv" in install_run
-    assert '"${{ steps.setup-python.outputs.python-path }}" -m venv .venv' in install_run
-    assert ".venv/bin/python -m pip install --upgrade pip" in install_run
     assert '.venv/bin/python -m pip install -e "./apps/server[dev]"' in install_run
+    assert install_run.index("rm -rf .venv") < install_run.index("pip install -e")
+    assert "retry_command()" not in install_run
 
-    backend_python_step = next(
-        step for step in steps if isinstance(step, dict) and step.get("id") == "backend-python"
-    )
-    backend_python_run = backend_python_step["run"]
-    assert isinstance(backend_python_run, str)
-    assert 'echo "${GITHUB_WORKSPACE}/.venv/bin" >> "${GITHUB_PATH}"' in backend_python_run
-    assert 'echo "VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv" >> "${GITHUB_ENV}"' in backend_python_run
-    assert 'echo "python-path=${backend_python}" >> "${GITHUB_OUTPUT}"' in backend_python_run
 
-    platformio_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Install PlatformIO dependencies"
-    )
+def test_setup_backend_platformio_install_is_opt_in_and_uses_configured_python() -> None:
+    platformio_step = _named_step(_action_steps(), "Install PlatformIO dependencies")
+    assert platformio_step["if"] == "${{ inputs.include-platformio == 'true' }}"
+
     platformio_run = platformio_step["run"]
     assert isinstance(platformio_run, str)
     assert 'source "${RUNNER_TEMP}/setup-backend-retry.sh"' in platformio_run
-    assert "retry_command()" not in platformio_run
     assert (
         'retry_command 3 "${{ steps.backend-python.outputs.python-path }}"'
         ' -m pip install "platformio>=6,<7"' in platformio_run


### PR DESCRIPTION
Closes #3847.

What changed:
- Reworked CI workflow manifest tests around real local-runner contracts.
- Backend shard matrix checks now derive shard count from the manifest instead of pinning five exact jobs.
- Removed exact backend quality/docs/needs topology pins.
- Kept release-smoke artifact substitution, skipped-action substitute, workspace write-set, and host-tool guardrails.
- Split setup-backend cache coverage into focused cache, interpreter, install, and PlatformIO contracts.
- Relaxed backend parallel command assertions to required pytest behavior instead of full argv shape.

Why:
- CI tests should catch broken workflow behavior.
- They should not force many edits for harmless YAML topology changes.

Validation:
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_workflow_backend_env_cache.py apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_run_e2e_parallel.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --job repo-hygiene --job backend-lint --job backend-static-guards --job backend-preflight --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5 --job release-smoke --job e2e`
- Reran `backend-tests-2` after unrelated raw-capture and worker-pool timing flakes; final rerun passed.

Risks:
- Fewer assertions pin exact CI topology. Remaining coverage targets command drift, runnable shard expansion, artifact/cache substitutes, workspace write conflicts, and host prerequisites.

Follow-ups:
- None for this issue.
