### PR TITLE
Consolidate release hygiene contracts

### DIFF
--- a/apps/server/tests/hygiene/test_main_release_workflow.py
+++ b/apps/server/tests/hygiene/test_main_release_workflow.py
@@ -1,4 +1,4 @@
-"""Guard the main release workflow's release-validation paths."""
+"""Guard release workflow safety contracts without pinning step names."""
 
 from __future__ import annotations
 
@@ -12,113 +12,58 @@ _MAIN_RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "main-release.yml
 _WEEKLY_PI_IMAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "weekly-pi-image.yml"
 
 
-def test_main_release_workflow_fetches_full_history_and_validates_release_artifacts() -> None:
-    workflow_path = _MAIN_RELEASE_WORKFLOW
-    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-    release_job = workflow["jobs"]["release"]
-    steps = release_job["steps"]
+def _load_workflow(path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
 
-    checkout_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("uses") == "actions/checkout@v6"
+
+def _job_steps(workflow_path, job_name: str) -> list[dict[str, object]]:
+    workflow = _load_workflow(workflow_path)
+    return [step for step in workflow["jobs"][job_name]["steps"] if isinstance(step, dict)]
+
+
+def _combined_run_script(steps: list[dict[str, object]]) -> str:
+    return "\n".join(str(step.get("run") or "") for step in steps)
+
+
+def _step_index_containing(steps: list[dict[str, object]], text: str) -> int:
+    return next(
+        index
+        for index, step in enumerate(steps)
+        if text in str(step.get("name") or "") or text in str(step.get("run") or "")
     )
+
+
+def test_main_release_workflow_uses_ci_source_and_release_artifact_contracts() -> None:
+    workflow = _load_workflow(_MAIN_RELEASE_WORKFLOW)
+    release_job = workflow["jobs"]["release"]
+    steps = [step for step in release_job["steps"] if isinstance(step, dict)]
+    run_script = _combined_run_script(steps)
+
+    checkout_step = next(step for step in steps if step.get("uses") == "actions/checkout@v6")
     assert checkout_step["with"]["fetch-depth"] == 0
     assert "github.event.workflow_run.head_sha" in checkout_step["with"]["ref"]
+    assert 'echo "sha=$(git rev-parse HEAD)"' in run_script
 
-    source_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Compute release source SHA"
-    )
-    assert source_step["id"] == "release_source"
-    assert "git rev-parse HEAD" in source_step["run"]
+    assert "tools/release/main_release.py compute-version" in run_script
+    assert "tools/release/main_release.py build-wheel" in run_script
+    assert "tools/tests/run_release_smoke.py" in run_script
+    assert "--skip-ui-build" in run_script
+    assert "--wheel-path" in run_script
 
-    compute_version_step = next(
-        step for step in steps if isinstance(step, dict) and step.get("name") == "Compute version"
-    )
-    compute_script = compute_version_step["run"]
-    assert "tools/release/main_release.py compute-version" in compute_script
-
-    build_wheel_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Stamp version and build server wheel"
-    )
-    build_wheel_script = build_wheel_step["run"]
-    assert "tools/release/main_release.py build-wheel" in build_wheel_script
-
-    metadata_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Validate built server wheel metadata"
-    )
-    run_script = metadata_step["run"]
     assert _LIVE_MODULE in run_script
     assert "validate-wheel-metadata" in run_script
     assert "--expected-version" in run_script
-    assert _STALE_MODULE not in run_script
-
-    firmware_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Validate firmware manifest"
-    )
-    run_script = firmware_step["run"]
-    assert _LIVE_MODULE in run_script
     assert "validate-firmware-manifest" in run_script
     assert _STALE_MODULE not in run_script
 
-    manifest_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Generate flash manifest"
-    )
-    manifest_script = manifest_step["run"]
-    assert "tools/release/main_release.py generate-firmware-manifest" in manifest_script
-    assert '--generated-from "${{ steps.release_source.outputs.sha }}"' in manifest_script
-    assert "GITHUB_SHA" not in manifest_script
-
-    release_step_names = {
-        step.get("name")
-        for step in steps
-        if isinstance(step, dict) and isinstance(step.get("name"), str)
-    }
+    assert "tools/release/main_release.py generate-firmware-manifest" in run_script
+    assert '--generated-from "${{ steps.release_source.outputs.sha }}"' in run_script
+    assert "tools/publish_github_release.py" in run_script
+    assert '--target "${{ steps.release_source.outputs.sha }}"' in run_script
+    assert "tools/release/main_release.py cleanup-releases" in run_script
+    assert "WHEEL_ESP_RELEASE_TITLE_PREFIX: Wheel / ESP release" in yaml.safe_dump(release_job)
+    assert "GITHUB_SHA" not in run_script
     assert "publish_wiki" not in workflow["jobs"]
