### PR TITLE
Reduce buffer/cache internal mechanics test pinning

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py
@@ -30,27 +30,11 @@ def _seed_cached_payload(store: SignalBufferStore, client_id: str) -> None:
     with store.locked_client_buffer(client_id, create=True) as buf:
         assert buf is not None
         buf.cached_spectrum_payload = {"freq": [1.0, 2.0]}
-        buf.cached_spectrum_payload_generation = 5
 
 
-def test_flush_client_buffer_invalidates_cached_payloads() -> None:
+def test_ingest_and_flush_invalidate_cached_payloads() -> None:
     store = SignalBufferStore(_config())
-    client_id = "sensor-flush"
-
-    store.ingest(client_id, np.ones((16, 3), dtype=np.float32), sample_rate_hz=200)
-    _seed_cached_payload(store, client_id)
-
-    store.flush_client_buffer(client_id)
-
-    with store.locked_client_buffer(client_id) as buf:
-        assert buf is not None
-        assert buf.cached_spectrum_payload is None
-        assert buf.cached_spectrum_payload_generation == -1
-
-
-def test_ingest_invalidates_cached_payloads() -> None:
-    store = SignalBufferStore(_config())
-    client_id = "sensor-ingest"
+    client_id = "sensor-cache"
 
     store.ingest(client_id, np.ones((16, 3), dtype=np.float32), sample_rate_hz=200)
     _seed_cached_payload(store, client_id)
@@ -60,7 +44,13 @@ def test_ingest_invalidates_cached_payloads() -> None:
     with store.locked_client_buffer(client_id) as buf:
         assert buf is not None
         assert buf.cached_spectrum_payload is None
-        assert buf.cached_spectrum_payload_generation == -1
+
+    _seed_cached_payload(store, client_id)
+    store.flush_client_buffer(client_id)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.cached_spectrum_payload is None
 
 
 def test_store_metrics_result_invalidates_cached_payloads() -> None:
@@ -90,4 +80,3 @@ def test_store_metrics_result_invalidates_cached_payloads() -> None:
     with store.locked_client_buffer(client_id) as buf:
         assert buf is not None
         assert buf.cached_spectrum_payload is None
-        assert buf.cached_spectrum_payload_generation == -1

--- a/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
@@ -7,7 +7,7 @@ import numpy as np
 from vibesensor.infra.processing.buffer_capacity import MAX_CLIENT_SAMPLE_RATE_HZ
 from vibesensor.infra.processing.buffer_store import SignalBufferStore
 from vibesensor.infra.processing.compute import SignalMetricsComputer
-from vibesensor.infra.processing.models import CachedMetricsHit, MetricsSnapshot, ProcessorConfig
+from vibesensor.infra.processing.models import MetricsSnapshot, ProcessorConfig
 
 
 def _config(**overrides: object) -> ProcessorConfig:
@@ -62,13 +62,11 @@ def test_stale_result_is_rejected_after_buffer_eviction_and_recreation() -> None
 
     with store.locked_client_buffer(client_id) as buf:
         assert buf is not None
-        assert buf.buffer_epoch == recreated_epoch
         assert buf.latest_metrics == {}
-        assert buf.compute_generation == -1
 
     next_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
     assert isinstance(next_plan, MetricsSnapshot)
-    assert not isinstance(next_plan, CachedMetricsHit)
+    assert next_plan.buffer_epoch == recreated_epoch
 
 
 def test_sample_rate_change_forces_fresh_snapshot_before_reusing_cache() -> None:
@@ -84,14 +82,11 @@ def test_sample_rate_change_forces_fresh_snapshot_before_reusing_cache() -> None
     assert isinstance(first_plan, MetricsSnapshot)
     store.store_metrics_result(computer.compute(first_plan))
 
-    cached_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
-    assert isinstance(cached_plan, CachedMetricsHit)
-
     changed_rate_plan = store.snapshot_for_compute(client_id, sample_rate_hz=400)
     assert isinstance(changed_rate_plan, MetricsSnapshot)
     assert changed_rate_plan.sample_rate_hz == 400
 
