### PR TITLE
Reduce startup bootstrap shape test pinning

### DIFF
--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -135,19 +135,10 @@ def test_main_reload_uses_factory_target(monkeypatch, tmp_path) -> None:
 
     _run_with_restored_root_logging(app_module.main)
 
-    assert calls == [
-        (
-            "vibesensor.app.bootstrap:create_app_from_env",
-            {
-                "address": "127.0.0.1",
-                "port": 8000,
-                "interface": "asgi",
-                "log_enabled": True,
-                "log_level": "info",
-                "loop": "uvloop",
-                "reload": True,
-                "factory": True,
-            },
-        ),
-    ]
+    target, kwargs = calls[0]
+    assert target == "vibesensor.app.bootstrap:create_app_from_env"
+    assert kwargs["address"] == "127.0.0.1"
+    assert kwargs["port"] == 8000
+    assert kwargs["reload"] is True
+    assert kwargs["factory"] is True
     assert os.environ[app_module._CONFIG_PATH_ENV] == str(config_path.resolve())

--- a/apps/server/tests/app/test_granian_runtime.py
+++ b/apps/server/tests/app/test_granian_runtime.py
@@ -69,39 +69,14 @@ def _run_main_for_platform(monkeypatch, *, platform: str) -> dict[str, object]:
     return recorded
 
 
-def test_main_uses_uvloop_on_linux(monkeypatch) -> None:
-    recorded = _run_main_for_platform(monkeypatch, platform="linux")
+def test_main_uses_platform_appropriate_granian_loop(monkeypatch) -> None:
+    cases = [("linux", Loops.uvloop), ("darwin", Loops.asyncio)]
 
-    assert recorded == {
-        "args": ("vibesensor.app.bootstrap:create_app_from_env",),
-        "kwargs": {
-            "address": "127.0.0.1",
-            "port": 8000,
-            "interface": Interfaces.ASGI,
-            "log_enabled": True,
-            "log_level": LogLevels.info,
-            "loop": Loops.uvloop,
-            "reload": False,
-            "factory": True,
-        },
-        "served": True,
-    }
+    for platform, expected_loop in cases:
+        recorded = _run_main_for_platform(monkeypatch, platform=platform)
 
-
-def test_main_uses_asyncio_off_linux(monkeypatch) -> None:
-    recorded = _run_main_for_platform(monkeypatch, platform="darwin")
-
-    assert recorded == {
-        "args": ("vibesensor.app.bootstrap:create_app_from_env",),
-        "kwargs": {
-            "address": "127.0.0.1",
-            "port": 8000,
-            "interface": Interfaces.ASGI,
-            "log_enabled": True,
-            "log_level": LogLevels.info,
-            "loop": Loops.asyncio,
-            "reload": False,
-            "factory": True,
-        },
-        "served": True,
-    }
+        assert recorded["args"] == ("vibesensor.app.bootstrap:create_app_from_env",)
+        assert recorded["kwargs"]["interface"] == Interfaces.ASGI
+        assert recorded["kwargs"]["log_level"] == LogLevels.info
+        assert recorded["kwargs"]["loop"] == expected_loop
+        assert recorded["served"] is True

--- a/apps/server/tests/app/test_import_purity.py
+++ b/apps/server/tests/app/test_import_purity.py
@@ -1,4 +1,4 @@
-"""Import-purity guardrails for the app package and bootstrap module."""
+"""Import-purity smoke coverage for app startup entrypoints."""
 
 from __future__ import annotations
 
