### PR TITLE
Test cleanup: reduce WebSocket payload shape pinning

### DIFF
--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.shared.types.payload_types import (
     SCHEMA_VERSION,
@@ -64,60 +66,43 @@ class _StubPayloadSource:
         return self._payloads[index]
 
 
-def test_build_ws_payload_preserves_shared_payload_and_explicit_selection() -> None:
-    payload_source = _StubPayloadSource(
-        [_shared_payload(clients=[_client_row("aaaaaaaaaaaa", "front-left")])]
-    )
+@pytest.mark.parametrize(
+    ("clients", "selected_client", "expected_selected"),
+    [
+        pytest.param(
+            [_client_row("aaaaaaaaaaaa", "front-left")],
+            "aaaaaaaaaaaa",
+            "aaaaaaaaaaaa",
+            id="explicit-selection",
+        ),
+        pytest.param(
+            [
+                _client_row("aaaaaaaaaaaa", "front-left"),
+                _client_row("bbbbbbbbbbbb", "rear-right"),
+            ],
+            None,
+            "aaaaaaaaaaaa",
+            id="auto-selects-first-client",
+        ),
+        pytest.param([], None, None, id="no-clients"),
+    ],
+)
+def test_build_ws_payload_resolves_selected_client_per_shared_payload(
+    clients: list[ClientApiRow],
+    selected_client: str | None,
+    expected_selected: str | None,
+) -> None:
+    payload_source = _StubPayloadSource([_shared_payload(clients=clients)])
     ws_broadcast = WsBroadcastService(
         ui_push_hz=10,
         ui_heavy_push_hz=4,
         payload_source=payload_source,
     )
 
-    payload = ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
+    payload = ws_broadcast.build_payload(selected_client=selected_client)
 
-    assert payload["schema_version"] == SCHEMA_VERSION
-    assert payload["server_time"] == "2026-04-05T00:00:00Z"
-    assert payload["speed_mps"] == 12.5
-    assert payload["clients"][0]["id"] == "aaaaaaaaaaaa"
-    assert payload["selected_client_id"] == "aaaaaaaaaaaa"
-    assert payload["rotational_speeds"]["basis_speed_source"] == "gps"
-    assert "spectra" in payload
-
-
-def test_build_ws_payload_auto_selects_first_client() -> None:
-    payload_source = _StubPayloadSource(
-        [
-            _shared_payload(
-                clients=[
-                    _client_row("aaaaaaaaaaaa", "front-left"),
-                    _client_row("bbbbbbbbbbbb", "rear-right"),
-                ]
-            )
-        ]
-    )
-    ws_broadcast = WsBroadcastService(
-        ui_push_hz=10,
-        ui_heavy_push_hz=4,
-        payload_source=payload_source,
-    )
-
-    payload = ws_broadcast.build_payload(selected_client=None)
-
-    assert payload["selected_client_id"] == "aaaaaaaaaaaa"
-
-
-def test_build_ws_payload_no_clients_keeps_selection_empty() -> None:
-    ws_broadcast = WsBroadcastService(
-        ui_push_hz=10,
-        ui_heavy_push_hz=4,
-        payload_source=_StubPayloadSource([_shared_payload(clients=[])]),
-    )
-
-    payload = ws_broadcast.build_payload(selected_client=None)
-
-    assert payload["clients"] == []
-    assert payload["selected_client_id"] is None
+    assert payload["clients"] == clients
+    assert payload["selected_client_id"] == expected_selected
 
 
 def test_build_ws_payload_reuses_shared_payload_per_tick() -> None:

--- a/apps/server/tests/adapters/websocket/test_ws_models.py
+++ b/apps/server/tests/adapters/websocket/test_ws_models.py
@@ -1,4 +1,4 @@
-"""Tests for WS schema export and payload optimization (freq deduplication)."""
+"""WebSocket payload projection behavior not covered by generated schema drift checks."""
 
 from __future__ import annotations
 
@@ -7,109 +7,8 @@ import json
 import numpy as np
 import pytest
 
-from vibesensor.cli.ws_schema_export import export_schema
 from vibesensor.infra.processing import ClientBuffer, SignalProcessor
-from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
-from vibesensor.shared.types.payload_types import SCHEMA_VERSION, LiveWsPayload
 from vibesensor.vibration_strength import empty_vibration_strength_metrics
-
-# ---------------------------------------------------------------------------
-# Schema export check
-# ---------------------------------------------------------------------------
-
-
-def test_schema_export_check_passes() -> None:
-    """Verify the exported schema exposes the live WS contract shape consumers use."""
-    generated = export_schema()
-    parsed = json.loads(generated)
-    assert parsed["title"] == "LiveWsPayload"
-    assert parsed["type"] == "object"
-
-    properties = parsed["properties"]
-    assert set(properties) == {
-        "schema_version",
-        "server_time",
-        "speed_mps",
-        "clients",
-        "selected_client_id",
-        "rotational_speeds",
-        "spectra",
-    }
-    assert set(parsed["required"]) == {
-        "schema_version",
-        "server_time",
-        "speed_mps",
-        "clients",
-        "selected_client_id",
-        "rotational_speeds",
-    }
-    assert properties["spectra"] == {"$ref": "#/$defs/SpectraPayload"}
-    assert properties["rotational_speeds"]["anyOf"] == [
-        {"$ref": "#/$defs/RotationalSpeedsPayload"},
-        {"type": "null"},
-    ]
-
-    rotational_speeds = parsed["$defs"]["RotationalSpeedsPayload"]
-    assert set(rotational_speeds["required"]) == {
-        "basis_speed_source",
-        "wheel",
-        "driveshaft",
-        "engine",
-        "order_bands",
-    }
-
-    spectra = parsed["$defs"]["SpectraPayload"]
-    assert set(spectra["properties"]) == {
-        "alignment",
-        "clients",
-        "frame_fingerprint",
-        "freq",
-        "warning",
-    }
-
-
-# ---------------------------------------------------------------------------
-# build_ws_payload includes schema_version
-# ---------------------------------------------------------------------------
-
-
-class _StubPayloadSource:
-    def build_shared_payload(self, *, include_heavy: bool) -> LiveWsPayload:
-        payload: LiveWsPayload = {
-            "schema_version": SCHEMA_VERSION,
-            "server_time": "2026-04-05T00:00:00Z",
-            "speed_mps": None,
-            "clients": [],
-            "selected_client_id": None,
-            "rotational_speeds": {
-                "basis_speed_source": None,
-                "wheel": {"rpm": None, "mode": None, "reason": None},
-                "driveshaft": {"rpm": None, "mode": None, "reason": None},
-                "engine": {"rpm": None, "mode": None, "reason": None},
-                "order_bands": None,
-            },
-        }
-        if include_heavy:
-            payload["spectra"] = {"freq": [], "clients": {}}
-        return payload
-
-
-def test_build_ws_payload_includes_schema_version() -> None:
-    ws_broadcast = WsBroadcastService(
-        ui_push_hz=10,
-        ui_heavy_push_hz=4,
-        payload_source=_StubPayloadSource(),
-    )
-
-    payload = ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
-
-    assert "schema_version" in payload
-    assert payload["schema_version"] == SCHEMA_VERSION
-
-
-# ---------------------------------------------------------------------------
-# multi_spectrum_payload – freq deduplication
-# ---------------------------------------------------------------------------
 
 
 class TestMultiSpectrumFreqDedup:

--- a/apps/server/tests/adapters/websocket/test_ws_schema_export.py
+++ b/apps/server/tests/adapters/websocket/test_ws_schema_export.py
@@ -75,25 +75,3 @@ def test_export_schema_matches_committed_schema(schema_text: str) -> None:
         "Committed ws_payload_schema.json is out of sync with generated schema. "
         "Run `make sync-contracts` and commit the results."
     )