-    store.store_metrics_result(computer.compute(changed_rate_plan))
+    changed_result = computer.compute(changed_rate_plan)
+    store.store_metrics_result(changed_result)
 
-    refreshed_cached_plan = store.snapshot_for_compute(client_id, sample_rate_hz=400)
-    assert isinstance(refreshed_cached_plan, CachedMetricsHit)
+    assert store.latest_metrics(client_id) == changed_result.metrics

--- a/apps/server/tests/infra/processing/test_buffer_store_reset_generation.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_reset_generation.py
@@ -41,8 +41,6 @@ def test_flush_rejects_pre_reset_inflight_result() -> None:
         assert buf is not None
         assert buf.count == 0
         assert buf.latest_metrics == {}
-        assert buf.compute_generation == -1
-        assert buf.reset_generation == stale_plan.reset_generation + 1
 
 
 def test_post_reset_result_commits_after_new_ingest() -> None:
@@ -70,8 +68,6 @@ def test_post_reset_result_commits_after_new_ingest() -> None:
 
     with store.locked_client_buffer(client_id) as buf:
         assert buf is not None
-        assert buf.reset_generation == fresh_plan.reset_generation
-        assert buf.compute_generation == fresh_result.ingest_generation
         assert buf.latest_metrics == fresh_result.metrics
 
 
@@ -102,6 +98,4 @@ def test_repeated_resets_keep_older_results_rejected() -> None:
     with store.locked_client_buffer(client_id) as buf:
         assert buf is not None
         assert buf.count == 0
-        assert buf.reset_generation == second_plan.reset_generation + 1
         assert buf.latest_metrics == {}
-        assert buf.compute_generation == -1

--- a/apps/server/tests/infra/processing/test_buffers_repr_and_fastpath.py
+++ b/apps/server/tests/infra/processing/test_buffers_repr_and_fastpath.py
@@ -1,12 +1,4 @@
-"""Unit tests for ClientBuffer.__repr__ and invalidate_caches fast-path.
-
-The existing test_processing_buffers.py covers creation, normal cache
-invalidation, and slot existence.  These tests fill the remaining gaps:
-
-- __repr__: must be compact and must NOT dump raw numpy array data
-- invalidate_caches fast-path: when both caches are already None, the
-  method must return early without touching the generation counters
-"""
+"""Focused ClientBuffer debug and cache-invalidation behavior."""
 
 from __future__ import annotations
 
@@ -20,57 +12,25 @@ def _make_buf(capacity: int = 64) -> ClientBuffer:
     return ClientBuffer(data=data, capacity=capacity)
 
 
-class TestClientBufferRepr:
-    """__repr__ should be compact and not embed the raw ndarray."""
+def test_repr_is_compact_and_omits_raw_sample_data() -> None:
+    buf = _make_buf(capacity=512)
+    buf.data[0, :] = 1.23
 
-    def test_repr_is_a_string(self) -> None:
-        buf = _make_buf()
-        assert isinstance(repr(buf), str)
+    rendered = repr(buf)
 
-    def test_repr_contains_capacity(self) -> None:
-        buf = _make_buf(capacity=512)
-        assert "512" in repr(buf)
-
-    def test_repr_does_not_contain_array_data(self) -> None:
-        """Embedding the numpy array would make repr unusably large."""
-        buf = _make_buf(capacity=100)
-        buf.data[0, :] = 1.23  # fill with non-zero so naive repr would show data
-        r = repr(buf)
-        # A raw ndarray repr contains the dtype keyword; our compact repr must not
-        assert "dtype" not in r, "repr must not embed raw ndarray data"
-
-    def test_repr_includes_generation_counters(self) -> None:
-        buf = _make_buf()
-        buf.ingest_generation = 7
-        buf.compute_generation = 5
-        r = repr(buf)
-        assert "igen=7" in r
-        assert "cgen=5" in r
+    assert "capacity=512" in rendered
+    assert "dtype" not in rendered
+    assert len(rendered) < 200
 
 
 class TestInvalidateCachesFastPath:
     """When caches are already None, invalidate_caches must be a no-op."""
 
