### PR TITLE
Consolidate manual speed settings tests

### DIFF
--- a/apps/ui/tests/regression.settings.spec.ts
+++ b/apps/ui/tests/regression.settings.spec.ts
@@ -141,48 +141,6 @@ test("manual speed save uses settings endpoint only (no speed-override call)", a
   await expect.poll(() => speedOverrideCalls).toBe(0);
 });
 
-test("manual speed validation marks the field invalid while keeping the active GPS card visible", async ({
-  page,
-}) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
-      "GET /api/settings/speed-source": {
-        speed_source: "gps",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-      },
-    }),
-  });
-  await bootLiveDashboard(page, { installRoutes: false });
-  await openSpeedSourceTab(page);
-  await page.locator('[data-speed-source-choice="manual"]').click();
-  await page.locator("#manualSpeedInput").fill("0");
-  await page.locator("#saveSpeedSourceBtn").click();
-
-  await expect(page.locator("#manualSpeedInput")).toHaveAttribute(
-    "aria-invalid",
-    "true",
-  );
-  await expect(page.locator("#manualSpeedFeedback")).toContainText(
-    "Enter a manual speed between 0.1 and 500 km/h.",
-  );
-  await expect(page.locator("#speedSourceSaveFeedback")).toContainText(
-    "GPS remains active right now",
-  );
-  await expect(
-    page.locator('[data-speed-source-choice="gps"]'),
-  ).toHaveAttribute("data-selected", "true");
-  await expect(
-    page.locator('[data-speed-source-choice="manual"]'),
-  ).toHaveAttribute("data-choice-state", "draft");
-  await expect(page.locator("#speedSourceDiagnostics")).toHaveAttribute(
-    "open",
-    "",
-  );
-});
-
 test("resolved fallback manual state stays coherent across header status, form, and GPS status", async ({
   page,
 }) => {
@@ -462,50 +420,6 @@ test("settings keep inferred sensor names unassigned until an explicit location 
   const locationSelect = row.locator("select.row-location-select");
 
   await expect(locationSelect).toHaveValue("");
-});
-
-test("failed speed-source save keeps the draft and explains which source remains active", async ({
-  page,
-}) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
-      "GET /api/settings/speed-source": {
-        speed_source: "gps",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-      },
-      "PUT /api/settings/speed-source": async (route: Route) => {
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Speed source save failed" }),
-        });
-      },
-    }),
-  });
-  await bootLiveDashboard(page, { installRoutes: false });
-  await openSpeedSourceTab(page);
-  await page.locator('[data-speed-source-choice="manual"]').click();
-  await page.locator("#manualSpeedInput").fill("45");
-  await page.locator("#saveSpeedSourceBtn").click();
-
-  await expect(page.locator("#speedSourceSaveFeedback")).toBeVisible();
-  await expect(page.locator("#speedSourceSaveFeedback")).toContainText(
-    "Speed source save failed",
-  );
-  await expect(page.locator("#speedSourceSaveFeedback")).toContainText(
-    "GPS remains active right now",
-  );
-  await expect(
-    page.locator('input[name="speedSourceRadio"][value="manual"]'),
-  ).toBeChecked();
-  await expect(page.locator("#manualSpeedInput")).toHaveValue("45");
-  await expect(page.locator("#speedSourceDiagnostics")).toHaveAttribute(
-    "open",
-    "",
-  );
 });
 
 test("manual OBD scan sorts named devices first and background rescans progressively improve the list", async ({

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -324,6 +324,46 @@ describe("createSettingsSpeedSourceWorkflow", () => {
     workflow.dispose();
   });
 
+  test("keeps the manual draft when a speed-source save fails", async () => {
+    const harness = createHarness();
+    const appState = createAppState();
+    const workflow = createSettingsSpeedSourceWorkflow({
+      obdConfigVisible: harness.obdConfigVisible,
+      queryClient: createTestQueryClient(),
+      settings: appState.settings,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      t: createTranslator(),
+      transport: {
+        async saveSpeedSource() {
+          throw new Error("Speed source save failed");
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    workflow.handleSpeedSourceChanged("manual");
+    workflow.handleManualSpeedInput("45");
+    await workflow.saveSpeedSource();
+
+    expect(workflow.getRenderState()).toMatchObject({
+      manualSpeedInputValue: "45",
+      saveFeedback: {
+        body: "Speed source save failed",
+        detail: "settings.speed.save_failed_detail:settings.speed.gps",
+        title: "settings.speed.save_failed_title",
+        tone: "error",
+      },
+      selectedMode: "manual",
+    });
+    expect(appState.settings.speed.source.value).toBe("gps");
+    expect(appState.settings.speed.manualSpeedKph.value).toBeNull();
+    expect(harness.focuses).toEqual([]);
+    expect(harness.errors).toEqual([]);
+    workflow.dispose();
+  });
+
   test("scans and pairs OBD devices without DOM bindings", async () => {
     const harness = createHarness();
     const appState = createAppState();


### PR DESCRIPTION
## What changed
- Removed duplicate browser assertions for manual-speed validation and failed speed-source saves from `regression.settings.spec.ts`.
- Added workflow-owner coverage for failed speed-source saves preserving the manual draft and explaining the active GPS source.
- Kept one browser manual-speed save path that verifies the settings endpoint and no legacy speed-override call.

## Why
Manual-speed validation and feedback should be owned by production workflow/presenter tests. The broad settings browser spec should keep only the integration path that proves the settings UI talks to the right endpoint.

## Validation
- `cd apps/ui && npm run test:unit -- tests/settings_speed_source_workflow.spec.ts tests/settings_speed_source_presenter.spec.ts`
- `cd apps/ui && npm run test:regression -- tests/regression.settings.spec.ts`
- `PATH="$PWD/.venv/bin:$PATH" make ui-typecheck`
- `PATH="$PWD/.venv/bin:$PATH" make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --job repo-hygiene --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke --job release-smoke --job e2e`

## Risks / tradeoffs
- The browser spec no longer repeats manual validation details already covered by workflow and presenter tests.
- Remaining browser coverage focuses on the user path that saves manual speed through production UI wiring.

Closes #3903