### PR TITLE
Reduce update workflow mock-only tests

### DIFF
--- a/apps/server/tests/use_cases/updates/test_firmware_refresh_execution.py
+++ b/apps/server/tests/use_cases/updates/test_firmware_refresh_execution.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from vibesensor.shared.exceptions import UpdateReleaseError
@@ -17,17 +15,31 @@ from vibesensor.use_cases.updates.run_models import (
 )
 
 
+class RecordingCompletion:
+    def __init__(self) -> None:
+        self.successes: list[tuple[object, str]] = []
+
+    async def complete_success(self, prepared_transport: object, *, message: str) -> None:
+        self.successes.append((prepared_transport, message))
+
+
+class RecordingFirmwareRefresher:
+    def __init__(self, result: FirmwareRefreshResult) -> None:
+        self.result = result
+        self.pinned_tags: list[str] = []
+
+    async def refresh_esp_firmware(self, pinned_tag: str = "") -> FirmwareRefreshResult:
+        self.pinned_tags.append(pinned_tag)
+        return self.result
+
+
 def _coordinator() -> tuple[
     RefreshFirmwareExecutionCoordinator,
-    MagicMock,
-    MagicMock,
+    RecordingCompletion,
+    RecordingFirmwareRefresher,
 ]:
-    completion = MagicMock()
-    completion.complete_success = AsyncMock()
-    firmware_refresher = MagicMock()
-    firmware_refresher.refresh_esp_firmware = AsyncMock(
-        return_value=FirmwareRefreshResult.success(),
-    )
+    completion = RecordingCompletion()
+    firmware_refresher = RecordingFirmwareRefresher(FirmwareRefreshResult.success())
     return (
         RefreshFirmwareExecutionCoordinator(
             completion=completion,
@@ -56,26 +68,23 @@ def _refresh_workflow(prepared_transport: object) -> tuple[PlannedUpdateRun, Ref
 @pytest.mark.asyncio
 async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() -> None:
     coordinator, completion, firmware_refresher = _coordinator()
-    prepared_transport = MagicMock()
+    prepared_transport = object()
     workflow, plan = _refresh_workflow(prepared_transport)
 
     completed = await coordinator.execute(workflow, plan)
 
     assert completed == UpdateExecutionOutcome.refresh_only
-    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
-        pinned_tag="server-v2026.4.3",
-    )
-    completion.complete_success.assert_awaited_once_with(
-        prepared_transport,
-        message="No server update needed; ESP firmware checked",
-    )
+    assert firmware_refresher.pinned_tags == ["server-v2026.4.3"]
+    assert completion.successes == [
+        (prepared_transport, "No server update needed; ESP firmware checked"),
+    ]
 
 
 @pytest.mark.asyncio
 async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
     coordinator, completion, firmware_refresher = _coordinator()
-    workflow, plan = _refresh_workflow(MagicMock())
-    firmware_refresher.refresh_esp_firmware.return_value = FirmwareRefreshResult.failure(
+    workflow, plan = _refresh_workflow(object())
+    firmware_refresher.result = FirmwareRefreshResult.failure(
         message="ESP firmware cache refresh failed (exit 1)",
         detail="cache unavailable",
     )
@@ -89,4 +98,4 @@ async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
         excinfo.value.log_message
         == "ESP firmware refresh failed; refresh-only update did not complete"
     )
-    completion.complete_success.assert_not_awaited()
+    assert completion.successes == []

--- a/apps/server/tests/use_cases/updates/test_server_release_execution.py
+++ b/apps/server/tests/use_cases/updates/test_server_release_execution.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from test_support.update_status import build_update_status_harness
@@ -69,6 +68,14 @@ class _RecordingDeployment:
         self.deployed_release = staged_release
 
 
+class _RecordingCompletion:
+    def __init__(self) -> None:
+        self.successes: list[tuple[object, str]] = []
+
+    async def complete_success(self, prepared_transport: object, *, message: str) -> None:
+        self.successes.append((prepared_transport, message))
+
+
 def _workflow(release: object, prepared_transport: object) -> tuple[PlannedUpdateRun, object]:
     plan = InstallServerReleasePlan(release=release)
     return (
@@ -87,8 +94,7 @@ async def test_execute_deploys_staged_release_after_successful_refresh(tmp_path:
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
     firmware_refresher = _StaticFirmwareRefresher(FirmwareRefreshResult.success())
     deployment = _RecordingDeployment()
-    completion = MagicMock()
-    completion.complete_success = AsyncMock()
+    completion = _RecordingCompletion()
     coordinator = ServerReleaseExecutionCoordinator(
         completion=completion,
         stager=_StaticStager(staged_release),
@@ -105,10 +111,7 @@ async def test_execute_deploys_staged_release_after_successful_refresh(tmp_path:
     assert firmware_refresher.pinned_tags == ["server-v2026.4.4"]
     assert deployment.deployed_release is staged_release
     assert status.status.issues == []
-    completion.complete_success.assert_awaited_once_with(
-        prepared_transport,
-        message="Update completed successfully",
-    )
+    assert completion.successes == [(prepared_transport, "Update completed successfully")]
 
 
 @pytest.mark.asyncio
@@ -123,8 +126,7 @@ async def test_execute_records_firmware_refresh_failure_and_still_deploys(tmp_pa
         ),
     )
     deployment = _RecordingDeployment()
-    completion = MagicMock()
-    completion.complete_success = AsyncMock()
+    completion = _RecordingCompletion()
     coordinator = ServerReleaseExecutionCoordinator(
         completion=completion,
         stager=_StaticStager(staged_release),
@@ -141,4 +143,6 @@ async def test_execute_records_firmware_refresh_failure_and_still_deploys(tmp_pa
     assert status.status.issues[-1].message == "ESP firmware cache refresh failed (exit 4)"
     assert status.status.issues[-1].detail == "download timed out"
     assert "ESP firmware refresh failed; continuing with existing cache" in status.status.log_tail
-    completion.complete_success.assert_awaited_once()
+    assert completion.successes == [
+        (workflow.prepared.prepared_transport, "Update completed successfully"),
+    ]

--- a/apps/server/tests/use_cases/updates/test_startup_recovery.py
+++ b/apps/server/tests/use_cases/updates/test_startup_recovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
@@ -12,77 +13,95 @@ from vibesensor.use_cases.updates.models import (
     UpdateTransport,
 )
 from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
+from vibesensor.use_cases.updates.status import (
+    UpdateStateStore,
+    UpdateTerminalStateReporter,
+    build_update_status_tracker,
+)
+
+
+class RecordingTransportCoordinator:
+    def __init__(self) -> None:
+        self.recovered_statuses: list[UpdateJobStatus] = []
+
+    async def recover_interrupted(self, status: UpdateJobStatus) -> None:
+        self.recovered_statuses.append(status)
+
+
+@dataclass(frozen=True, slots=True)
+class Snapshot:
+    metadata: object
+
+
+class SnapshotStore:
+    def __init__(self, snapshot: Snapshot | None) -> None:
+        self.snapshot = snapshot
+        self.load_attempts = 0
+
+    def load_snapshot(self, *, report_issues: bool = True) -> Snapshot | None:
+        assert report_issues is False
+        self.load_attempts += 1
+        return self.snapshot
+
+
+class RollbackVerifier:
+    def __init__(self, *, result: bool) -> None:
+        self.result = result
+        self.verified_metadata: list[object] = []
+
+    async def verify(self, metadata: object) -> bool:
+        self.verified_metadata.append(metadata)
+        return self.result
 
 
 def _make_recovery(
+    tmp_path: Path,
     status: UpdateJobStatus,
     *,
-    rollback_snapshots: MagicMock | None = None,
-    rollback_verifier: AsyncMock | None = None,
-) -> tuple[
-    UpdateStartupRecoveryCoordinator,
-    MagicMock,
-    AsyncMock,
-    MagicMock,
-    MagicMock,
-]:
-    status_tracker = MagicMock()
-    status_tracker.status = status
-    reporter = MagicMock()
-    transport_coordinator = MagicMock()
-    transport_coordinator.recover_interrupted = AsyncMock()
-    return (
-        UpdateStartupRecoveryCoordinator(
-            status=status_tracker,
-            reporter=reporter,
-            transport_coordinator=transport_coordinator,
-            rollback_snapshots=rollback_snapshots,
-            rollback_verifier=rollback_verifier,
-        ),
-        transport_coordinator,
-        transport_coordinator.recover_interrupted,
-        reporter,
-        status_tracker,
+    rollback_snapshots: SnapshotStore | None = None,
+    rollback_verifier: RollbackVerifier | None = None,
+) -> tuple[UpdateStartupRecoveryCoordinator, RecordingTransportCoordinator]:
+    status_tracker = build_update_status_tracker(
+        state_store=UpdateStateStore(tmp_path / "update_status.json"),
+        status=status,
     )
+    transport_coordinator = RecordingTransportCoordinator()
+    coordinator = UpdateStartupRecoveryCoordinator(
+        status=status_tracker,
+        reporter=UpdateTerminalStateReporter(status=status_tracker),
+        transport_coordinator=transport_coordinator,
+        rollback_snapshots=rollback_snapshots,
+        rollback_verifier=rollback_verifier,
+    )
+    return coordinator, transport_coordinator
 
 
 @pytest.mark.asyncio
-async def test_recover_skips_non_running_jobs() -> None:
-    (
-        coordinator,
-        transport_coordinator,
-        recover,
-        reporter,
-        status_tracker,
-    ) = _make_recovery(UpdateJobStatus(state=UpdateState.idle))
+async def test_recover_skips_non_running_jobs(tmp_path: Path) -> None:
+    status = UpdateJobStatus(state=UpdateState.idle)
+    coordinator, transport_coordinator = _make_recovery(tmp_path, status)
 
     await coordinator.recover()
 
-    transport_coordinator.recover_interrupted.assert_not_called()
-    recover.assert_not_awaited()
-    reporter.mark_interrupted.assert_not_called()
+    assert transport_coordinator.recovered_statuses == []
+    assert status.state is UpdateState.idle
+    assert status.issues == []
 
 
 @pytest.mark.asyncio
-async def test_recover_reverifies_rollback_snapshot_after_interrupted_install() -> None:
-    snapshot = MagicMock()
-    snapshot.metadata = object()
-    rollback_snapshots = MagicMock()
-    rollback_snapshots.load_snapshot.return_value = snapshot
-    rollback_verifier = MagicMock()
-    rollback_verifier.verify = AsyncMock(return_value=True)
+async def test_recover_marks_interrupted_recovers_transport_and_verifies_snapshot(
+    tmp_path: Path,
+) -> None:
+    metadata = object()
+    rollback_snapshots = SnapshotStore(Snapshot(metadata=metadata))
+    rollback_verifier = RollbackVerifier(result=True)
     status = UpdateJobStatus(
         state=UpdateState.running,
         phase=UpdatePhase.installing,
         transport=UpdateTransport.usb_internet,
     )
-    (
-        coordinator,
-        transport_coordinator,
-        recover,
-        reporter,
-        status_tracker,
-    ) = _make_recovery(
+    coordinator, transport_coordinator = _make_recovery(
+        tmp_path,
         status,
         rollback_snapshots=rollback_snapshots,
         rollback_verifier=rollback_verifier,
@@ -90,54 +109,26 @@ async def test_recover_reverifies_rollback_snapshot_after_interrupted_install() 
 
     await coordinator.recover()
 
-    transport_coordinator.recover_interrupted.assert_awaited_once_with(status)
-    reporter.mark_interrupted.assert_called_once_with("Update interrupted by server restart")
-    rollback_snapshots.load_snapshot.assert_called_once_with(report_issues=False)
-    rollback_verifier.verify.assert_awaited_once_with(snapshot.metadata)
+    assert transport_coordinator.recovered_statuses == [status]
+    assert status.state is UpdateState.failed
+    assert [(issue.phase, issue.message) for issue in status.issues] == [
+        ("startup", "Update interrupted by server restart"),
+    ]
+    assert rollback_snapshots.load_attempts == 1
+    assert rollback_verifier.verified_metadata == [metadata]
 
 
 @pytest.mark.asyncio
-async def test_recover_marks_interrupted_and_recovers_transport() -> None:
-    (
-        coordinator,
-        transport_coordinator,
-        recover,
-        reporter,
-        status_tracker,
-    ) = _make_recovery(
-        UpdateJobStatus(
-            state=UpdateState.running,
-            transport=UpdateTransport.usb_internet,
-        ),
-    )
-
-    await coordinator.recover()
-
-    transport_coordinator.recover_interrupted.assert_awaited_once_with(
-        UpdateJobStatus(
-            state=UpdateState.running,
-            transport=UpdateTransport.usb_internet,
-        ),
-    )
-    reporter.mark_interrupted.assert_called_once_with("Update interrupted by server restart")
-
-
-@pytest.mark.asyncio
-async def test_recover_repairs_cleanup_failed_terminal_state() -> None:
+async def test_recover_repairs_cleanup_failed_terminal_state(tmp_path: Path) -> None:
     status = UpdateJobStatus(
         state=UpdateState.failed,
         finished_at=123.0,
         terminal_state=UpdateTerminalState.timeout_cleanup_failed,
     )
-    (
-        coordinator,
-        transport_coordinator,
-        recover,
-        reporter,
-        status_tracker,
-    ) = _make_recovery(status)
+    coordinator, transport_coordinator = _make_recovery(tmp_path, status)
 
     await coordinator.recover()
 
-    transport_coordinator.recover_interrupted.assert_awaited_once_with(status)
-    reporter.mark_interrupted.assert_not_called()
+    assert transport_coordinator.recovered_statuses == [status]
+    assert status.state is UpdateState.failed
+    assert status.issues == []

--- a/apps/server/tests/use_cases/updates/test_update_completion.py
+++ b/apps/server/tests/use_cases/updates/test_update_completion.py
@@ -1,23 +1,52 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
 
 import pytest
 
 from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
+from vibesensor.use_cases.updates.models import (
+    UpdateJobStatus,
+    UpdatePhase,
+    UpdateState,
+    UpdateTerminalState,
+)
+from vibesensor.use_cases.updates.status import (
+    UpdateStateStore,
+    UpdateTerminalStateReporter,
+    build_update_status_tracker,
+)
+
+
+class RecordingPreparedTransport:
+    def __init__(self) -> None:
+        self.completed = False
+
+    async def complete_success(self) -> None:
+        self.completed = True
+
+
+class RecordingRestartScheduler:
+    def __init__(self, *, result: bool) -> None:
+        self.result = result
+        self.scheduled = False
+
+    async def schedule(self) -> bool:
+        self.scheduled = True
+        return self.result
 
 
 @pytest.mark.asyncio
-async def test_completion_finishes_transport_then_schedules_restart() -> None:
-    restart_scheduler = MagicMock()
-    restart_scheduler.schedule = AsyncMock(return_value=True)
-    reporter = MagicMock()
-    status = MagicMock()
-    prepared_transport = MagicMock()
-    prepared_transport.complete_success = AsyncMock()
+async def test_completion_finishes_transport_then_schedules_restart(tmp_path: Path) -> None:
+    status = build_update_status_tracker(
+        state_store=UpdateStateStore(tmp_path / "update_status.json"),
+        status=UpdateJobStatus(state=UpdateState.running, phase=UpdatePhase.installing),
+    )
+    restart_scheduler = RecordingRestartScheduler(result=True)
+    prepared_transport = RecordingPreparedTransport()
     coordinator = UpdateCompletionCoordinator(
         restart_scheduler=restart_scheduler,
-        reporter=reporter,
+        reporter=UpdateTerminalStateReporter(status=status),
         status=status,
     )
 
@@ -26,24 +55,25 @@ async def test_completion_finishes_transport_then_schedules_restart() -> None:
         message="Update completed successfully",
     )
 
-    prepared_transport.complete_success.assert_awaited_once_with()
-    reporter.mark_success.assert_called_once_with("Update completed successfully")
-    restart_scheduler.schedule.assert_awaited_once_with()
-    status.add_issue.assert_not_called()
-    status.log.assert_not_called()
+    assert prepared_transport.completed is True
+    assert restart_scheduler.scheduled is True
+    assert status.status.state is UpdateState.success
+    assert status.status.terminal_state is UpdateTerminalState.success
+    assert status.status.log_tail == ["Update completed successfully"]
+    assert status.status.issues == []
 
 
 @pytest.mark.asyncio
-async def test_completion_records_issue_when_restart_scheduling_fails() -> None:
-    restart_scheduler = MagicMock()
-    restart_scheduler.schedule = AsyncMock(return_value=False)
-    reporter = MagicMock()
-    status = MagicMock()
-    prepared_transport = MagicMock()
-    prepared_transport.complete_success = AsyncMock()
+async def test_completion_records_issue_when_restart_scheduling_fails(tmp_path: Path) -> None:
+    status = build_update_status_tracker(
+        state_store=UpdateStateStore(tmp_path / "update_status.json"),
+        status=UpdateJobStatus(state=UpdateState.running, phase=UpdatePhase.checking),
+    )
+    restart_scheduler = RecordingRestartScheduler(result=False)
+    prepared_transport = RecordingPreparedTransport()
     coordinator = UpdateCompletionCoordinator(
         restart_scheduler=restart_scheduler,
-        reporter=reporter,
+        reporter=UpdateTerminalStateReporter(status=status),
         status=status,
     )
 
@@ -52,13 +82,17 @@ async def test_completion_records_issue_when_restart_scheduling_fails() -> None:
         message="No server update needed; ESP firmware checked",
     )
 
-    prepared_transport.complete_success.assert_awaited_once_with()
-    reporter.mark_success.assert_called_once_with(
+    assert prepared_transport.completed is True
+    assert restart_scheduler.scheduled is True
+    assert status.status.state is UpdateState.success
+    assert status.status.log_tail == [
         "No server update needed; ESP firmware checked",
-    )
-    status.add_issue.assert_called_once_with(
-        "done",
-        "Backend restart was not scheduled automatically",
-        "Run 'sudo systemctl restart vibesensor.service' manually",
-    )
-    status.log.assert_called_once_with("Automatic backend restart scheduling failed")
+        "Automatic backend restart scheduling failed",
+    ]
+    assert [(issue.phase, issue.message, issue.detail) for issue in status.status.issues] == [
+        (
+            "done",
+            "Backend restart was not scheduled automatically",
+            "Run 'sudo systemctl restart vibesensor.service' manually",
+        ),
+    ]

--- a/apps/server/tests/use_cases/updates/test_update_finalization.py
+++ b/apps/server/tests/use_cases/updates/test_update_finalization.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -9,13 +8,30 @@ from vibesensor.shared.exceptions import UpdateCleanupError
 from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 
 
+class RecordingTransportCoordinator:
+    def __init__(self, *, cleanup_error: UpdateCleanupError | None = None) -> None:
+        self.cleanup_error = cleanup_error
+        self.cleaned_transports: list[object | None] = []
+
+    async def cleanup_after_update(self, prepared_transport: object | None) -> None:
+        self.cleaned_transports.append(prepared_transport)
+        if self.cleanup_error is not None:
+            raise self.cleanup_error
+
+
+class RecordingRuntimeDetailsRefresher:
+    def __init__(self) -> None:
+        self.refreshed = False
+
+    async def refresh(self) -> None:
+        self.refreshed = True
+
+
 @pytest.mark.asyncio
 async def test_finalizer_cleans_up_transport_then_refreshes_runtime() -> None:
-    transport_coordinator = MagicMock()
-    transport_coordinator.cleanup_after_update = AsyncMock()
-    runtime_details_refresher = MagicMock()
-    runtime_details_refresher.refresh = AsyncMock()
-    prepared_transport = MagicMock()
+    transport_coordinator = RecordingTransportCoordinator()
+    runtime_details_refresher = RecordingRuntimeDetailsRefresher()
+    prepared_transport = object()
     finalizer = UpdateWorkflowFinalizer(
         transport_coordinator=transport_coordinator,
         runtime_details_refresher=runtime_details_refresher,
@@ -23,38 +39,34 @@ async def test_finalizer_cleans_up_transport_then_refreshes_runtime() -> None:
 
     await finalizer.finalize(prepared_transport)
 
-    transport_coordinator.cleanup_after_update.assert_awaited_once_with(prepared_transport)
-    runtime_details_refresher.refresh.assert_awaited_once_with()
+    assert transport_coordinator.cleaned_transports == [prepared_transport]
+    assert runtime_details_refresher.refreshed is True
 
 
 @pytest.mark.asyncio
 async def test_finalizer_adds_cleanup_note_to_prior_failure() -> None:
-    transport_coordinator = MagicMock()
-    transport_coordinator.cleanup_after_update = AsyncMock(
-        side_effect=UpdateCleanupError("transport cleanup failed"),
+    transport_coordinator = RecordingTransportCoordinator(
+        cleanup_error=UpdateCleanupError("transport cleanup failed"),
     )
-    runtime_details_refresher = MagicMock()
-    runtime_details_refresher.refresh = AsyncMock()
+    runtime_details_refresher = RecordingRuntimeDetailsRefresher()
     finalizer = UpdateWorkflowFinalizer(
         transport_coordinator=transport_coordinator,
         runtime_details_refresher=runtime_details_refresher,
     )
     workflow_error = RuntimeError("workflow bug")
 
-    await finalizer.finalize(MagicMock(), prior_error=workflow_error)
+    await finalizer.finalize(object(), prior_error=workflow_error)
 
     assert workflow_error.__notes__ == ["Cleanup also failed: transport cleanup failed"]
-    runtime_details_refresher.refresh.assert_not_awaited()
+    assert runtime_details_refresher.refreshed is False
 
 
 @pytest.mark.asyncio
 async def test_finalizer_raises_cleanup_error_when_cleanup_fails_after_cancellation() -> None:
-    transport_coordinator = MagicMock()
-    transport_coordinator.cleanup_after_update = AsyncMock(
-        side_effect=UpdateCleanupError("transport cleanup failed"),
+    transport_coordinator = RecordingTransportCoordinator(
+        cleanup_error=UpdateCleanupError("transport cleanup failed"),
     )
-    runtime_details_refresher = MagicMock()
-    runtime_details_refresher.refresh = AsyncMock()
+    runtime_details_refresher = RecordingRuntimeDetailsRefresher()
     finalizer = UpdateWorkflowFinalizer(
         transport_coordinator=transport_coordinator,
         runtime_details_refresher=runtime_details_refresher,
@@ -64,4 +76,4 @@ async def test_finalizer_raises_cleanup_error_when_cleanup_fails_after_cancellat
         UpdateCleanupError,
         match="Cleanup failed after cancellation: transport cleanup failed",
     ):
-        await finalizer.finalize(MagicMock(), prior_error=asyncio.CancelledError())
+        await finalizer.finalize(object(), prior_error=asyncio.CancelledError())

--- a/apps/server/tests/use_cases/updates/test_update_preparation.py
+++ b/apps/server/tests/use_cases/updates/test_update_preparation.py
@@ -15,7 +15,6 @@ from vibesensor.use_cases.updates.models import (
 from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
 from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.transport.coordinator import UpdateTransportCoordinator
 
 
 def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateRequest:
@@ -26,13 +25,30 @@ def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateReq
     )
 
 
+class RecordingTransportCoordinator:
+    def __init__(self, prepared_transport: object) -> None:
+        self.prepared_transport = prepared_transport
+        self.requests: list[UpdateRequest] = []
+        self.error: UpdateTransportError | None = None
+
+    async def prepare(self, request: UpdateRequest) -> object:
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.prepared_transport
+
+
 def _build_preparation(
     tmp_path: Path,
-) -> tuple[UpdatePreparationCoordinator, UpdateStatusTracker, AsyncMock, AsyncMock]:
+) -> tuple[
+    UpdatePreparationCoordinator,
+    UpdateStatusTracker,
+    object,
+    RecordingTransportCoordinator,
+]:
     status = build_update_status_harness(tmp_path / "state.json")
-    prepared_transport = AsyncMock()
-    transport_coordinator = MagicMock(spec=UpdateTransportCoordinator)
-    transport_coordinator.prepare = AsyncMock(return_value=prepared_transport)
+    prepared_transport = object()
+    transport_coordinator = RecordingTransportCoordinator(prepared_transport)
     preparation = UpdatePreparationCoordinator(
         status=status,
         commands=MagicMock(),
@@ -58,14 +74,14 @@ async def test_prepare_stops_after_validation_failure(tmp_path: Path) -> None:
     ):
         await preparation.prepare(_wifi_request())
 
-    transport_coordinator.prepare.assert_not_awaited()
+    assert transport_coordinator.requests == []
 
 
 @pytest.mark.asyncio
 async def test_prepare_stops_when_transport_cannot_prepare(tmp_path: Path) -> None:
     preparation, _tracker, _prepared_transport, transport_coordinator = _build_preparation(tmp_path)
     request = _wifi_request()
-    transport_coordinator.prepare.side_effect = UpdateTransportError("transport failed")
+    transport_coordinator.error = UpdateTransportError("transport failed")
 
     with (
         patch(
@@ -76,7 +92,7 @@ async def test_prepare_stops_when_transport_cannot_prepare(tmp_path: Path) -> No
     ):
         await preparation.prepare(request)
 
-    transport_coordinator.prepare.assert_awaited_once_with(request)
+    assert transport_coordinator.requests == [request]
 
 
 @pytest.mark.asyncio
@@ -91,5 +107,5 @@ async def test_prepare_returns_canonical_prepared_run(tmp_path: Path) -> None:
         prepared = await preparation.prepare(request)
 
     assert isinstance(prepared, PreparedUpdateRun)
-    transport_coordinator.prepare.assert_awaited_once_with(request)
+    assert transport_coordinator.requests == [request]
     assert prepared.prepared_transport is prepared_transport

--- a/apps/server/tests/use_cases/updates/test_update_workflow_planner.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_planner.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from vibesensor.shared.exceptions import UpdatePreparationError
@@ -18,13 +16,40 @@ def _request() -> UpdateRequest:
     )
 
 
-def _planner() -> tuple[UpdateWorkflowPlanner, MagicMock, MagicMock, PreparedUpdateRun]:
+class RecordingPreparation:
+    def __init__(self, prepared: PreparedUpdateRun) -> None:
+        self.prepared = prepared
+        self.requests: list[UpdateRequest] = []
+        self.error: UpdatePreparationError | None = None
+
+    async def prepare(self, request: UpdateRequest) -> PreparedUpdateRun:
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.prepared
+
+
+class RecordingReleasePlanner:
+    def __init__(self, result: PlannedUpdateRun) -> None:
+        self.result = result
+        self.prepared_runs: list[PreparedUpdateRun] = []
+
+    async def plan(self, prepared: PreparedUpdateRun) -> PlannedUpdateRun:
+        self.prepared_runs.append(prepared)
+        return self.result
+
+
+def _planner() -> tuple[
+    UpdateWorkflowPlanner,
+    RecordingPreparation,
+    RecordingReleasePlanner,
+    PreparedUpdateRun,
+    PlannedUpdateRun,
+]:
     prepared = PreparedUpdateRun(prepared_transport=object())
-    planning_result = MagicMock(spec=PlannedUpdateRun)
-    preparation = MagicMock()
-    preparation.prepare = AsyncMock(return_value=prepared)
-    release_planner = MagicMock()
-    release_planner.plan = AsyncMock(return_value=planning_result)
+    planning_result = PlannedUpdateRun(prepared=prepared, execution_plan=object())
+    preparation = RecordingPreparation(prepared)
+    release_planner = RecordingReleasePlanner(planning_result)
     return (
         UpdateWorkflowPlanner(
             preparation=preparation,
@@ -33,29 +58,30 @@ def _planner() -> tuple[UpdateWorkflowPlanner, MagicMock, MagicMock, PreparedUpd
         preparation,
         release_planner,
         prepared,
+        planning_result,
     )
 
 
 @pytest.mark.asyncio
 async def test_plan_prepares_transport_before_release_planning() -> None:
-    planner, preparation, release_planner, prepared = _planner()
+    planner, preparation, release_planner, prepared, planning_result = _planner()
     request = _request()
     observed: list[PreparedUpdateRun] = []
 
     result = await planner.plan(request, on_prepared=observed.append)
 
-    assert result is release_planner.plan.return_value
+    assert result is planning_result
     assert observed == [prepared]
-    preparation.prepare.assert_awaited_once_with(request)
-    release_planner.plan.assert_awaited_once_with(prepared)
+    assert preparation.requests == [request]
+    assert release_planner.prepared_runs == [prepared]
 
 
 @pytest.mark.asyncio
 async def test_plan_stops_before_release_planning_when_preparation_fails() -> None:
-    planner, preparation, release_planner, _prepared = _planner()
-    preparation.prepare.side_effect = UpdatePreparationError("validation failed")
+    planner, preparation, release_planner, _prepared, _planning_result = _planner()
+    preparation.error = UpdatePreparationError("validation failed")
 
     with pytest.raises(UpdatePreparationError, match="validation failed"):
         await planner.plan(_request())
 
-    release_planner.plan.assert_not_awaited()
+    assert release_planner.prepared_runs == []


### PR DESCRIPTION
Closes #3906

## What changed
- Replaced mock-call assertions with small stateful fakes in update workflow seam tests.
- Asserted observable outcomes: status state, issues, log tail, prepared transport results, staged deployment, and recorded recovery decisions.
- Merged overlapping startup recovery coverage into one interrupted-install scenario.

## Why
- The old tests mostly checked calls and call ordering.
- These paths are safer when tests prove durable update/runtime outcomes instead of internal wiring shape.

## Validation
- `pytest -q apps/server/tests/use_cases/updates/test_update_completion.py apps/server/tests/use_cases/updates/test_startup_recovery.py apps/server/tests/use_cases/updates/test_update_finalization.py apps/server/tests/use_cases/updates/test_update_workflow_planner.py apps/server/tests/use_cases/updates/test_firmware_refresh_execution.py apps/server/tests/use_cases/updates/test_server_release_execution.py apps/server/tests/use_cases/updates/test_update_preparation.py`
- `make lint`
- `make typecheck-backend`
- `make plan-validation`
- `tools/tests/plan_validation.py --run` reached an unrelated raw-capture queue flake in backend shard parallelism; the failed shard passed on rerun.

## Risks / tradeoffs
- Keeps mock assertions only in remaining hard-boundary tests outside this update/runtime seam cleanup.
- More local fake code, but assertions now follow observable behavior.

## Follow-ups
- None.