-    def test_no_op_when_caches_already_clear(self) -> None:
-        """Called on a fresh buffer (caches are None) must not raise or mutate
-        the generation fields.
-        """
-        buf = _make_buf()
-        # Confirm caches are already None
-        assert buf.cached_spectrum_payload is None
-
-        before_gen = buf.cached_spectrum_payload_generation
-        buf.invalidate_caches()
-        # The fast-path return must NOT reset the generation counter to -1
-        # again (it's already -1 — we just verify no side effects occurred
-        # beyond what the initial state established).
-        assert buf.cached_spectrum_payload_generation == before_gen
-
-    def test_idempotent_double_call(self) -> None:
-        """Calling invalidate_caches twice in a row must not raise."""
+    def test_cache_invalidation_is_idempotent(self) -> None:
         buf = _make_buf()
         buf.cached_spectrum_payload = {"combined_spectrum_amp_g": [1.0]}
+
         buf.invalidate_caches()
-        # Second call triggers the fast-path
         buf.invalidate_caches()
+
         assert buf.cached_spectrum_payload is None

--- a/apps/server/tests/infra/processing/test_snapshot_builder.py
+++ b/apps/server/tests/infra/processing/test_snapshot_builder.py
@@ -1,11 +1,11 @@
-"""Tests for snapshot_builder: cache-hit decisions and window-size computation."""
+"""Tests for snapshot window sizing."""
 
 from __future__ import annotations
 
-from vibesensor.infra.processing.models import CachedMetricsHit
+import pytest
+
 from vibesensor.infra.processing.snapshot_builder import (
     SnapshotWindow,
-    check_cache_hit,
     compute_snapshot_window,
 )
 
@@ -22,112 +22,41 @@ def _snapshot_window(**overrides: int) -> SnapshotWindow:
     return compute_snapshot_window(**{**_DEFAULT_WINDOW_KWARGS, **overrides})
 
 
-class TestCheckCacheHit:
-    """Cover snapshot-builder cache-hit eligibility based on generations and sample rate."""
-
-    def test_cache_hit_when_generations_and_rate_match(self) -> None:
-        metrics = {"rms_x": 0.5}
-        result = check_cache_hit(
-            ingest_generation=3,
-            compute_generation=3,
-            compute_sample_rate_hz=200,
-            effective_sample_rate_hz=200,
-            latest_metrics=metrics,
-        )
-        assert isinstance(result, CachedMetricsHit)
-        assert result.metrics is metrics
-
-    def test_cache_miss_when_generation_differs(self) -> None:
-        result = check_cache_hit(
-            ingest_generation=4,
-            compute_generation=3,
-            compute_sample_rate_hz=200,
-            effective_sample_rate_hz=200,
-            latest_metrics={"rms_x": 0.5},
-        )
-        assert result is None
-
-    def test_cache_miss_when_sample_rate_differs(self) -> None:
-        result = check_cache_hit(
-            ingest_generation=3,
-            compute_generation=3,
-            compute_sample_rate_hz=200,
-            effective_sample_rate_hz=500,
-            latest_metrics={"rms_x": 0.5},
-        )
-        assert result is None
-
-    def test_cache_miss_when_never_computed(self) -> None:
-        result = check_cache_hit(
-            ingest_generation=0,
-            compute_generation=-1,
-            compute_sample_rate_hz=0,
-            effective_sample_rate_hz=200,
-            latest_metrics={},
-        )
-        assert result is None
-
-    def test_cache_hit_with_empty_metrics(self) -> None:
-        result = check_cache_hit(
-            ingest_generation=1,
-            compute_generation=1,
-            compute_sample_rate_hz=100,
-            effective_sample_rate_hz=100,
-            latest_metrics={},
-        )
-        assert isinstance(result, CachedMetricsHit)
-        assert result.metrics == {}
-
-
 class TestComputeSnapshotWindow:
     """Exercise snapshot-window sizing and whether a separate FFT block is needed."""
 