@@ -53,45 +53,16 @@ def _run_import_probe(import_code: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_importing_app_package_exposes_startup_entrypoints() -> None:
+def test_importing_startup_entrypoints_is_side_effect_free() -> None:
     result = _run_import_probe(
         """
 import importlib
 
-module = importlib.import_module("vibesensor.app")
-assert module.__name__ == "vibesensor.app"
-assert callable(module.create_app)
-assert callable(module.create_app_from_env)
-assert callable(module.main)
-assert not hasattr(module, "app")
-        """
-    )
-    assert result.stdout.strip() == "ok"
-
-
-def test_importing_bootstrap_does_not_construct_runtime() -> None:
-    result = _run_import_probe(
-        """
-import importlib
-
+package = importlib.import_module("vibesensor.app")
 bootstrap = importlib.import_module("vibesensor.app.bootstrap")
-assert callable(bootstrap.create_app)
-assert callable(bootstrap.create_app_from_env)
-assert callable(bootstrap.main)
-assert not hasattr(bootstrap, "app")
-        """
-    )
-    assert result.stdout.strip() == "ok"
-
-
-def test_importing_create_app_from_package_is_side_effect_free() -> None:
-    result = _run_import_probe(
-        """
 from vibesensor.app import create_app, create_app_from_env, main
 
-assert callable(create_app)
-assert callable(create_app_from_env)
-assert callable(main)
+_ = (package, bootstrap, create_app, create_app_from_env, main)
         """
     )
     assert result.stdout.strip() == "ok"

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -100,21 +100,23 @@ describe("UiStartupCoordinator", () => {
     installWindowGlobal();
   });
 
-  test("runs startup and background activity in the expected order", () => {
+  test("starts the shell, background startup tasks, and transport", () => {
     const restoreLocation = installLocation("");
     const harness = createCoordinatorHarness();
 
     try {
       harness.coordinator.start();
 
-      expect(harness.calls).toEqual([
-        "shell.start:dashboardView",
-        "shell.hydratePersistedPreferences",
-        "realtime.refreshLocationOptions",
-        "realtime.refreshLoggingStatus",
-        "dashboard.hydrateStartupState",
-        "transport.startTransportMode",
-      ]);
+      expect(harness.calls[0]).toBe("shell.start:dashboardView");
+      expect(harness.calls.at(-1)).toBe("transport.startTransportMode");
+      expect(harness.calls).toEqual(
+        expect.arrayContaining([
+          "shell.hydratePersistedPreferences",
+          "realtime.refreshLocationOptions",
+          "realtime.refreshLoggingStatus",
+          "dashboard.hydrateStartupState",
+        ]),
+      );
     } finally {
       restoreLocation();
     }


### PR DESCRIPTION
## What changed
- Collapsed backend app import-purity tests into one side-effect-free startup-entrypoint import smoke.
- Relaxed exact Granian/reload kwargs assertions to startup behavior that matters: target, host/port, reload/factory, platform loop, ASGI interface, and serve call.
- Relaxed UI startup coordinator ordering checks to shell/background/transport behavior instead of exact full call choreography.

## Why
- The old tests pinned bootstrap module shape and exact wiring details that are already covered by type checks, lifecycle tests, and startup smoke behavior.

## Validation
- `./.venv/bin/ruff format apps/server/tests/app/test_import_purity.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_granian_runtime.py`
- `./.venv/bin/ruff check apps/server/tests/app/test_import_purity.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_granian_runtime.py`
- `cd apps/ui && npx biome format tests/ui_startup_coordinator.spec.ts --write`
- `cd apps/ui && npx biome lint tests/ui_startup_coordinator.spec.ts`
- `./.venv/bin/python -m pytest -q apps/server/tests/app/test_import_purity.py apps/server/tests/app/test_app_composition.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_granian_runtime.py apps/server/tests/app/test_runtime_state.py`
- `cd apps/ui && npm run test:unit -- start_ui_app.spec.ts ui_startup_coordinator.spec.ts`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `make ui-typecheck`
- `cd apps/ui && npm run typecheck:tests`
- `PATH="$PWD/.venv/bin:$PATH" make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --job repo-hygiene --job backend-lint --job backend-static-guards --job backend-preflight --job backend-contract-drift --job backend-typecheck --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5 --job release-smoke --job e2e`

## Risks / tradeoffs
- Less direct protection for exact export/callable shapes and full Granian kwargs. Remaining tests keep import-purity, startup target, reload/factory behavior, platform loop choice, lifecycle, and route-composition smoke coverage.

## Follow-ups
- None.