### PR TITLE
Split focused test support helpers

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_reconnect_backoff.py
+++ b/apps/server/tests/adapters/gps/test_gps_reconnect_backoff.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from test_support.core import async_wait_until
+from test_support.polling import async_wait_until
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.gps.transport_lifecycle import (

--- a/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 
 import pytest
-from test_support.core import async_wait_until
+from test_support.polling import async_wait_until
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 

--- a/apps/server/tests/adapters/pdf/test_report_appendix_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_appendix_layout.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 from _paths import SERVER_ROOT
-from test_support.core import extract_pdf_text
+from test_support.pdf import extract_pdf_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.shared.boundaries.reporting.document import (

--- a/apps/server/tests/adapters/pdf/test_report_confidence_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_confidence_rendering.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from test_support.core import extract_pdf_text
 from test_support.findings import make_finding_payload
+from test_support.pdf import extract_pdf_text
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf

--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from test_support.core import extract_pdf_text
 from test_support.findings import make_finding_payload
+from test_support.pdf import extract_pdf_text
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf

--- a/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 from _paths import SERVER_ROOT
 from pypdf import PdfReader
-from test_support.core import extract_pdf_text
+from test_support.pdf import extract_pdf_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.shared.boundaries.reporting.document import (

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from test_support.core import extract_pdf_text
+from test_support.pdf import extract_pdf_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.domain import LocationIntensitySummary

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -9,7 +9,7 @@ from _report_pdf_test_helpers import (
     extract_media_box,
     sample,
 )
-from test_support.core import extract_pdf_text
+from test_support.pdf import extract_pdf_text
 from test_support.report_helpers import (
     RUN_END,
     minimal_summary,

--- a/apps/server/tests/adapters/pdf/test_report_pdf_usefulness_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_usefulness_layout.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from io import BytesIO
 
 from pypdf import PdfReader
-from test_support.core import extract_pdf_text
+from test_support.pdf import extract_pdf_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.shared.boundaries.reporting.document import (

--- a/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 from _paths import SERVER_ROOT
 from pypdf import PdfReader
-from test_support.core import extract_pdf_text
 from test_support.findings import make_finding_payload
+from test_support.pdf import extract_pdf_text
 from test_support.report_helpers import (
     RUN_END,
     ambiguous_primary_location_summary,

--- a/apps/server/tests/infra/workers/test_worker_pool.py
+++ b/apps/server/tests/infra/workers/test_worker_pool.py
@@ -16,7 +16,7 @@ from math import pi
 
 import numpy as np
 import pytest
-from test_support.core import wait_until
+from test_support.polling import wait_until
 
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.workers.worker_pool import WorkerPool

--- a/apps/server/tests/integration/test_ingest_backpressure_metrics.py
+++ b/apps/server/tests/integration/test_ingest_backpressure_metrics.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
-from test_support.core import async_wait_until
+from test_support.polling import async_wait_until
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.persistence.history_db import (

--- a/apps/server/tests/test_support/__init__.py
+++ b/apps/server/tests/test_support/__init__.py
@@ -54,7 +54,6 @@ from test_support.core import (
     assert_summary_sections,
     assert_top_cause_contract,
     engine_hz,
-    extract_pdf_text,
     profile_circ,
     profile_metadata,
     profile_wheel_hz,
@@ -72,6 +71,8 @@ from test_support.fault_scenarios import (
     make_profile_speed_sweep_fault_samples,
     make_speed_sweep_fault_samples,
 )
+from test_support.pdf import extract_pdf_text
+from test_support.polling import async_wait_until, wait_until
 from test_support.sample_scenarios import (
     make_clipped_samples,
     make_clock_skew_samples,
@@ -139,6 +140,8 @@ __all__ = [
     "assert_top_cause_contract",
     "engine_hz",
     "extract_pdf_text",
+    "async_wait_until",
+    "wait_until",
     "profile_circ",
     "profile_metadata",
     "profile_wheel_hz",

--- a/apps/server/tests/test_support/core.py
+++ b/apps/server/tests/test_support/core.py
@@ -1,15 +1,12 @@
-"""Core metadata, vehicle-profile, frequency helpers, and polling utilities for tests."""
+"""Core metadata, vehicle-profile, and frequency helpers for tests."""
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import math
 import re
-import time
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from functools import cache
-from io import BytesIO
 from typing import Any
 
 from vibesensor.domain import TireSpec
@@ -367,48 +364,6 @@ def engine_hz(
     """Rough engine-1x Hz from speed (2-stroke assumption for simplicity)."""
     whz = wheel_hz(speed_kmh)
     return whz * final_drive * gear_ratio
-
-
-# ---------------------------------------------------------------------------
-# Polling helpers
-# ---------------------------------------------------------------------------
-
-
-def wait_until(
-    predicate: Callable[[], object], timeout_s: float = 2.0, step_s: float = 0.02
-) -> bool:
-    """Poll *predicate* until it returns truthy, or *timeout_s* expires."""
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if predicate():
-            return True
-        time.sleep(step_s)
-    return False
-
-
-async def async_wait_until(
-    predicate: Callable[[], object], timeout_s: float = 2.0, step_s: float = 0.02
-) -> bool:
-    """Async version of :func:`wait_until` — yields to the event loop between polls."""
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if predicate():
-            return True
-        await asyncio.sleep(step_s)
-    return False
-
-
-# ---------------------------------------------------------------------------
-# PDF text extraction helper
-# ---------------------------------------------------------------------------
-
-
-def extract_pdf_text(pdf_bytes: bytes) -> str:
-    """Extract all text from a PDF byte string using pypdf."""
-    from pypdf import PdfReader
-
-    reader = PdfReader(BytesIO(pdf_bytes))
-    return "\n".join((page.extract_text() or "") for page in reader.pages)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/test_support/pdf.py
+++ b/apps/server/tests/test_support/pdf.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+
+def extract_pdf_text(pdf_bytes: bytes) -> str:
+    """Extract all text from a PDF byte string using pypdf."""
+    from pypdf import PdfReader
+
+    reader = PdfReader(BytesIO(pdf_bytes))
+    return "\n".join((page.extract_text() or "") for page in reader.pages)

--- a/apps/server/tests/test_support/polling.py
+++ b/apps/server/tests/test_support/polling.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+
+def wait_until(
+    predicate: Callable[[], object], timeout_s: float = 2.0, step_s: float = 0.02
+) -> bool:
+    """Poll *predicate* until it returns truthy, or *timeout_s* expires."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(step_s)
+    return False
+
+
+async def async_wait_until(
+    predicate: Callable[[], object], timeout_s: float = 2.0, step_s: float = 0.02
+) -> bool:
+    """Async version of wait_until; yields to the event loop between polls."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(step_s)
+    return False

--- a/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
+++ b/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
@@ -6,8 +6,8 @@ import logging
 from pathlib import Path
 
 import pytest
-from test_support.core import wait_until
 from test_support.persisted_analysis import make_persisted_analysis
+from test_support.polling import wait_until
 
 from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 

--- a/apps/server/tests/use_cases/run/test_recorder_post_analysis_flow.py
+++ b/apps/server/tests/use_cases/run/test_recorder_post_analysis_flow.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from test_support.core import wait_until
 from test_support.persisted_analysis import make_persisted_analysis
+from test_support.polling import wait_until
 
 from tests.use_cases.run.test_metrics_log_helpers import (
     _started_snapshot,

--- a/apps/ui/tests/maintenance_feature_test_support.ts
+++ b/apps/ui/tests/maintenance_feature_test_support.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 
 import { render } from "preact";
-import { expect } from "vitest";
 
 import type { EspFlashFeatureDeps } from "../src/app/features/esp_flash_feature";
 import { createEspFlashFeature } from "../src/app/features/esp_flash_feature";
@@ -23,17 +22,7 @@ import type {
   UpdatePanelRenderModel,
   UpdatePanelView,
 } from "../src/app/views/update_panel";
-import type { TimerHarness } from "./async_test_helpers";
-import { flushAsyncWork } from "./async_test_helpers";
 import { installMountedDomGlobals } from "./dom_render_test_support";
-import {
-  createEspFlashPort,
-  createHealthyUpdateStatus,
-  createIdleUpdateStatus,
-  createUsbInternetStatus,
-} from "./maintenance_payload_test_support";
-import { http } from "./msw/http";
-import { createUiMswTestScope } from "./msw/node";
 import { createTestQueryClient } from "./query_client_test_support";
 
 type FeatureServices = UpdateFeatureDeps["services"];
@@ -255,12 +244,6 @@ function createFeatureNavigationHarness(defaultTabId: string) {
   };
 }
 
-function pendingPollDelays(timers: TimerHarness): number[] {
-  return timers
-    .pendingDelays()
-    .filter((delay) => delay !== 10_000 && delay >= 100);
-}
-
 function createMountedHost(): HTMLElement {
   const host = globalThis.document.createElement("div");
   globalThis.document.body.appendChild(host);
@@ -480,29 +463,6 @@ async function createUpdateFeatureDeps() {
   };
 }
 
-function installFeatureFetchMock(
-  handler: (
-    url: URL,
-    method: string,
-    body: string,
-  ) => Promise<Response> | Response,
-): () => void {
-  const scope = createUiMswTestScope();
-  scope.server.use(
-    http.all("*", async ({ request }) => {
-      const requestBody =
-        request.method === "GET" || request.method === "HEAD"
-          ? ""
-          : await request.text();
-      return await handler(new URL(request.url), request.method, requestBody);
-    }),
-  );
-
-  return () => {
-    scope.close();
-  };
-}
-
 export function installMaintenanceFeatureGlobals(): () => void {
   drainMaintenanceCleanups();
   const restoreDomGlobals = installMountedDomGlobals();
@@ -510,40 +470,6 @@ export function installMaintenanceFeatureGlobals(): () => void {
     drainMaintenanceCleanups();
     restoreDomGlobals();
   };
-}
-
-async function expectPollDelays(
-  timers: TimerHarness,
-  expected: number[],
-): Promise<void> {
-  for (let attempt = 0; attempt < 25; attempt += 1) {
-    const actual = pendingPollDelays(timers);
-    if (
-      actual.length === expected.length &&
-      actual.every((delay, index) => delay === expected[index])
-    ) {
-      return;
-    }
-    await flushAsyncWork(1);
-  }
-  expect(pendingPollDelays(timers)).toEqual(expected);
-}
-
-async function expectTimerDelays(
-  timers: TimerHarness,
-  expected: number[],
-): Promise<void> {
-  for (let attempt = 0; attempt < 25; attempt += 1) {
-    const actual = timers.pendingDelays();
-    if (
-      actual.length === expected.length &&
-      actual.every((delay, index) => delay === expected[index])
-    ) {
-      return;
-    }
-    await flushAsyncWork(1);
-  }
-  expect(timers.pendingDelays()).toEqual(expected);
 }
 
 export async function createEspFlashFeatureHarness() {


### PR DESCRIPTION
Closes #3864

What changed:
- Moved polling helpers out of `test_support.core` into `test_support.polling`.
- Moved PDF text extraction out of `test_support.core` into `test_support.pdf`.
- Updated direct imports at backend call sites.
- Removed unused maintenance feature timer/fetch helper leftovers.

Why:
- `test_support.core` now owns vehicle metadata and frequency helpers instead of unrelated polling/PDF utilities.
- Shared support modules are smaller and grouped by purpose.
- Dead UI support setup paths no longer hide unused assumptions.

Validation:
- Affected backend support/import tests: 121 passed.
- Maintenance feature UI support consumer: 18 passed.
- `git diff --check`, touched ruff format/check, UI format/lint/test typecheck, `make lint`, `make typecheck-backend`, `make ui-typecheck`, `make plan-validation`.
- Planned local CI passed after rerunning the known unrelated raw-capture backend-tests-4 flake.

Risks / edge cases:
- Public `test_support` package convenience exports remain for existing broad imports, but touched call sites now import focused owners directly.
- No production code changed.

Follow-ups:
- None.