-    assert "Generate wiki screenshots" not in release_step_names
-    assert "Upload wiki screenshot artifact" not in release_step_names
-    assert "Publish GitHub wiki screenshots" not in release_step_names
-
-
-def test_main_release_workflow_labels_and_cleans_only_wheel_esp_releases() -> None:
-    workflow_path = _MAIN_RELEASE_WORKFLOW
-    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-    release_job = workflow["jobs"]["release"]
-    steps = release_job["steps"]
-
-    create_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Create combined Wheel / ESP release"
-    )
-    assert isinstance(create_step["run"], str)
-    assert '--target "${{ steps.release_source.outputs.sha }}"' in create_step["run"]
-    assert "GITHUB_SHA" not in create_step["run"]
-
-    cleanup_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Remove superseded Wheel / ESP releases"
-    )
-    assert cleanup_step["env"]["WHEEL_ESP_RELEASE_TITLE_PREFIX"] == "Wheel / ESP release"
-    assert cleanup_step["env"]["GH_TOKEN"] == "${{ github.token }}"
-    cleanup_script = cleanup_step["run"]
-    assert "tools/release/main_release.py cleanup-releases" in cleanup_script
-    assert "--current-tag" in cleanup_script
-    assert "--release-title-prefix" in cleanup_script
-
-    assert release_job["outputs"]["version"] == "${{ steps.version.outputs.version }}"
-    assert release_job["outputs"]["tag"] == "${{ steps.version.outputs.tag }}"
 
 
 def test_manual_release_workflows_require_main_branch_before_publishing() -> None:
@@ -128,18 +73,9 @@ def test_manual_release_workflows_require_main_branch_before_publishing() -> Non
     )
 
     for workflow_path, job_name, publish_step_name in workflow_cases:
-        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-        steps = workflow["jobs"][job_name]["steps"]
-        guard_index = next(
-            index
-            for index, step in enumerate(steps)
-            if isinstance(step, dict) and step.get("name") == "Validate manual release source"
-        )
-        publish_index = next(
-            index
-            for index, step in enumerate(steps)
-            if isinstance(step, dict) and step.get("name") == publish_step_name
-        )
+        steps = _job_steps(workflow_path, job_name)
+        guard_index = _step_index_containing(steps, "Manual release workflow runs must use")
+        publish_index = _step_index_containing(steps, publish_step_name)
         guard_step = steps[guard_index]
 
         assert guard_index < publish_index

--- a/apps/server/tests/hygiene/test_publish_github_release.py
+++ b/apps/server/tests/hygiene/test_publish_github_release.py
@@ -23,6 +23,11 @@ def _load_publish_github_release_module():
     return module
 
 
+def _option_value(command: list[str], option: str) -> str:
+    assert option in command
+    return command[command.index(option) + 1]
+
+
 def test_existing_release_id_uses_repo_endpoint_without_repo_flag(monkeypatch) -> None:
     module = _load_publish_github_release_module()
     commands: list[list[str]] = []
@@ -55,114 +60,78 @@ def test_existing_release_id_uses_repo_endpoint_without_repo_flag(monkeypatch) -
         )
         == 123
     )
-    assert commands == [["gh", "api", "repos/owner/repo/releases/tags/server-v2026.3.28"]]
+    command = commands[0]
+    assert command[:2] == ["gh", "api"]
+    assert "repos/owner/repo/releases/tags/server-v2026.3.28" in command
+    assert "-R" not in command
     assert timeouts == [12.0]
 
 