-
-
-def test_export_schema_has_schema_version(schema_dict: dict[str, object]) -> None:
-    """The schema must include the schema_version field."""
-    props = schema_dict.get("properties", {})
-    assert "schema_version" in props, "schema_version must be a top-level property"
-
-
-def test_export_schema_requires_always_present_top_level_fields(
-    schema_dict: dict[str, object],
-) -> None:
-    """Always-emitted WS payload fields must be required in the schema."""
-    required = set(schema_dict.get("required", []))
-    assert required == {
-        "schema_version",
-        "server_time",
-        "speed_mps",
-        "clients",
-        "selected_client_id",
-        "rotational_speeds",
-    }
-    assert "spectra" not in required

--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -4,18 +4,18 @@
  * Validates:
  *  1. adaptServerPayload uses shared top-level freq when per-client freq is absent
  *  2. adaptServerPayload prefers per-client freq when present (mismatch case)
- *  3. adaptServerPayload rejects payloads that omit required top-level fields
+ *  3. adaptServerPayload rejects missing schema version and warns on mismatches
  *  4. EXPECTED_SCHEMA_VERSION matches the server's current version
  */
 
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { adaptServerPayload } from "../src/server_payload";
 import {
   EXPECTED_SCHEMA_VERSION,
   type StrengthMetricsPayload,
   type WsClientInfo,
 } from "../src/contracts/ws_payload_types";
 import type { components as HttpComponents } from "../src/generated/http_api_contracts";
