### PR TITLE
Make synthetic diagnostic matrices opt-in

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ This file is the canonical AI guidance entrypoint and short index. Preserve guar
 - Start with `make plan-validation`; run planned non-Docker jobs with `./.venv/bin/python tools/tests/plan_validation.py --run`, or use `--act` / `./tools/tests/run_ci_with_act.sh` only when GitHub workflow or Docker parity is needed.
 - Use `./tools/tests/run_ci_with_act.sh --full-stack` only when you must force all gated CI jobs.
 - Docs or instruction-only changes: run `make docs-lint` plus `make plan-validation`.
-- Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
+- Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`; broad synthetic matrices are opt-in via `make test-diagnostic-matrix`.
 - Backend API/contracts/shared UI constants: add `make sync-contracts` and `make ui-typecheck`.
 - Frontend logic/contracts/composition: `make ui-typecheck`; add `cd apps/ui && npm run build`, `npm run test:unit`, or `npm run test:visual` when the changed seam requires it.
 - Firmware: `cd firmware/esp && pio run`; for protocol/native parity add `python tools/firmware/generate_protocol_contract_fixtures.py --check` and `cd firmware/esp && pio test -e native`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean pristine format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean pristine format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay test-diagnostic-matrix plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -121,6 +121,10 @@ test-changed: ## Run heuristic checks for files changed vs origin/main
 test-golden-replay: ## Run fast generated dense post-run golden replay tests
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" -m pytest -q apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py
+
+test-diagnostic-matrix: ## Run opt-in broad synthetic diagnostic matrices excluded from default backend CI
+	@$(RESOLVE_PYTHON) \
+	"$$PYTHON" tools/tests/run_backend_parallel.py --include-diagnostic-matrix
 
 plan-validation: ## Plan changed-file validation from CI path rules
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -92,6 +92,7 @@ pythonpath = [".", "tests"]
 testpaths = ["tests"]
 markers = [
     "e2e: end-to-end tests",
+    "diagnostic_matrix: broad synthetic diagnostic matrices excluded from default backend CI",
     "long_sim: longer simulated-run tests (>20 s of synthetic data)",
     "smoke: minimal critical path checks",
     "benchmark: explicit performance regression benchmarks run outside default CI",

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -34,7 +34,10 @@ def _install_main_fakes(module, monkeypatch, tmp_path: Path) -> tuple[dict[str, 
     monkeypatch.setattr(
         module,
         "collect_test_ids",
-        lambda _pytest_args: ["apps/server/tests/app/test_app_main.py::test_fast"],
+        lambda pytest_args: (
+            captured.setdefault("collect_args", list(pytest_args))
+            and ["apps/server/tests/app/test_app_main.py::test_fast"]
+        ),
     )
     monkeypatch.setattr(module, "_load_duration_cache", lambda _path: {})
     monkeypatch.setattr(module, "_observed_durations_from_junit", lambda _path, _selected: {})
@@ -119,6 +122,8 @@ def test_main_builds_pytest_command_for_selected_backend_shard(
     assert command[:4] == [sys.executable, "-m", "pytest", "-q"]
     assert command[command.index("-n") + 1] == "3"
     assert command[command.index("--junitxml") + 1] == str(tmp_path / "backend-tests-1.xml")
+    assert captured["collect_args"] == ["-m", "not diagnostic_matrix", "apps/server/tests"]
+    assert command[command.index("-m", 2) + 1] == "not diagnostic_matrix"
     assert "apps/server/tests/app/test_app_main.py" in command
     assert any("running shard 1/1" in line for line in emitted)
 
@@ -141,6 +146,28 @@ def test_main_cli_overrides_env_xdist_workers(monkeypatch, tmp_path: Path) -> No
     assert module.main(["--xdist-workers", "2"]) == 0
 
     assert captured["cmd"][4:6] == ["-n", "2"]
+
+
+def test_main_can_include_diagnostic_matrix(monkeypatch, tmp_path: Path) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.delenv(module._INCLUDE_DIAGNOSTIC_MATRIX_ENV, raising=False)
+    captured, _emitted = _install_main_fakes(module, monkeypatch, tmp_path)
+
+    assert module.main(["--include-diagnostic-matrix"]) == 0
+
+    command = captured["cmd"]
+    assert captured["collect_args"] == ["apps/server/tests"]
+    assert "not diagnostic_matrix" not in command
+
+
+def test_main_reads_diagnostic_matrix_env(monkeypatch, tmp_path: Path) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.setenv(module._INCLUDE_DIAGNOSTIC_MATRIX_ENV, "1")
+    captured, _emitted = _install_main_fakes(module, monkeypatch, tmp_path)
+
+    assert module.main([]) == 0
+
+    assert captured["collect_args"] == ["apps/server/tests"]
 
 
 def test_main_passes_configured_shard_timeout(monkeypatch, tmp_path: Path) -> None:

--- a/apps/server/tests/integration/test_messy_real_world.py
+++ b/apps/server/tests/integration/test_messy_real_world.py
@@ -1,8 +1,7 @@
-"""Messy synthetic scenarios with optimized profile coverage.
+"""Opt-in messy synthetic diagnostic matrix.
 
 These tests keep the real-world data-quality dimensions that are distinct from
-the core scenario matrix while avoiding a full profile cross-product on every
-edge case.
+the core scenario matrix while staying out of default backend CI.
 """
 
 from __future__ import annotations
@@ -65,6 +64,8 @@ from test_support.diagnostic_matrix_catalogs import (
 from test_support.diagnostic_matrix_catalogs import (
     MESSY_CABIN_OVERLAP_MIXES as _CABIN_OVERLAP_MIXES,
 )
+
+pytestmark = pytest.mark.diagnostic_matrix
 
 # F.1 – Persistent wheel fault + sensor dropout (4 corners = 4 cases)
 

--- a/apps/server/tests/integration/test_multi_no_transient.py
+++ b/apps/server/tests/integration/test_multi_no_transient.py
@@ -1,8 +1,8 @@
-"""Multi-sensor steady scenarios that stay distinct after matrix consolidation.
+"""Opt-in multi-sensor steady diagnostic matrix.
 
 Representative corner/speed, no-fault baseline, and phased-onset coverage now
 lives in ``test_synthetic_scenario_matrix.py``. This module keeps the
-multi-sensor-specific steady-state behaviors that remain unique.
+multi-sensor-specific steady-state axes available outside default backend CI.
 """
 
 from __future__ import annotations
@@ -50,6 +50,8 @@ from test_support.diagnostic_matrix_catalogs import (
     DIAGNOSTIC_WEAK_SIGNAL_CORNERS,
     DIAGNOSTIC_WHEEL_CORNERS,
 )
+
+pytestmark = pytest.mark.diagnostic_matrix
 
 # Helpers
 

--- a/apps/server/tests/integration/test_multi_transient.py
+++ b/apps/server/tests/integration/test_multi_transient.py
@@ -1,8 +1,8 @@
-"""Multi-sensor transient scenarios that stay distinct after matrix consolidation.
+"""Opt-in multi-sensor transient diagnostic matrix.
 
 Representative corner/speed, no-fault baseline, and phased-onset coverage now
 lives in ``test_synthetic_scenario_matrix.py``. This module keeps the
-multi-sensor transient behaviors that remain unique.
+multi-sensor transient axes available outside default backend CI.
 """
 
 from __future__ import annotations
@@ -60,6 +60,8 @@ from test_support.diagnostic_matrix_catalogs import (
 from test_support.diagnostic_matrix_catalogs import (
     DIAGNOSTIC_WHEEL_CORNERS as _CORNERS,
 )
+
+pytestmark = pytest.mark.diagnostic_matrix
 
 # Helpers
 

--- a/apps/server/tests/integration/test_single_no_transient.py
+++ b/apps/server/tests/integration/test_single_no_transient.py
@@ -1,8 +1,8 @@
-"""Single-sensor synthetic scenarios that stay distinct after matrix consolidation.
+"""Opt-in single-sensor synthetic diagnostic matrix.
 
 Representative corner/speed, no-fault baseline, and phased-onset coverage now
 lives in ``test_synthetic_scenario_matrix.py``. This module keeps the
-single-sensor-specific behavior axes that still earn their own tests.
+single-sensor-specific behavior axes available outside default backend CI.
 """
 
 from __future__ import annotations
@@ -32,6 +32,8 @@ from test_support import (
     profile_metadata,
     run_analysis,
 )
+
+pytestmark = pytest.mark.diagnostic_matrix
 
 _CORNERS = ["FL", "FR", "RL", "RR"]
 _SPEEDS = [SPEED_LOW, SPEED_MID, SPEED_HIGH]

--- a/apps/server/tests/integration/test_single_transient.py
+++ b/apps/server/tests/integration/test_single_transient.py
@@ -1,8 +1,8 @@
-"""Single-sensor transient scenarios that stay distinct after matrix consolidation.
+"""Opt-in single-sensor transient diagnostic matrix.
 
 Representative steady-vs-transient corner/speed, no-fault baseline, and
 phased-onset coverage now lives in ``test_synthetic_scenario_matrix.py``.
-This module keeps the single-sensor transient behaviors that remain unique.
+This module keeps single-sensor transient axes available outside default backend CI.
 """
 
 from __future__ import annotations
@@ -31,6 +31,8 @@ from test_support import (
     profile_wheel_hz,
     run_analysis,
 )
+
+pytestmark = pytest.mark.diagnostic_matrix
 
 _CORNERS = ["FL", "FR", "RL", "RR"]
 _SPEEDS = [SPEED_LOW, SPEED_MID, SPEED_HIGH]

--- a/apps/server/tests/integration/test_weird_sensor_mix.py
+++ b/apps/server/tests/integration/test_weird_sensor_mix.py
@@ -1,7 +1,7 @@
-"""Weird-sensor-mix direct-injection tests.
+"""Opt-in weird-sensor-mix diagnostic matrix.
 
-154 parameterized cases covering ambiguity-aware localization with
-non-standard sensor topologies (cabin-only, mixed, sparse).
+Ambiguity-aware localization across non-standard topologies stays available
+outside default backend CI; the core matrix keeps default wheel/no-fault risks.
 """
 
 from __future__ import annotations
@@ -78,6 +78,8 @@ from test_support.diagnostic_matrix_catalogs import (
 )
 from test_support.fault_scenarios import make_fault_samples
 from test_support.sample_scenarios import make_diffuse_samples, make_noise_samples
+
+pytestmark = pytest.mark.diagnostic_matrix
 
 # ===================================================================
 # 1. test_cabin_only_no_exact_corner — 45 cases

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,6 +11,7 @@ High-traffic validation router. Keep this concise; use Makefile targets and scri
 - Fast broad gate: `make test-ci-fast` for lint, docs, static guards, and type checks without heavy suites.
 - Larger non-Docker gate: `make test-ci-lite` for workflow jobs except e2e.
 - Backend iteration: `make test` or targeted `pytest -q apps/server/tests/<module>/`.
+- Broad synthetic diagnostic matrices: `make test-diagnostic-matrix` (default backend CI excludes `diagnostic_matrix` cases).
 - UI validation: `make ui-typecheck`; add UI test/build commands below when the changed seam requires them.
 - Firmware and Pi image validation: use the narrow commands below; avoid hardware/full image builds unless required.
 - Local `shell-lint` parity needs host `shellcheck`; `make doctor` reports prerequisites. Use ACT for the workflow-managed install path.
@@ -24,6 +25,7 @@ make plan-validation
 
 make docs-lint
 make test-changed
+make test-diagnostic-matrix
 make test-ci-fast
 make test-ci-lite
 make test-all
@@ -77,6 +79,7 @@ Direct pytest benchmark runs need `-o addopts=''` so default xdist addopts do no
 - Temporary migration/absence tests must name the stable boundary they protect and be removed once positive current-behavior coverage exists.
 - New test-looking files must map to a runner or be explicitly allowed in `tools/dev/test_inventory_allowlist.yml`.
 - Marker policy lives in `tools/dev/test_marker_policy_allowlist.yml`. Use `smoke`, `long_sim`, and `e2e` sparingly.
+- `diagnostic_matrix` marks broad synthetic axis matrices; run them with `make test-diagnostic-matrix` or `tools/tests/run_backend_parallel.py --include-diagnostic-matrix`.
 - Oversized test/spec guardrails live in `tools/dev/check_hygiene.py`; intentional exceptions require a reason in `tools/dev/oversized_test_allowlist.yml`.
 - For cached helpers, clear caches in tests that monkeypatch underlying files, paths, or cached state.
 

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -49,6 +49,7 @@ LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci"
 _DURATION_CACHE_ENV = "VIBESENSOR_BACKEND_DURATION_CACHE"
 _XDIST_WORKERS_ENV = "VIBESENSOR_BACKEND_XDIST_WORKERS"
 _SHARD_TIMEOUT_ENV = "VIBESENSOR_BACKEND_SHARD_TIMEOUT_S"
+_INCLUDE_DIAGNOSTIC_MATRIX_ENV = "VIBESENSOR_INCLUDE_DIAGNOSTIC_MATRIX"
 _DEFAULT_DURATION = 1.0
 _DEFAULT_XDIST_WORKERS = 3
 _DEFAULT_SHARD_TIMEOUT_S = 900
@@ -96,6 +97,21 @@ def _shard_timeout_default(env: Mapping[str, str] | None = None) -> int:
     if value <= 0:
         raise SystemExit(f"{_SHARD_TIMEOUT_ENV} must be > 0")
     return value
+
+
+def _include_diagnostic_matrix_default(env: Mapping[str, str] | None = None) -> bool:
+    source = os.environ if env is None else env
+    raw = source.get(_INCLUDE_DIAGNOSTIC_MATRIX_ENV, "")
+    if raw == "":
+        return False
+    normalized = raw.lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(
+        f"{_INCLUDE_DIAGNOSTIC_MATRIX_ENV} must be one of 1/0, true/false, yes/no, or on/off"
+    )
 
 
 def _duration_cache_path(env: Mapping[str, str] | None = None) -> Path:
@@ -310,6 +326,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             f"{_SHARD_TIMEOUT_ENV} or {_DEFAULT_SHARD_TIMEOUT_S}."
         ),
     )
+    parser.add_argument(
+        "--include-diagnostic-matrix",
+        action="store_true",
+        default=_include_diagnostic_matrix_default(),
+        help=(
+            "Include tests marked diagnostic_matrix. Default backend CI excludes "
+            f"them unless {_INCLUDE_DIAGNOSTIC_MATRIX_ENV}=1."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
@@ -326,7 +351,10 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-    collected = collect_test_ids(["apps/server/tests"])
+    marker_args = (
+        [] if args.include_diagnostic_matrix else ["-m", "not diagnostic_matrix"]
+    )
+    collected = collect_test_ids([*marker_args, "apps/server/tests"])
     grouped_tests = _group_tests_by_path(collected)
 
     duration_cache_path = _duration_cache_path(os.environ)
@@ -373,6 +401,7 @@ def main(argv: list[str] | None = None) -> int:
         "--tb=short",
         "--junitxml",
         str(junit_path),
+        *marker_args,
         *selected_targets,
     ]
     started = time.monotonic()


### PR DESCRIPTION
## What changed
- Added a `diagnostic_matrix` pytest marker for broad synthetic integration matrices.
- Made `tools/tests/run_backend_parallel.py` exclude `diagnostic_matrix` by default for backend CI shards.
- Added explicit opt-ins: `--include-diagnostic-matrix`, `VIBESENSOR_INCLUDE_DIAGNOSTIC_MATRIX=1`, and `make test-diagnostic-matrix`.
- Marked broad single/multi/transient/messy/weird synthetic matrices as opt-in while keeping the representative synthetic matrix and multi-system overlap tests in default CI.
- Updated testing docs and AI validation routing.

## Why
The candidate synthetic integration set collected 730 cases with many repeated axes. Default backend CI now keeps 92 representative/default cases from that set, while the full 730-case matrix remains available when diagnostic depth is needed.

## Validation
- `pytest -q apps/server/tests/hygiene/test_run_backend_parallel.py`
- `pytest -q -m "not diagnostic_matrix" apps/server/tests/integration/test_synthetic_scenario_matrix.py apps/server/tests/integration/test_multi_system_overlap.py`
- `pytest -q -m diagnostic_matrix apps/server/tests/integration/test_single_no_transient.py -k "idle_only"`
- `make lint`
- `make typecheck-backend`
- `make plan-validation`
- `./.venv/bin/python tools/tests/plan_validation.py --run` (backend-tests-5 hit the known raw-capture queue-full flake; exact failures and backend-tests-5 rerun passed)

## Risks and edge cases
- Risk: a broad diagnostic axis no longer runs in default PR CI. Mitigation: the representative matrix stays in default CI, and full coverage is one explicit command/flag away.
- Direct pytest still runs marked tests unless callers use the backend CI runner default marker expression.

Closes #3910