-def test_main_creates_release_without_repo_flag_and_uploads_with_repo_flag(
+def test_main_creates_or_updates_release_with_repo_endpoint_and_uploads_assets(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     module = _load_publish_github_release_module()
-    commands: list[list[str]] = []
     notes_file = tmp_path / "notes.md"
     notes_file.write_text("release notes\n", encoding="utf-8")
     asset_file = tmp_path / "artifact.zip"
     asset_file.write_text("artifact", encoding="utf-8")
-
-    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag, *, timeout_s: None)
-
-    def _fake_run(
-        command: list[str],
-        *,
-        check: bool = True,
-        capture_output: bool = False,
-        context: str,
-        timeout_s: float,
-    ):
-        commands.append(list(command))
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(module, "_run", _fake_run)
-
-    module.main(
-        [
-            "--repo",
-            "owner/repo",
-            "--tag",
-            "server-v2026.3.28",
-            "--target",
-            "abc123",
-            "--title",
-            "Release 2026.3.28",
-            "--notes-file",
-            str(notes_file),
-            "--asset",
-            str(asset_file),
-        ]
+    cases = (
+        (None, "POST", "repos/owner/repo/releases"),
+        (77, "PATCH", "repos/owner/repo/releases/77"),
     )
 
-    create_command, upload_command = commands
-    assert create_command[:2] == ["gh", "api"]
-    assert "-R" not in create_command
-    assert "repos/owner/repo/releases" in create_command
-    assert "--method" in create_command
-    assert create_command[create_command.index("--method") + 1] == "POST"
+    for existing_release_id, method, endpoint in cases:
+        commands: list[list[str]] = []
+        monkeypatch.setattr(
+            module,
+            "_existing_release_id",
+            lambda repo, tag, *, timeout_s, release_id=existing_release_id: release_id,
+        )
 
-    assert upload_command[:3] == ["gh", "release", "upload"]
-    assert upload_command[-2:] == ["-R", "owner/repo"]
-    assert str(asset_file) in upload_command
+        def _fake_run(
+            command: list[str],
+            *,
+            check: bool = True,
+            capture_output: bool = False,
+            context: str,
+            timeout_s: float,
+            recorded_commands: list[list[str]] = commands,
+        ):
+            recorded_commands.append(list(command))
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
+        monkeypatch.setattr(module, "_run", _fake_run)
 
-def test_main_updates_existing_release_without_repo_flag(monkeypatch, tmp_path: Path) -> None:
-    module = _load_publish_github_release_module()
-    commands: list[list[str]] = []
-    notes_file = tmp_path / "notes.md"
-    notes_file.write_text("release notes\n", encoding="utf-8")
-    asset_file = tmp_path / "artifact.zip"
-    asset_file.write_text("artifact", encoding="utf-8")
+        module.main(
+            [
+                "--repo",
+                "owner/repo",
+                "--tag",
+                "server-v2026.3.28",
+                "--target",
+                "abc123",
+                "--title",
+                "Release 2026.3.28",
+                "--notes-file",
+                str(notes_file),
+                "--asset",
+                str(asset_file),
+            ]
+        )
 
-    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag, *, timeout_s: 77)
+        release_command, upload_command = commands
+        assert release_command[:2] == ["gh", "api"]
+        assert "-R" not in release_command
+        assert endpoint in release_command
+        assert _option_value(release_command, "--method") == method
+        assert "--input" in release_command
 
-    def _fake_run(
-        command: list[str],
-        *,
-        check: bool = True,
-        capture_output: bool = False,
-        context: str,
-        timeout_s: float,
-    ):
-        commands.append(list(command))
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(module, "_run", _fake_run)
-
-    module.main(
-        [
-            "--repo",
-            "owner/repo",
-            "--tag",
-            "server-v2026.3.28",
-            "--target",
-            "abc123",
-            "--title",
-            "Release 2026.3.28",
-            "--notes-file",
-            str(notes_file),
-            "--asset",
-            str(asset_file),
-        ]
-    )
-
-    update_command, upload_command = commands
-    assert update_command[:2] == ["gh", "api"]
-    assert "-R" not in update_command
-    assert "repos/owner/repo/releases/77" in update_command
-    assert "--method" in update_command
-    assert update_command[update_command.index("--method") + 1] == "PATCH"
-
-    assert upload_command[:3] == ["gh", "release", "upload"]
-    assert upload_command[-2:] == ["-R", "owner/repo"]
+        assert upload_command[:3] == ["gh", "release", "upload"]
+        assert "server-v2026.3.28" in upload_command
+        assert str(asset_file) in upload_command
+        assert "--clobber" in upload_command
+        assert _option_value(upload_command, "-R") == "owner/repo"
 
 
 def test_run_reports_timeout_with_command_context(monkeypatch) -> None:


### PR DESCRIPTION
Closes #3848.

What changed:
- Collapsed main-release workflow YAML checks into release safety contracts.
- Kept coverage for CI source checkout, release source SHA, version/wheel build, release smoke validation, metadata/firmware validation, source SHA target/generated-from, cleanup, and stale module/GITHUB_SHA regressions.
- Kept manual release main-branch guard ordering without pinning the guard step name.
- Merged create/update GitHub release CLI coverage into one intent-level test.
- Relaxed CLI assertions away from full argv ordering while keeping repo endpoint, method, upload asset, clobber, and repo targeting checks.

Why:
- Release tests should fail on broken release behavior.
- They should not churn for harmless step renames or command rearrangement.

Validation:
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_main_release_workflow.py apps/server/tests/hygiene/test_main_release_scripts.py apps/server/tests/hygiene/test_publish_github_release.py apps/server/tests/use_cases/updates/test_run_release_smoke.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --job repo-hygiene --job backend-lint --job backend-static-guards --job backend-preflight --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5 --job release-smoke --job e2e`
- Reran `backend-tests-2` after unrelated raw-capture queue flake; final rerun passed.

Risks:
- Fewer tests pin exact release workflow step names and argument ordering. Remaining checks target release outcomes and safety invariants.

Follow-ups:
- None for this issue.