-    def test_basic_window_smaller_than_count(self) -> None:
-        result = _snapshot_window()
-        assert result == SnapshotWindow(n_time=400, needs_separate_fft_block=False)
-
-    def test_count_limits_window(self) -> None:
-        result = _snapshot_window(count=50)
-        assert result.n_time == 50
-
-    def test_capacity_limits_window(self) -> None:
-        result = _snapshot_window(count=500, capacity=100)
-        assert result.n_time == 100
-
-    def test_needs_separate_fft_block_when_n_time_smaller(self) -> None:
-        # count >= fft_n and n_time < fft_n → needs separate fft block
-        result = _snapshot_window(
-            count=512,
-            capacity=512,
-            sample_rate_hz=100,
-            waveform_seconds=1,
-        )
-        assert result.n_time == 100
-        assert result.needs_separate_fft_block is True
-
-    def test_separate_fft_block_true_when_small_window_large_count(self) -> None:
-        # count >= fft_n but n_time < fft_n → needs separate fft block
-        result = _snapshot_window(
-            count=512,
-            capacity=512,
-            sample_rate_hz=10,
-        )
-        assert result.n_time == 20
-        assert result.needs_separate_fft_block is True
-
-    def test_no_separate_fft_block_when_n_time_ge_fft_n(self) -> None:
-        result = _snapshot_window(capacity=1000)
-        assert result.n_time == 400
-        assert result.needs_separate_fft_block is False
-
-    def test_no_separate_fft_block_when_count_lt_fft_n(self) -> None:
-        result = _snapshot_window(
-            count=100,
-            capacity=1000,
-            sample_rate_hz=10,
-        )
-        assert result.n_time == 20
-        assert result.needs_separate_fft_block is False
+    @pytest.mark.parametrize(
+        ("overrides", "expected"),
+        [
+            pytest.param({}, SnapshotWindow(400, False), id="default-time-window"),
+            pytest.param({"count": 50}, SnapshotWindow(50, False), id="count-limits-window"),
+            pytest.param(
+                {"count": 500, "capacity": 100},
+                SnapshotWindow(100, True),
+                id="capacity-limits-window-and-requires-fft",
+            ),
+            pytest.param(
+                {"count": 512, "capacity": 512, "sample_rate_hz": 100, "waveform_seconds": 1},
+                SnapshotWindow(100, True),
+                id="separate-fft-for-small-time-window",
+            ),
+            pytest.param(
+                {"count": 512, "capacity": 512, "sample_rate_hz": 10},
+                SnapshotWindow(20, True),
+                id="separate-fft-for-low-rate-large-count",
+            ),
+            pytest.param(
+                {"capacity": 1000}, SnapshotWindow(400, False), id="time-window-covers-fft"
+            ),
+            pytest.param(
+                {"count": 100, "capacity": 1000, "sample_rate_hz": 10},
+                SnapshotWindow(20, False),
+                id="small-count-skips-separate-fft",
+            ),
+        ],
+    )
+    def test_window_contract(self, overrides: dict[str, int], expected: SnapshotWindow) -> None:
+        assert _snapshot_window(**overrides) == expected
 
     def test_minimum_window_is_one(self) -> None:
         result = _snapshot_window(


### PR DESCRIPTION
## What changed
- Collapsed buffer repr/cache invalidation tests around compact repr and idempotent cache clearing.
- Removed assertions on generation counter names, cached payload generation values, reset/compute counters, and `CachedMetricsHit` helper classes.
- Kept behavior coverage for stale result rejection, sample-rate refresh, reset/flush lifecycle, payload cache invalidation, and snapshot-window sizing.

## Why
- The old tests made buffer/cache refactors pay for private implementation details instead of public processing behavior.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/infra/processing/test_buffers_repr_and_fastpath.py apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py apps/server/tests/infra/processing/test_buffer_store_reset_generation.py apps/server/tests/infra/processing/test_payload_builders.py apps/server/tests/infra/processing/test_snapshot_builder.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/infra/processing`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --job repo-hygiene --job backend-lint --job backend-static-guards --job backend-preflight --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5 --job release-smoke --job e2e` (backend-tests-3 hit known raw-capture queue-full flake; rerun passed)

## Risks / tradeoffs
- Less direct coverage of private cache-hit classes and counters. Behavior coverage remains around stale cache rejection and fresh metrics after lifecycle changes.

## Follow-ups
- None.