### PR TITLE
Refine Pi image guardrail tests

### DIFF
--- a/apps/server/tests/hygiene/test_pi_image_build_action.py
+++ b/apps/server/tests/hygiene/test_pi_image_build_action.py
@@ -7,17 +7,25 @@ import yaml
 from tests._paths import REPO_ROOT
 
 
-def test_build_pi_image_action_reuses_shared_runtime_setup_and_artifact_collection() -> None:
+def _step_by_id(steps: list[dict[str, object]], step_id: str) -> dict[str, object]:
+    return next(step for step in steps if isinstance(step, dict) and step.get("id") == step_id)
+
+
+def _step_by_name(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+    return next(step for step in steps if isinstance(step, dict) and step.get("name") == name)
+
+
+def test_build_pi_image_action_reuses_shared_runtime_and_publishes_image_contract() -> None:
     action_path = REPO_ROOT / ".github" / "actions" / "build-pi-image" / "action.yml"
     action = yaml.safe_load(action_path.read_text(encoding="utf-8"))
 
     inputs = action["inputs"]
-    assert set(inputs) == {
+    assert {
         "release-dir-name",
         "release-artifact-name",
         "workflow-artifact-name",
         "include-published-artifact",
-    }
+    }.issubset(inputs)
     assert inputs["include-published-artifact"]["default"] == "false"
 
     outputs = action["outputs"]
@@ -28,23 +36,14 @@ def test_build_pi_image_action_reuses_shared_runtime_setup_and_artifact_collecti
     )
 
     steps = action["runs"]["steps"]
-    assert steps[0]["uses"] == "actions/setup-node@v6"
-
-    setup_python_step = next(
-        step for step in steps if isinstance(step, dict) and step.get("id") == "setup-python"
-    )
+    setup_python_step = _step_by_id(steps, "setup-python")
     assert setup_python_step["uses"] == "./.github/actions/setup-python"
 
-    build_step = next(
-        step for step in steps if isinstance(step, dict) and step.get("name") == "Build Pi image"
-    )
+    build_step = _step_by_name(steps, "Build Pi image")
     assert build_step["env"]["VS_PYTHON_BIN"] == "${{ steps.setup-python.outputs.python-path }}"
+    assert "./infra/pi-image/pi-gen/build.sh" in build_step["run"]
 
-    collect_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Collect Pi image workflow artifacts"
-    )
+    collect_step = _step_by_id(steps, "assets")
     assert collect_step["id"] == "assets"
     assert collect_step["env"]["VS_RELEASE_DIR_NAME"] == "${{ inputs.release-dir-name }}"
     assert collect_step["env"]["VS_RELEASE_ARTIFACT_NAME"] == "${{ inputs.release-artifact-name }}"
@@ -52,12 +51,14 @@ def test_build_pi_image_action_reuses_shared_runtime_setup_and_artifact_collecti
         collect_step["env"]["VS_INCLUDE_PUBLISHED_ARTIFACT"]
         == "${{ inputs.include-published-artifact }}"
     )
+    collect_run = collect_step["run"]
+    assert '-name "image_*-vibesensor-lite*.zip"' in collect_run
+    assert "sha256sum" in collect_run
+    assert "version_info_source" in collect_run
+    assert "published_artifact=${artifact_name}" in collect_run
 
-    upload_step = next(
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Upload Pi image workflow artifact"
-    )
+    upload_step = _step_by_name(steps, "Upload Pi image workflow artifact")
     assert upload_step["uses"] == "actions/upload-artifact@v7"
     assert upload_step["with"]["name"] == "${{ inputs.workflow-artifact-name }}"
-    assert upload_step["with"]["retention-days"] == 21
+    assert upload_step["with"]["path"] == "${{ steps.assets.outputs.release-dir }}/*"
+    assert upload_step["with"]["if-no-files-found"] == "error"

--- a/apps/server/tests/hygiene/test_pi_image_python_runtime_policy.py
+++ b/apps/server/tests/hygiene/test_pi_image_python_runtime_policy.py
@@ -91,13 +91,33 @@ def test_pi_image_stage_records_runtime_python_metadata_before_cleanup() -> None
     assert text.index(metadata_write) < text.index(cleanup_block)
 
 
