### PR TITLE
Deduplicate synthetic diagnostic matrices

### DIFF
--- a/apps/server/tests/integration/test_multi_system_overlap.py
+++ b/apps/server/tests/integration/test_multi_system_overlap.py
@@ -1,10 +1,10 @@
-"""Multi-system overlap resolution tests (≥50 direct-injection cases).
+"""Representative multi-system overlap resolution tests.
 
 Tests how the analysis pipeline resolves overlapping system signatures
 (wheel, engine, driveshaft) when multiple vibration sources are present
 simultaneously.  Coverage includes:
 
-  MO1 – Engine + wheel both present: correct source separation.
+  MO1 – Engine + wheel both present: representative speed/profile separation.
   MO2 – Engine-wheel harmonic alias suppression (1.15 ratio / 0.60 penalty).
   MO3 – Driveshaft + wheel overlap at low speed.
   MO4 – Three systems present simultaneously.
@@ -19,7 +19,6 @@ from typing import Any
 
 import pytest
 from test_support import (
-    ADDITIONAL_CAR_PROFILE_IDS,
     ADDITIONAL_CAR_PROFILES,
     ALL_WHEEL_SENSORS,
     CAR_PROFILES,
@@ -43,8 +42,6 @@ from test_support import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_CORNERS = list(CORNER_SENSORS)
 
 # Ratio of driveshaft order to wheel-1x order (prop shaft speed ≈ 2.5× wheel)
 _DRIVESHAFT_WHEEL_RATIO = 2.5
@@ -181,11 +178,15 @@ def _make_driveshaft_plus_wheel_samples(
 
 # ===================================================================
 # MO1 – Engine + localized wheel fault: wheel should be detected
-# 4 corners × 3 speeds × 2 new profiles = 24 cases
+# Representative low/high speed and front/rear profile cases.
 # ===================================================================
-@pytest.mark.parametrize("corner", _CORNERS)
-@pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
-@pytest.mark.parametrize("profile", ADDITIONAL_CAR_PROFILES, ids=ADDITIONAL_CAR_PROFILE_IDS)
+@pytest.mark.parametrize(
+    ("corner", "speed", "profile"),
+    [
+        pytest.param("FL", SPEED_LOW, ADDITIONAL_CAR_PROFILES[0], id="low-front"),
+        pytest.param("RR", SPEED_HIGH, ADDITIONAL_CAR_PROFILES[-1], id="high-rear"),
+    ],
+)
 def test_engine_plus_wheel_detects_wheel(
     corner: str,
     speed: float,
@@ -211,7 +212,7 @@ def test_engine_plus_wheel_detects_wheel(
 # ===================================================================
 # MO2 – Engine harmonic alias suppression
 # When engine confidence is close to wheel, engine should be suppressed.
-# 4 corners × 3 engine strengths = 12 cases
+# Three engine strengths on one representative corner.
 # ===================================================================
 _ENGINE_STRENGTHS = [
     ("weak_engine", 0.015),  # engine much weaker than wheel
@@ -220,15 +221,14 @@ _ENGINE_STRENGTHS = [
 ]
 
 
-@pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize(
     ("eng_name", "engine_amp"),
     _ENGINE_STRENGTHS,
     ids=[e[0] for e in _ENGINE_STRENGTHS],
 )
-def test_engine_alias_suppression(corner: str, eng_name: str, engine_amp: float) -> None:
+def test_engine_alias_suppression(eng_name: str, engine_amp: float) -> None:
     """Engine alias suppression should prevent engine from dominating when wheel is present."""
-    sensor = CORNER_SENSORS[corner]
+    sensor = CORNER_SENSORS["FL"]
     samples = _make_engine_plus_wheel_samples(
         fault_sensor=sensor,
         sensors=ALL_WHEEL_SENSORS,
@@ -243,11 +243,15 @@ def test_engine_alias_suppression(corner: str, eng_name: str, engine_amp: float)
 
 # ===================================================================
 # MO3 – Driveshaft + wheel overlap
-# 4 corners × 2 speeds × 2 new profiles = 16 cases
+# Representative front/rear and low/mid speed profile cases.
 # ===================================================================
-@pytest.mark.parametrize("corner", _CORNERS)
-@pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID], ids=["low", "mid"])
-@pytest.mark.parametrize("profile", ADDITIONAL_CAR_PROFILES, ids=ADDITIONAL_CAR_PROFILE_IDS)
+@pytest.mark.parametrize(
+    ("corner", "speed", "profile"),
+    [
+        pytest.param("FR", SPEED_LOW, ADDITIONAL_CAR_PROFILES[0], id="low-front"),
+        pytest.param("RL", SPEED_MID, ADDITIONAL_CAR_PROFILES[-1], id="mid-rear"),
+    ],
+)
 def test_driveshaft_plus_wheel_overlap(
     corner: str,
     speed: float,
@@ -268,10 +272,15 @@ def test_driveshaft_plus_wheel_overlap(
 
 # ===================================================================
 # MO4 – Three systems simultaneously (wheel + engine + driveshaft-like)
-# 4 corners × 2 speeds = 8 cases
+# One front/high and one rear/mid representative.
 # ===================================================================
-@pytest.mark.parametrize("corner", _CORNERS)
-@pytest.mark.parametrize("speed", [SPEED_MID, SPEED_HIGH], ids=["mid", "high"])
+@pytest.mark.parametrize(
+    ("corner", "speed"),
+    [
+        pytest.param("FL", SPEED_HIGH, id="high-front"),
+        pytest.param("RR", SPEED_MID, id="mid-rear"),
+    ],
+)
 def test_three_systems_simultaneous(corner: str, speed: float) -> None:
     """Pipeline should handle wheel + engine + driveshaft-like signals without crash."""
     sensor = CORNER_SENSORS[corner]
@@ -305,7 +314,7 @@ def test_three_systems_simultaneous(corner: str, speed: float) -> None:
 
 # ===================================================================
 # MO5 – Engine-only (all sensors uniform) → no localized wheel fault
-# 3 speeds × 2 engine strengths = 6 cases
+# One moderate mid-speed and one strong high-speed representative.
 # ===================================================================
 _ENGINE_ONLY_STRENGTHS = [
     ("moderate", 0.04, 22.0),
@@ -313,11 +322,12 @@ _ENGINE_ONLY_STRENGTHS = [
 ]
 
 
-@pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
 @pytest.mark.parametrize(
-    ("eng_name", "engine_amp", "engine_db"),
-    _ENGINE_ONLY_STRENGTHS,
-    ids=[e[0] for e in _ENGINE_ONLY_STRENGTHS],
+    ("speed", "eng_name", "engine_amp", "engine_db"),
+    [
+        pytest.param(SPEED_MID, *_ENGINE_ONLY_STRENGTHS[0], id="mid-moderate"),
+        pytest.param(SPEED_HIGH, *_ENGINE_ONLY_STRENGTHS[1], id="high-strong"),
+    ],
 )
 def test_engine_only_no_localized_wheel(
     speed: float,
@@ -342,7 +352,7 @@ def test_engine_only_no_localized_wheel(
 
 # ===================================================================
 # MO6 – Engine + single-sensor wheel: wheel dominance
-# 4 corners × 2 relative strengths = 8 cases
+# Two relative strengths on one limited-layout representative.
 # ===================================================================
 _RELATIVE_STRENGTHS = [
     ("wheel_dominates", 0.06, 0.02),
@@ -350,19 +360,18 @@ _RELATIVE_STRENGTHS = [
 ]
 
 
-@pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize(
     ("strength_name", "wheel_amp", "engine_amp"),
     _RELATIVE_STRENGTHS,
     ids=[s[0] for s in _RELATIVE_STRENGTHS],
 )
 def test_engine_plus_single_sensor_wheel(
-    corner: str,
     strength_name: str,
     wheel_amp: float,
     engine_amp: float,
 ) -> None:
     """Engine + localized wheel: pipeline should find the localized wheel signal."""
+    corner = "FL"
     sensor = CORNER_SENSORS[corner]
     samples = _make_engine_plus_wheel_samples(
         fault_sensor=sensor,
@@ -380,12 +389,12 @@ def test_engine_plus_single_sensor_wheel(
 
 # ===================================================================
 # MO7 – Profile-aware multi-system overlap
-# 7 profiles × 4 corners = 28 cases
+# Profile span on one representative corner; corner behavior is covered above.
 # ===================================================================
 @pytest.mark.parametrize("profile", _PROFILE_SPAN, ids=_PROFILE_SPAN_IDS)
-@pytest.mark.parametrize("corner", _CORNERS)
-def test_profile_engine_plus_wheel(profile: dict[str, Any], corner: str) -> None:
+def test_profile_engine_plus_wheel(profile: dict[str, Any]) -> None:
     """Profile-aware engine+wheel should not crash and should produce findings."""
+    corner = "FL"
     sensor = CORNER_SENSORS[corner]
     whz = profile_wheel_hz(profile, SPEED_MID)
     ehz = whz * profile["final_drive_ratio"] * profile["current_gear_ratio"]

--- a/apps/server/tests/integration/test_synthetic_scenario_matrix.py
+++ b/apps/server/tests/integration/test_synthetic_scenario_matrix.py
@@ -1,16 +1,12 @@
 """Representative synthetic scenario matrix coverage.
 
-This module owns the cross-cutting synthetic scenario dimensions that were
-previously duplicated across the single-vs-multi and transient-vs-steady
-integration suites:
+This module owns the cross-cutting synthetic scenario matrix:
 
-- core fault corner/speed detection
-- no-fault noise baselines
-- phased onset behavior
-
-The 4-sensor steady matrix remains the full corner x speed owner. Single-sensor
-and transient variants keep representative subsets so the suite still covers
-those dimensions without repeating the entire cartesian product.
+- 4-sensor steady faults: full corner x speed owner.
+- Single-sensor faults: one limited-localization representative.
+- Transient faults: one single-sensor and one 4-sensor representative.
+- No-fault baselines: one representative per layout/steady/transient purpose.
+- Phased onset: one representative per layout/transient purpose.
 """
 
 from __future__ import annotations
@@ -50,6 +46,16 @@ from test_support.diagnostic_matrix_catalogs import (
 )
 
 SensorLayout = Literal["single", "4sensor", "12sensor"]
+
+SCENARIO_PURPOSE_MATRIX = (
+    ("4sensor-core", "full corner x speed fault owner"),
+    ("single-representative", "limited sensor-layout fault owner"),
+    ("single-transient-representative", "single-sensor transient fault owner"),
+    ("4sensor-transient-representative", "multi-sensor transient fault owner"),
+    ("noise-baseline", "steady no-fault suppression by layout"),
+    ("transient-baseline", "transient no-fault tolerance by layout"),
+    ("phased", "idle/ramp/fault phase onset by layout"),
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,49 +113,37 @@ FAULT_MATRIX_CASES = [
         for corner in DIAGNOSTIC_WHEEL_CORNERS
         for speed_case_id, speed_kmh in DIAGNOSTIC_STANDARD_SPEED_CASES
     ],
-    *[
-        _fault_case(
-            case_id="single-representative",
-            sensor_layout="single",
-            corner=corner,
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=False,
-            min_confidence=0.45,
-            expect_warnings=True,
-            expect_confidence_label=True,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
-    *[
-        _fault_case(
-            case_id="single-transient-representative",
-            sensor_layout="single",
-            corner=corner,
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=True,
-            min_confidence=0.30,
-            expect_warnings=True,
-            expect_confidence_label=True,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
-    *[
-        _fault_case(
-            case_id="4sensor-transient-representative",
-            sensor_layout="4sensor",
-            corner=corner,
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=True,
-            min_confidence=0.15,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
+    _fault_case(
+        case_id="single-representative",
+        sensor_layout="single",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[0],
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[0][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[0][1],
+        transient=False,
+        min_confidence=0.45,
+        expect_warnings=True,
+        expect_confidence_label=True,
+    ),
+    _fault_case(
+        case_id="single-transient-representative",
+        sensor_layout="single",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[1],
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][1],
+        transient=True,
+        min_confidence=0.30,
+        expect_warnings=True,
+        expect_confidence_label=True,
+    ),
+    _fault_case(
+        case_id="4sensor-transient-representative",
+        sensor_layout="4sensor",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[0],
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][1],
+        transient=True,
+        min_confidence=0.15,
+    ),
 ]
 
 
@@ -186,57 +180,42 @@ def _no_fault_case(
 
 
 NO_FAULT_MATRIX_CASES = [
-    *[
-        _no_fault_case(
-            case_id="single-noise-baseline",
-            sensor_layout="single",
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=False,
-            expect_warnings=True,
-        )
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
-    *[
-        _no_fault_case(
-            case_id="4sensor-noise-baseline",
-            sensor_layout="4sensor",
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=False,
-        )
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
-    *[
-        _no_fault_case(
-            case_id="single-transient-baseline",
-            sensor_layout="single",
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=True,
-        )
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
-    *[
-        _no_fault_case(
-            case_id="4sensor-transient-baseline",
-            sensor_layout="4sensor",
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=True,
-        )
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
-    *[
-        _no_fault_case(
-            case_id="12sensor-transient-baseline",
-            sensor_layout="12sensor",
-            speed_case_id=speed_case_id,
-            speed_kmh=speed_kmh,
-            transient=True,
-        )
-        for speed_case_id, speed_kmh in DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES
-    ],
+    _no_fault_case(
+        case_id="single-noise-baseline",
+        sensor_layout="single",
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[0][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[0][1],
+        transient=False,
+        expect_warnings=True,
+    ),
+    _no_fault_case(
+        case_id="4sensor-noise-baseline",
+        sensor_layout="4sensor",
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][1],
+        transient=False,
+    ),
+    _no_fault_case(
+        case_id="single-transient-baseline",
+        sensor_layout="single",
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][1],
+        transient=True,
+    ),
+    _no_fault_case(
+        case_id="4sensor-transient-baseline",
+        sensor_layout="4sensor",
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[0][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[0][1],
+        transient=True,
+    ),
+    _no_fault_case(
+        case_id="12sensor-transient-baseline",
+        sensor_layout="12sensor",
+        speed_case_id=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][0],
+        speed_kmh=DIAGNOSTIC_REPRESENTATIVE_SPEED_CASES[1][1],
+        transient=True,
+    ),
 ]
 
 
@@ -267,42 +246,30 @@ def _phased_case(
 
 
 PHASED_MATRIX_CASES = [
-    *[
-        _phased_case(
-            case_id="single-phased",
-            sensor_layout="single",
-            corner=corner,
-            transient=False,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-    ],
-    *[
-        _phased_case(
-            case_id="4sensor-phased",
-            sensor_layout="4sensor",
-            corner=corner,
-            transient=False,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-    ],
-    *[
-        _phased_case(
-            case_id="single-phased-transient",
-            sensor_layout="single",
-            corner=corner,
-            transient=True,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-    ],
-    *[
-        _phased_case(
-            case_id="4sensor-phased-transient",
-            sensor_layout="4sensor",
-            corner=corner,
-            transient=True,
-        )
-        for corner in DIAGNOSTIC_REPRESENTATIVE_CORNERS
-    ],
+    _phased_case(
+        case_id="single-phased",
+        sensor_layout="single",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[0],
+        transient=False,
+    ),
+    _phased_case(
+        case_id="4sensor-phased",
+        sensor_layout="4sensor",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[1],
+        transient=False,
+    ),
+    _phased_case(
+        case_id="single-phased-transient",
+        sensor_layout="single",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[1],
+        transient=True,
+    ),
+    _phased_case(
+        case_id="4sensor-phased-transient",
+        sensor_layout="4sensor",
+        corner=DIAGNOSTIC_REPRESENTATIVE_CORNERS[0],
+        transient=True,
+    ),
 ]
 
 


### PR DESCRIPTION
## What changed
- Documented the unique synthetic scenario purposes owned by the matrix test.
- Kept full 4-sensor steady fault corner x speed coverage.
- Reduced single-sensor, transient, no-fault, and phased scenario variants to one named representative per purpose.
- Reduced multi-system overlap cross-products to front/rear, speed, strength, and profile representatives instead of broad corner/speed/profile matrices.

## Why
- The cited synthetic scenario suite had overlapping variants across matrix and overlap tests.
- Default CI should keep diagnostic confidence without repeating near-identical synthetic cases.

## Validation
- Cited suite collection: 889 tests before, 753 tests after.
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python -m pytest -q apps/server/tests/integration/test_synthetic_scenario_matrix.py apps/server/tests/integration/test_multi_system_overlap.py
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python -m pytest -q apps/server/tests/integration/test_synthetic_scenario_matrix.py apps/server/tests/integration/test_scenario_ground_truth_contract.py apps/server/tests/integration/test_scenario_ground_truth_invariants.py apps/server/tests/integration/test_messy_real_world.py apps/server/tests/integration/test_multi_system_overlap.py apps/server/tests/integration/test_multi_transient.py apps/server/tests/use_cases/diagnostics/test_negative_false_positives.py apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py apps/server/tests/use_cases/diagnostics/test_contradictory_phase_signals.py
- PATH="$PWD/.venv/bin:$PATH" git diff --check
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make typecheck-backend
- PATH="$PWD/.venv/bin:$PATH" make plan-validation
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/plan_validation.py --run (backend-tests-5 hit known raw-capture queue-full flakes; rerun of backend-tests-5 passed)

## Risks / tradeoffs
- Removed broad cartesian coverage for single-sensor, transient, and overlap variants.
- Representative cases still cover no-fault, transient, overlap, phased, and profile-aware risks; full corner x speed ownership remains in the 4-sensor steady matrix.