+import { adaptServerPayload } from "../src/server_payload";
 
 // Compile-time guard: if `frame_samples` ever regresses to optional in either
 // generated contract, this file fails `tsc` before runtime tests run. Keeps
@@ -136,48 +136,6 @@ describe("schema_version handling", () => {
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("rejects invalid field types via runtime validation", () => {
-    expectInvalidPayload({
-      ...basePayload,
-      speed_mps: "10",
-    });
-  });
-
-  test("rejects client rows that omit required frame_samples", () => {
-    expectInvalidPayload({
-      ...basePayload,
-      clients: [
-        {
-          id: "sensor1",
-          name: "Front Left",
-          connected: true,
-          mac_address: "001122334455",
-          location_code: "front_left_wheel",
-          last_seen_age_ms: 5,
-          dropped_frames: 0,
-          frames_total: 100,
-          sample_rate_hz: 1600,
-          firmware_version: "fw-1.0.0",
-        },
-      ],
-    });
-  });
-
-  test("rejects partial strength_metrics instead of defaulting missing fields", () => {
-    expectInvalidPayload({
-      ...basePayload,
-      spectra: {
-        freq: [10, 20, 30],
-        clients: {
-          sensor1: {
-            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: { vibration_strength_db: 12 },
-          },
-        },
-      },
-    });
-  });
-
   test("EXPECTED_SCHEMA_VERSION is string '1'", () => {
     expect(EXPECTED_SCHEMA_VERSION).toBe("1");
   });
@@ -277,23 +235,6 @@ describe("shared freq optimization", () => {
     expect(Object.keys(spectra.clients)).toHaveLength(0);
   });
 
-  test("rejects malformed per-client freq elements instead of skipping the client", () => {
-    expectInvalidPayload({
-      ...basePayload,
-      spectra: {
-        clients: {
-          sensor1: {
-            freq: [10, "bad", 30],
-            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({
-              vibration_strength_db: 12,
-            }),
-          },
-        },
-      },
-    });
-  });
-
   test("skips client when freq and amplitude bin counts differ", () => {
     const adapted = adaptServerPayload({
       ...basePayload,
@@ -338,35 +279,6 @@ describe("shared freq optimization", () => {
     expect(spectra.clients.sensor1.freq).toEqual([10, 20, 30]);
     // sensor2 uses its own per-client freq
     expect(spectra.clients.sensor2.freq).toEqual([15, 25, 35]);
-  });
-
-  test("rejects malformed strength metric peaks instead of dropping them", () => {
-    expectInvalidPayload({
-      ...basePayload,
-      spectra: {
-        freq: [10, 20, 30],
-        clients: {
-          sensor1: {
-            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: {
-              vibration_strength_db: 12,
-              peak_amp_g: 0.2,
-              noise_floor_amp_g: 0.01,
-              strength_bucket: null,
-              top_peaks: [
-                {
-                  hz: 10,
-                  amp: 0.1,
-                  vibration_strength_db: 12,
-                  strength_bucket: "l2",
-                },
-                { hz: 20, amp: 0.2 },
-              ],
-            },
-          },
-        },
-      },
-    });
   });
 
   test("reuses validated client and rotational speed references in hot path", () => {

--- a/apps/ui/tests/ws_payload_validator.spec.ts
+++ b/apps/ui/tests/ws_payload_validator.spec.ts
@@ -85,93 +85,78 @@ function makeRepresentativePayload(): LiveWsPayload {
   };
 }
 
-function requiredFields(schema: {
-  required?: readonly string[];
-}): readonly string[] {
-  return schema.required ?? [];
-}
-
 type RepresentativePayload = ReturnType<typeof makeRepresentativePayload>;
-type DriftBranch = {
+type RequiredFieldCase = {
   label: string;
   pathPrefix: string;
-  required: readonly string[];
+  schemaRequired: readonly string[] | undefined;
+  field: string;
   getTarget: (payload: RepresentativePayload) => Record<string, unknown>;
 };
 
-const driftBranches: readonly DriftBranch[] = [
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Expected ${label} record`);
+  }
+  return value as Record<string, unknown>;
+}
+
+const requiredFieldCases: readonly RequiredFieldCase[] = [
   {
     label: "live payload",
     pathPrefix: "",
-    required: requiredFields(wsPayloadSchema),
+    schemaRequired: wsPayloadSchema.required,
+    field: "schema_version",
     getTarget: (payload) => payload as unknown as Record<string, unknown>,
   },
   {
     label: "client row",
     pathPrefix: "/clients/0",
-    required: requiredFields(wsPayloadSchema.$defs.ClientApiRow),
+    schemaRequired: wsPayloadSchema.$defs.ClientApiRow.required,
+    field: "frame_samples",
     getTarget: (payload) =>
       payload.clients[0] as unknown as Record<string, unknown>,
   },
   {
-    label: "rotational speeds",
-    pathPrefix: "/rotational_speeds",
-    required: requiredFields(wsPayloadSchema.$defs.RotationalSpeedsPayload),
-    getTarget: (payload) =>
-      payload.rotational_speeds as unknown as Record<string, unknown>,
-  },
-  {
     label: "rotational speed value",
     pathPrefix: "/rotational_speeds/wheel",
-    required: requiredFields(wsPayloadSchema.$defs.RotationalSpeedValuePayload),
+    schemaRequired: wsPayloadSchema.$defs.RotationalSpeedValuePayload.required,
+    field: "rpm",
     getTarget: (payload) =>
-      payload.rotational_speeds!.wheel as unknown as Record<string, unknown>,
-  },
-  {
-    label: "order band",
-    pathPrefix: "/rotational_speeds/order_bands/0",
-    required: requiredFields(wsPayloadSchema.$defs.OrderBandPayload),
-    getTarget: (payload) =>
-      payload.rotational_speeds!.order_bands![0] as unknown as Record<
-        string,
-        unknown
-      >,
-  },
-  {
-    label: "warning",
-    pathPrefix: "/spectra/warning",
-    required: requiredFields(wsPayloadSchema.$defs.FrequencyWarningPayload),
-    getTarget: (payload) =>
-      payload.spectra!.warning as unknown as Record<string, unknown>,
+      requireRecord(payload.rotational_speeds?.wheel, "rotational speed value"),
   },
   {
     label: "alignment",
     pathPrefix: "/spectra/alignment",
-    required: requiredFields(wsPayloadSchema.$defs.AlignmentInfoPayload),
+    schemaRequired: wsPayloadSchema.$defs.AlignmentInfoPayload.required,
+    field: "clock_synced",
     getTarget: (payload) =>
-      payload.spectra!.alignment as unknown as Record<string, unknown>,
+      requireRecord(payload.spectra?.alignment, "alignment"),
   },
   {
     label: "strength metrics",
     pathPrefix: "/spectra/clients/sensor-1/strength_metrics",
-    required: requiredFields(wsPayloadSchema.$defs.VibrationStrengthMetrics),
+    schemaRequired: wsPayloadSchema.$defs.VibrationStrengthMetrics.required,
+    field: "vibration_strength_db",
     getTarget: (payload) =>
-      payload.spectra!.clients!["sensor-1"]
-        .strength_metrics as unknown as Record<string, unknown>,
+      requireRecord(
+        payload.spectra?.clients?.["sensor-1"]?.strength_metrics,
+        "strength metrics",
+      ),
   },
   {
     label: "strength peak",
     pathPrefix: "/spectra/clients/sensor-1/strength_metrics/top_peaks/0",
-    required: requiredFields(wsPayloadSchema.$defs.StrengthPeak),
+    schemaRequired: wsPayloadSchema.$defs.StrengthPeak.required,
+    field: "amp",
     getTarget: (payload) =>
-      payload.spectra!.clients!["sensor-1"]!.strength_metrics!
-        .top_peaks![0]! as unknown as Record<string, unknown>,
+      requireRecord(
+        payload.spectra?.clients?.["sensor-1"]?.strength_metrics
+          ?.top_peaks?.[0],
+        "strength peak",
+      ),
   },
 ];
-
-const requiredFieldCases = driftBranches.flatMap((branch) =>
-  branch.required.map((field) => ({ ...branch, field })),
-);
 
 describe("validateLiveWsPayload", () => {
   test("accepts a schema-valid payload", () => {
@@ -301,11 +286,13 @@ describe("validateLiveWsPayload", () => {
 
   test.each(
     requiredFieldCases,
-  )("rejects missing schema-derived required $field in $label", ({
+  )("rejects representative missing required $field in $label", ({
     field,
     getTarget,
     pathPrefix,
+    schemaRequired,
   }) => {
+    expect(schemaRequired).toContain(field);
     const payload = structuredClone(makeRepresentativePayload());
     delete getTarget(payload)[field];
     expect(() => validateLiveWsPayload(payload)).toThrow(


### PR DESCRIPTION
## What changed
- Removed backend WS schema field-list tests covered by committed schema drift.
- Removed duplicate WS model schema/build-shape pins.
- Consolidated broadcaster selected-client behavior into one table.
- Trimmed UI adapter tests that duplicated runtime validator shape checks.
- Reduced validator required-field coverage to representative schema-derived branches.

## Why
- Issue #3854 calls out repeated payload key/schema assertions across backend and UI tests.
- This keeps one clear contract path for schema drift and focused behavior tests for selection, caching, shared-frequency adaptation, and malformed payload rejection.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/websocket/test_ws_schema_export.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_payload_orchestrator.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/infra/runtime/test_ws_payload_projection.py`
- `cd apps/ui && npm run test:unit -- ws_contract.spec.ts ws_payload_validator.spec.ts`
- Touched ruff/Biome checks
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make ui-typecheck`
- `cd apps/ui && npm run typecheck:tests`
- `PATH="$PWD/.venv/bin:$PATH" make plan-validation`
- Planned local CI via `tools/tests/run_ci_parallel.py`

## Risks and tradeoffs
- Less exact key-list pinning in tests by design.
- Contract drift remains covered by generated schema checks and frontend validation.
- One initial planned local CI backend shard hit the known raw-capture queue-full flake; rerun passed.

Closes #3854