-def test_image_validation_reports_and_checks_embedded_python_runtime_metadata() -> None:
-    text = _IMAGE_VALIDATION_SCRIPT.read_text(encoding="utf-8")
+def test_image_validation_reads_embedded_python_runtime_metadata(
+    tmp_path: Path,
+) -> None:
+    metadata = tmp_path / ".vibesensor-python-runtime.env"
+    metadata.write_text(
+        "\n".join(
+            [
+                "system_python=/usr/bin/python3",
+                "system_python_version=3.13.4",
+                "venv_python=/opt/VibeSensor/apps/server/.venv/bin/python",
+                "venv_python_version=3.13.4",
+                "supported_python_floor=3.13",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
-    assert ".vibesensor-python-runtime.env" in text
-    assert "Validation failed: image runtime Python " in text
-    assert "validated_venv_python_version=${VALIDATED_IMAGE_PYTHON_VERSION}" in text
-    assert "validated_supported_python_floor=>=${VALIDATED_IMAGE_PYTHON_FLOOR}" in text
+    result = _run_image_validation_script(f'read_env_file_value "{metadata}" "venv_python_version"')
+    missing_key = _run_image_validation_script(
+        f'read_env_file_value "{metadata}" "missing_key"',
+        check=False,
+    )
+
+    assert result.stdout.strip() == "3.13.4"
+    assert missing_key.returncode == 1
+    assert missing_key.stdout == ""
 
 
 def test_write_version_info_includes_validated_image_python_metadata(tmp_path: Path) -> None:

--- a/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
+++ b/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
@@ -1,71 +1,114 @@
-"""Static guardrails for pi-image layout and packaged entrypoint contracts."""
+"""Deployment contracts for Pi image validation and systemd hardening."""
 
 from __future__ import annotations
+
+import shlex
+import subprocess
+from collections import defaultdict
+from collections.abc import Mapping
+from pathlib import Path
 
 import pytest
 from _paths import REPO_ROOT
 
-
-@pytest.mark.smoke
-def test_pi_gen_pipeline_split_files_exist() -> None:
-    pi_gen_root = REPO_ROOT / "infra" / "pi-image" / "pi-gen"
-
-    assert (pi_gen_root / "validate-image.sh").is_file()
-    assert (pi_gen_root / "lib" / "app_artifacts.sh").is_file()
-    assert (pi_gen_root / "lib" / "stage_assembly.sh").is_file()
-    assert (pi_gen_root / "lib" / "image_validation.sh").is_file()
-    assert (pi_gen_root / "templates" / "stage0-bootstrap-raspberrypi.gpg").is_file()
-    assert (
-        pi_gen_root / "templates" / "stage-vibesensor" / "00-vibesensor" / "00-run.sh.template"
-    ).is_file()
+_IMAGE_VALIDATION_SCRIPT = REPO_ROOT / "infra/pi-image/pi-gen/lib/image_validation.sh"
+_SERVER_SERVICE = REPO_ROOT / "apps/server/systemd/vibesensor.service"
 
 
-@pytest.mark.smoke
-def test_server_systemd_uses_console_script_entrypoint() -> None:
-    service_text = (REPO_ROOT / "apps" / "server" / "systemd" / "vibesensor.service").read_text(
-        encoding="utf-8"
-    )
-
-    assert (
-        "ExecStart=__VENV_DIR__/bin/vibesensor-server --config /etc/vibesensor/config.yaml"
-        in service_text
+def _run_image_validation_script(
+    command: str, *, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            "-lc",
+            f'set -euo pipefail; source "{_IMAGE_VALIDATION_SCRIPT}"; {command}',
+        ],
+        check=check,
+        capture_output=True,
+        text=True,
     )
 
 
-@pytest.mark.smoke
-def test_server_systemd_keeps_steady_state_privileges_narrow() -> None:
-    service_text = (REPO_ROOT / "apps" / "server" / "systemd" / "vibesensor.service").read_text(
-        encoding="utf-8"
-    )
+def _read_systemd_section(unit_path: Path, section_name: str) -> Mapping[str, list[str]]:
+    section: str | None = None
+    values: defaultdict[str, list[str]] = defaultdict(list)
+    for raw_line in unit_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            continue
+        if section == section_name and "=" in line:
+            key, value = line.split("=", 1)
+            values[key].append(value)
+    return values
 
-    assert "AmbientCapabilities=CAP_NET_BIND_SERVICE\n" in service_text
-    assert "CapabilityBoundingSet=CAP_NET_BIND_SERVICE\n" in service_text
-    assert "CAP_SETUID" not in service_text
-    assert "CAP_SETGID" not in service_text
-    assert "CAP_DAC_OVERRIDE" not in service_text
-    assert "CAP_FOWNER" not in service_text
-    assert "CAP_AUDIT_WRITE" not in service_text
-    assert "NoNewPrivileges=true" in service_text
-    assert "PrivateTmp=true" in service_text
-    assert "ProtectSystem=full" in service_text
-    assert "ReadWritePaths=/var/lib/vibesensor /var/log/vibesensor __VENV_DIR__" in service_text
-    assert (
-        "ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ __PI_DIR__"
-        not in service_text
-    )
-    assert (
-        "ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ "
-        "/var/log/vibesensor /var/lib/vibesensor"
-    ) in service_text
-    assert "ExecStartPre=/usr/bin/test -w __VENV_DIR__" in service_text
+
+def _only_value(section: Mapping[str, list[str]], key: str) -> str:
+    values = section[key]
+    assert len(values) == 1
+    return values[0]
 
 
 @pytest.mark.smoke
-def test_pi_image_validation_checks_current_packaged_static_data_layout() -> None:
-    validation_text = (
-        REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "image_validation.sh"
-    ).read_text(encoding="utf-8")
+def test_server_systemd_runs_packaged_server_with_narrow_steady_state_privileges() -> None:
+    service = _read_systemd_section(_SERVER_SERVICE, "Service")
 
-    assert "vehicle_configurations" in validation_text
-    assert "car_sources" in validation_text
-    assert "car_library.json" not in validation_text
+    assert _only_value(service, "User") == "__SERVICE_USER__"
+    assert _only_value(service, "PermissionsStartOnly") == "true"
+    assert _only_value(service, "NoNewPrivileges") == "true"
+    assert _only_value(service, "PrivateTmp") == "true"
+    assert _only_value(service, "ProtectSystem") == "full"
+    assert shlex.split(_only_value(service, "ExecStart")) == [
+        "__VENV_DIR__/bin/vibesensor-server",
+        "--config",
+        "/etc/vibesensor/config.yaml",
+    ]
+    assert set(shlex.split(_only_value(service, "ReadWritePaths"))) == {
+        "/var/lib/vibesensor",
+        "/var/log/vibesensor",
+        "__VENV_DIR__",
+    }
+    assert shlex.split(_only_value(service, "AmbientCapabilities")) == ["CAP_NET_BIND_SERVICE"]
+    assert shlex.split(_only_value(service, "CapabilityBoundingSet")) == ["CAP_NET_BIND_SERVICE"]
+
+    prestart_commands = [shlex.split(value) for value in service["ExecStartPre"]]
+    assert ["/usr/bin/test", "-r", "/etc/vibesensor/config.yaml"] in prestart_commands
+    assert [
+        "/usr/bin/chown",
+        "-R",
+        "__SERVICE_USER__:__SERVICE_USER__",
+        "/var/log/vibesensor",
+        "/var/lib/vibesensor",
+    ] in prestart_commands
+    for writable_path in ("/var/log/vibesensor", "/var/lib/vibesensor", "__VENV_DIR__"):
+        assert ["/usr/bin/test", "-w", writable_path] in prestart_commands
+
+
+@pytest.mark.smoke
+def test_image_validation_accepts_wheel_static_data_and_rejects_source_tree(
+    tmp_path: Path,
+) -> None:
+    rootfs = tmp_path / "rootfs"
+    data_dir = (
+        rootfs / "opt/VibeSensor/apps/server/.venv/lib/python3.13/site-packages/vibesensor/data"
+    )
+    (data_dir / "vehicle_configurations").mkdir(parents=True)
+    (data_dir / "car_sources").mkdir()
+    (data_dir / "report_i18n.json").write_text("{}", encoding="utf-8")
+    (data_dir / "vehicle_configurations/example.json").write_text("{}", encoding="utf-8")
+    (data_dir / "car_sources/example.json").write_text("{}", encoding="utf-8")
+
+    result = _run_image_validation_script(f'assert_wheel_static_data_contract "{rootfs}"')
+    assert result.returncode == 0
+
+    (rootfs / "opt/VibeSensor/apps/server/vibesensor").mkdir()
+    result = _run_image_validation_script(
+        f'assert_wheel_static_data_contract "{rootfs}"',
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "source tree still present" in result.stdout

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -48,6 +48,62 @@ python_version_meets_floor() {
   [ "${actual_minor}" -ge "${floor_minor}" ]
 }
 
+assert_wheel_static_data_contract() {
+  local root_mnt="$1"
+  local venv_site_packages_glob="${root_mnt}/opt/VibeSensor/apps/server/.venv/lib/python*/site-packages/vibesensor/data"
+  local venv_data_dir=""
+  local first_vehicle_shard=""
+  local first_car_source=""
+  local candidate=""
+
+  for candidate in ${venv_site_packages_glob}; do
+    if [ -d "${candidate}" ]; then
+      venv_data_dir="${candidate}"
+      break
+    fi
+  done
+  if [ -z "${venv_data_dir}" ]; then
+    echo "Validation failed: missing site-packages/vibesensor/data directory under ${root_mnt}/opt/VibeSensor/apps/server/.venv"
+    exit 1
+  fi
+
+  if [ ! -f "${venv_data_dir}/report_i18n.json" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/report_i18n.json"
+    exit 1
+  fi
+
+  if [ ! -d "${venv_data_dir}/vehicle_configurations" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/vehicle_configurations"
+    exit 1
+  fi
+
+  first_vehicle_shard="$(
+    find "${venv_data_dir}/vehicle_configurations" -type f -name "*.json" -print -quit
+  )"
+  if [ -z "${first_vehicle_shard}" ]; then
+    echo "Validation failed: no vehicle configuration shards found under ${venv_data_dir}/vehicle_configurations"
+    exit 1
+  fi
+
+  if [ ! -d "${venv_data_dir}/car_sources" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/car_sources"
+    exit 1
+  fi
+
+  first_car_source="$(
+    find "${venv_data_dir}/car_sources" -maxdepth 1 -type f -name "*.json" -print -quit
+  )"
+  if [ -z "${first_car_source}" ]; then
+    echo "Validation failed: no car source packs found under ${venv_data_dir}/car_sources"
+    exit 1
+  fi
+
+  if [ -d "${root_mnt}/opt/VibeSensor/apps/server/vibesensor" ]; then
+    echo "Validation failed: source tree still present at ${root_mnt}/opt/VibeSensor/apps/server/vibesensor"
+    exit 1
+  fi
+}
+
 validate_image_artifact() {
   local FINAL_ARTIFACT="$1"
   local INSPECT_DIR="${OUT_DIR}/inspect"
@@ -246,65 +302,11 @@ validate_image_artifact() {
     exit 1
   fi
 
-  # Static data ships inside the installed `vibesensor` package wheel
-  # (site-packages/vibesensor/data/*). The source tree under
-  # /opt/VibeSensor/apps/server/vibesensor is intentionally removed after install,
-  # so check the wheel-install path instead. `shopt -s nullglob` avoids literal
-  # glob strings when the path is missing; the explicit -f check then fails.
-  local venv_site_packages_glob="${ROOT_MNT}/opt/VibeSensor/apps/server/.venv/lib/python*/site-packages/vibesensor/data"
-  local venv_data_dir=""
-  for candidate in ${venv_site_packages_glob}; do
-    if [ -d "${candidate}" ]; then
-      venv_data_dir="${candidate}"
-      break
-    fi
-  done
-  if [ -z "${venv_data_dir}" ]; then
-    echo "Validation failed: missing site-packages/vibesensor/data directory under ${ROOT_MNT}/opt/VibeSensor/apps/server/.venv"
-    exit 1
-  fi
-
-  if [ ! -f "${venv_data_dir}/report_i18n.json" ]; then
-    echo "Validation failed: missing ${venv_data_dir}/report_i18n.json"
-    exit 1
-  fi
-
-  if [ ! -d "${venv_data_dir}/vehicle_configurations" ]; then
-    echo "Validation failed: missing ${venv_data_dir}/vehicle_configurations"
-    exit 1
-  fi
-
-  local first_vehicle_shard=""
-  first_vehicle_shard="$(
-    find "${venv_data_dir}/vehicle_configurations" -type f -name "*.json" -print -quit
-  )"
-  if [ -z "${first_vehicle_shard}" ]; then
-    echo "Validation failed: no vehicle configuration shards found under ${venv_data_dir}/vehicle_configurations"
-    exit 1
-  fi
-
-  if [ ! -d "${venv_data_dir}/car_sources" ]; then
-    echo "Validation failed: missing ${venv_data_dir}/car_sources"
-    exit 1
-  fi
-
-  local first_car_source=""
-  first_car_source="$(
-    find "${venv_data_dir}/car_sources" -maxdepth 1 -type f -name "*.json" -print -quit
-  )"
-  if [ -z "${first_car_source}" ]; then
-    echo "Validation failed: no car source packs found under ${venv_data_dir}/car_sources"
-    exit 1
-  fi
+  assert_wheel_static_data_contract "${ROOT_MNT}"
 
   ROOTFS_PYPROJECT="${ROOT_MNT}/opt/VibeSensor/apps/server/pyproject.toml"
   if [ ! -f "${ROOTFS_PYPROJECT}" ]; then
     echo "Validation failed: missing ${ROOTFS_PYPROJECT}"
-    exit 1
-  fi
-
-  if [ -d "${ROOT_MNT}/opt/VibeSensor/apps/server/vibesensor" ]; then
-    echo "Validation failed: source tree still present at ${ROOT_MNT}/opt/VibeSensor/apps/server/vibesensor"
     exit 1
   fi
 

--- a/tools/dev/test_marker_policy_allowlist.yml
+++ b/tools/dev/test_marker_policy_allowlist.yml
@@ -4,10 +4,8 @@ smoke:
     test_server_pyproject_includes_esp_flash_and_firmware_cache_entrypoints: Offline install CLIs stay in the compact install path.
     test_firmware_uses_pinned_registry_neopixel_library: Firmware dependency provenance stays in the compact install path.
   apps/server/tests/hygiene/test_pi_image_static_guardrails.py:
-    test_pi_gen_pipeline_split_files_exist: Pi-image pipeline layout stays in the compact image guard path.
-    test_server_systemd_uses_console_script_entrypoint: Packaged server startup wiring stays in the compact image guard path.
-    test_server_systemd_keeps_steady_state_privileges_narrow: Packaged service hardening stays in the compact image guard path.
-    test_pi_image_validation_checks_current_packaged_static_data_layout: Pi-image validation stays in the compact static-data guard path.
+    test_server_systemd_runs_packaged_server_with_narrow_steady_state_privileges: Packaged startup and service hardening stay in the compact image guard path.
+    test_image_validation_accepts_wheel_static_data_and_rejects_source_tree: Pi-image validation keeps runtime static data in the wheel install path.
   apps/server/tests/integration/test_contract_analysis_persistence_http.py:
     __module__: The persistence-to-HTTP bridge stays in the compact contract smoke lane.
   apps/server/tests/integration/test_contract_analysis_report.py:


### PR DESCRIPTION
## What changed
- Replaced Pi systemd substring guardrails with parsed service-property contracts.
- Extracted wheel static-data validation into a runnable image validation helper and test it with a fake rootfs.
- Relaxed Pi image action/runtime metadata checks toward deployment behavior instead of exact text layout.
- Updated smoke marker allowlist for the new compact critical-path tests.

## Why
#3849 asks to keep deployment safety coverage while reducing broad Pi image and systemd static string pinning.

## Validation
- `pytest -q apps/server/tests/hygiene/test_pi_image_static_guardrails.py apps/server/tests/hygiene/test_pi_image_python_runtime_policy.py apps/server/tests/hygiene/test_pi_image_build_action.py apps/server/tests/hygiene/test_pi_gen_artifact_selection.py apps/server/tests/hygiene/test_install_pi_runtime_policy.py`
- `pytest -q apps/server/tests/hygiene/`
- `ruff format ... && ruff check ...`
- `git diff --check`
- `make lint`
- `make typecheck-backend`
- `make plan-validation`
- `tools/tests/run_ci_parallel.py --job repo-hygiene --job shell-lint --job backend-lint --job backend-static-guards --job backend-preflight --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5 --job release-smoke --job e2e` (backend-tests-3 hit known raw-capture queue-full flake, rerun passed)

## Risks, tradeoffs, edge cases
- The service test still asserts exact security-relevant systemd properties and writable paths.
- Static data validation now shares the production helper path, so failures point at runtime-image contracts instead of test-only greps.
- Full Pi image build was not run; change is validation-script/test-focused and covered by shell-lint plus local CI.