### PR TITLE
Consolidate UI async lifecycle tests

### DIFF
--- a/apps/ui/tests/async_test_helpers.ts
+++ b/apps/ui/tests/async_test_helpers.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 export type TimerHarness = {
   pendingDelays(): number[];
   restore(): void;
@@ -72,4 +74,34 @@ export async function flushAsyncWork(rounds = 12): Promise<void> {
 
 export async function flushSignalUpdates(rounds = 12): Promise<void> {
   await flushAsyncWork(rounds);
+}
+
+export async function resolveAfterDisposal<T>(options: {
+  dispose(): void;
+  resolve(value: T): void;
+  start(): Promise<unknown>;
+  value: T;
+}): Promise<void> {
+  const pending = options.start();
+  await flushAsyncWork();
+  options.dispose();
+  options.resolve(options.value);
+  await pending;
+  await flushAsyncWork();
+}
+
+export async function expectSingleInFlightOperation<T>(options: {
+  callCount(): number;
+  resolve(value: T): void;
+  start(): Promise<unknown>;
+  value: T;
+}): Promise<void> {
+  const first = options.start();
+  const second = options.start();
+  await flushAsyncWork();
+
+  expect(options.callCount()).toBe(1);
+  options.resolve(options.value);
+  await Promise.all([first, second]);
+  await flushAsyncWork();
 }

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -8,7 +8,11 @@ import type {
   AnalysisPanelRenderModel,
   AnalysisPanelView,
 } from "../src/app/views/analysis_panel";
-import { installWindowGlobal } from "./async_test_helpers";
+import {
+  createDeferred,
+  flushAsyncWork,
+  installWindowGlobal,
+} from "./async_test_helpers";
 import {
   buildAnalysisSettingsHandlers,
   makeAnalysisSettingsPayload,
@@ -252,61 +256,6 @@ test("settings analysis module ignores loaded settings after disposal", async ()
   expect(refreshSpectrumDecorationCalls).toBe(0);
 });
 
-test("settings analysis module ignores saved settings after disposal", async () => {
-  const state = createAppState().settings;
-  const save = createDeferred<ReturnType<typeof makeAnalysisSettingsPayload>>();
-  let refreshSpectrumDecorationCalls = 0;
-  mswServer.use(
-    ...buildAnalysisSettingsHandlers({
-      save: () => save.promise,
-    }),
-  );
-  const module = createAnalysisModuleHarness(state, {
-    refreshSpectrumDecorations: () => {
-      refreshSpectrumDecorationCalls += 1;
-    },
-  });
-
-  const saving = module.saveAnalysisFromInputs();
-  module.dispose();
-  save.resolve(makeAnalysisSettingsPayload({ wheel_bandwidth_pct: 9 }));
-  await saving;
-
-  expect(state.analysis.vehicleSettings.value.wheel_bandwidth_pct).toBe(5);
-  expect(refreshSpectrumDecorationCalls).toBe(0);
-});
-
-test("settings analysis module ignores repeated saves while one is in flight", async () => {
-  const state = createAppState().settings;
-  const save = createDeferred<ReturnType<typeof makeAnalysisSettingsPayload>>();
-  let saveCalls = 0;
-  let refreshSpectrumDecorationCalls = 0;
-  mswServer.use(
-    ...buildAnalysisSettingsHandlers({
-      save: () => {
-        saveCalls += 1;
-        return save.promise;
-      },
-    }),
-  );
-  const module = createAnalysisModuleHarness(state, {
-    refreshSpectrumDecorations: () => {
-      refreshSpectrumDecorationCalls += 1;
-    },
-  });
-
-  const firstSave = module.saveAnalysisFromInputs();
-  const secondSave = module.saveAnalysisFromInputs();
-  await flushAsyncWork();
-
-  expect(saveCalls).toBe(1);
-  save.resolve(makeAnalysisSettingsPayload({ wheel_bandwidth_pct: 9 }));
-  await Promise.all([firstSave, secondSave]);
-
-  expect(state.analysis.vehicleSettings.value.wheel_bandwidth_pct).toBe(9);
-  expect(refreshSpectrumDecorationCalls).toBe(1);
-});
-
 test("settings analysis module ignores repeated reset confirmations while one is in flight", async () => {
   const state = createAppState().settings;
   const confirmation = createDeferred<boolean>();
@@ -364,30 +313,6 @@ test("settings analysis module ignores reset confirmation after disposal", async
 
   expect(saveCalls).toBe(0);
 });
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  reject(reason?: unknown): void;
-  resolve(value: T): void;
-};
-
-function createDeferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, reject, resolve };
-}
-
-async function flushAsyncWork(rounds = 6): Promise<void> {
-  for (let index = 0; index < rounds; index += 1) {
-    await new Promise<void>((resolve) => {
-      setImmediate(() => resolve());
-    });
-  }
-}
 
 type AnalysisModuleHarnessOptions = {
   refreshSpectrumDecorations?: () => void;

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -10,6 +10,11 @@ import type {
 } from "../src/api/types";
 import { createAppState } from "../src/app/ui_app_state";
 import { effect, signal, type Signal } from "../src/app/ui_signals";
+import {
+  createDeferred as deferred,
+  expectSingleInFlightOperation,
+  resolveAfterDisposal,
+} from "./async_test_helpers";
 import { createTestQueryClient } from "./query_client_test_support";
 
 type WorkflowHarness = {
@@ -82,20 +87,6 @@ function makeObdDevice(
     trusted: false,
     ...overrides,
   };
-}
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  reject: (reason: unknown) => void;
-  resolve: (value: T) => void;
-} {
-  let resolve: (value: T) => void = () => {};
-  let reject: (reason: unknown) => void = () => {};
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-  return { promise, reject, resolve };
 }
 
 describe("createSettingsSpeedSourceWorkflow", () => {
@@ -434,92 +425,22 @@ describe("createSettingsSpeedSourceWorkflow", () => {
 
     workflow.handleSpeedSourceChanged("manual");
     workflow.handleManualSpeedInput("77");
-    const saving = workflow.saveSpeedSource();
-    workflow.dispose();
-    save.resolve(
-      makeSpeedSourcePayload({
+    await resolveAfterDisposal({
+      dispose: () => {
+        workflow.dispose();
+      },
+      resolve: save.resolve,
+      start: () => workflow.saveSpeedSource(),
+      value: makeSpeedSourcePayload({
         manual_speed_kph: 77,
         speed_source: "manual",
         stale_timeout_s: 5,
       }),
-    );
-    await saving;
+    });
 
     expect(appState.settings.speed.source.value).toBe("gps");
     expect(appState.settings.speed.manualSpeedKph.value).toBeNull();
     expect(workflow.getRenderState().saveFeedback).toBeNull();
-    expect(harness.errors).toEqual([]);
-  });
-
-  test("ignores scan results that resolve after disposal", async () => {
-    const harness = createHarness();
-    const appState = createAppState();
-    const scan = deferred<{ devices: ObdDevicePayload[] }>();
-    const workflow = createSettingsSpeedSourceWorkflow({
-      obdConfigVisible: harness.obdConfigVisible,
-      queryClient: createTestQueryClient(),
-      settings: appState.settings,
-      showError: (message) => {
-        harness.errors.push(message);
-      },
-      t: createTranslator(),
-      transport: {
-        scanObdDevices: () => scan.promise,
-      },
-      view: createViewPorts(harness),
-    });
-
-    const scanning = workflow.scanObdDevices();
-    workflow.dispose();
-    scan.resolve({ devices: [makeObdDevice()] });
-    await scanning;
-
-    expect(workflow.getRenderState().scannedDevices).toEqual([]);
-    expect(workflow.getRenderState().obdScanStatusMessage).toBe(
-      "settings.speed.obd_scanning",
-    );
-    expect(harness.errors).toEqual([]);
-  });
-
-  test("ignores pair results that resolve after disposal", async () => {
-    const harness = createHarness();
-    const appState = createAppState();
-    const pair = deferred<{
-      configured_device_mac: string;
-      configured_device_name: string | null;
-      connected: boolean;
-      paired: boolean;
-      rfcomm_channel: number | null;
-      trusted: boolean;
-    }>();
-    const workflow = createSettingsSpeedSourceWorkflow({
-      obdConfigVisible: harness.obdConfigVisible,
-      queryClient: createTestQueryClient(),
-      settings: appState.settings,
-      showError: (message) => {
-        harness.errors.push(message);
-      },
-      t: createTranslator(),
-      transport: {
-        pairObdDevice: () => pair.promise,
-      },
-      view: createViewPorts(harness),
-    });
-
-    const pairing = workflow.pairObdDevice("00:22:d9:00:1b:b1");
-    workflow.dispose();
-    pair.resolve({
-      configured_device_mac: "00:22:d9:00:1b:b1",
-      configured_device_name: "OBDLink CX",
-      connected: true,
-      paired: true,
-      rfcomm_channel: 1,
-      trusted: true,
-    });
-    await pairing;
-
-    expect(appState.settings.speed.obdDeviceMac.value).toBeNull();
-    expect(workflow.getRenderState().scannedDevices).toEqual([]);
     expect(harness.errors).toEqual([]);
   });
 
@@ -548,8 +469,16 @@ describe("createSettingsSpeedSourceWorkflow", () => {
     workflow.handleSpeedSourceChanged("manual");
     workflow.handleManualSpeedInput("88");
     workflow.handleStaleTimeoutInput("5");
-    const firstSave = workflow.saveSpeedSource();
-    const secondSave = workflow.saveSpeedSource();
+    await expectSingleInFlightOperation({
+      callCount: () => savedPayloads.length,
+      resolve: save.resolve,
+      start: () => workflow.saveSpeedSource(),
+      value: makeSpeedSourcePayload({
+        manual_speed_kph: 88,
+        speed_source: "manual",
+        stale_timeout_s: 5,
+      }),
+    });
 
     expect(savedPayloads).toEqual([
       {
@@ -558,68 +487,9 @@ describe("createSettingsSpeedSourceWorkflow", () => {
         stale_timeout_s: 5,
       },
     ]);
-    save.resolve(
-      makeSpeedSourcePayload({
-        manual_speed_kph: 88,
-        speed_source: "manual",
-        stale_timeout_s: 5,
-      }),
-    );
-    await Promise.all([firstSave, secondSave]);
 
     expect(appState.settings.speed.source.value).toBe("manual");
     expect(appState.settings.speed.manualSpeedKph.value).toBe(88);
-    expect(harness.errors).toEqual([]);
-    workflow.dispose();
-  });
-
-  test("ignores repeated pair clicks while pairing is in flight", async () => {
-    const harness = createHarness();
-    const appState = createAppState();
-    const pair = deferred<{
-      configured_device_mac: string;
-      configured_device_name: string | null;
-      connected: boolean;
-      paired: boolean;
-      rfcomm_channel: number | null;
-      trusted: boolean;
-    }>();
-    const pairedMacs: string[] = [];
-    const workflow = createSettingsSpeedSourceWorkflow({
-      obdConfigVisible: harness.obdConfigVisible,
-      queryClient: createTestQueryClient(),
-      settings: appState.settings,
-      showError: (message) => {
-        harness.errors.push(message);
-      },
-      t: createTranslator(),
-      transport: {
-        pairObdDevice(macAddress) {
-          pairedMacs.push(macAddress);
-          return pair.promise;
-        },
-      },
-      view: createViewPorts(harness),
-    });
-
-    const firstPair = workflow.pairObdDevice("00:22:d9:00:1b:b1");
-    const secondPair = workflow.pairObdDevice("00:22:d9:00:1b:b1");
-
-    expect(pairedMacs).toEqual(["00:22:d9:00:1b:b1"]);
-    pair.resolve({
-      configured_device_mac: "00:22:d9:00:1b:b1",
-      configured_device_name: "OBDLink CX",
-      connected: true,
-      paired: true,
-      rfcomm_channel: 1,
-      trusted: true,
-    });
-    await Promise.all([firstPair, secondPair]);
-
-    expect(appState.settings.speed.obdDeviceMac.value).toBe(
-      "00:22:d9:00:1b:b1",
-    );
-    expect(workflow.getRenderState().pairInFlightMac).toBeNull();
     expect(harness.errors).toEqual([]);
     workflow.dispose();
   });

--- a/apps/ui/tests/update_feature_workflow.spec.ts
+++ b/apps/ui/tests/update_feature_workflow.spec.ts
@@ -9,7 +9,11 @@ import type {
   UsbInternetStatusPayload,
 } from "../src/api/types";
 import { signal } from "../src/app/ui_signals";
-import { createDeferred, flushAsyncWork } from "./async_test_helpers";
+import {
+  createDeferred,
+  expectSingleInFlightOperation,
+  flushAsyncWork,
+} from "./async_test_helpers";
 import { createHealthyUpdateStatus } from "./maintenance_payload_test_support";
 import { createTestQueryClient } from "./query_client_test_support";
 
@@ -406,54 +410,15 @@ describe("createUpdateFeatureWorkflow", () => {
       usbAvailable: false,
     };
 
-    const firstStart = workflow.startUpdate(intent);
-    void workflow.startUpdate(intent);
-    await flushAsyncWork();
-    start.resolve({});
-    await firstStart;
+    await expectSingleInFlightOperation({
+      callCount: () => startCalls,
+      resolve: start.resolve,
+      start: () => workflow.startUpdate(intent),
+      value: {},
+    });
 
     expect(startCalls).toBe(1);
     expect(harness.viewCalls).toEqual(["clearPassword"]);
-    expect(harness.errors).toEqual([]);
-    workflow.dispose();
-  });
-
-  test("ignores overlapping update cancel requests while one is in flight", async () => {
-    const harness = createHarness();
-    const cancel = createDeferred<unknown>();
-    let cancelCalls = 0;
-    const workflow = createUpdateFeatureWorkflow({
-      t: (key) => key,
-      showError: (message) => {
-        harness.errors.push(message);
-      },
-      view: createViewPorts(harness),
-      pollingEnabled: signal(false),
-      queryClient: createTestQueryClient(),
-      api: {
-        async cancelUpdate() {
-          cancelCalls += 1;
-          return cancel.promise;
-        },
-        async getHealthStatus() {
-          return makeHealth();
-        },
-        async getUpdateInternetStatus() {
-          return makeInternet();
-        },
-        async getUpdateStatus() {
-          return makeStatus();
-        },
-      },
-    });
-
-    const firstCancel = workflow.cancelUpdate();
-    void workflow.cancelUpdate();
-    await flushAsyncWork();
-    cancel.resolve({});
-    await firstCancel;
-
-    expect(cancelCalls).toBe(1);
     expect(harness.errors).toEqual([]);
     workflow.dispose();
   });


### PR DESCRIPTION
Closes #3863

What changed:
- Added shared async test helpers for late disposal resolution and single in-flight operations.
- Used those helpers for representative speed-source and update lifecycle contracts.
- Removed repeated speed-source scan/pair disposal variants, pair in-flight coverage, analysis save lifecycle variants, and update cancel duplicate-action coverage.

Why:
- Stale responses, disposal, duplicate actions, and confirmation races remain covered.
- Feature tests now focus less on repeating the same async policy for every endpoint/form field.

Validation:
- Cited UI unit suite: 62 passed.
- `git diff --check`, UI format/lint/test typecheck, `make ui-typecheck`, `make plan-validation`.
- Planned local CI passed.

Risks / edge cases:
- Removed cases were duplicate lifecycle-policy variants, not unique user-visible behavior.
- Update start disposal still protects password-clearing behavior; reset confirmation races remain covered.

Follow-ups:
- None.