### PR TITLE
Rationalize report copy assertions

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_document_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_document_evidence.py
@@ -8,12 +8,17 @@ from test_support.report_helpers import (
     minimal_summary,
 )
 
+from vibesensor import report_i18n
 from vibesensor.shared.boundaries.reporting import (
     prepare_persisted_report_input,
     prepare_report_input,
 )
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def _tr(key: str, **kwargs: object) -> str:
+    return report_i18n.tr("en", key, **kwargs)
 
 
 def test_build_report_document_surfaces_evidence_snapshot_rows() -> None:
@@ -95,25 +100,47 @@ def test_build_report_document_surfaces_evidence_snapshot_rows() -> None:
     data = build_report_document(prepared)
 
     assert [row.label for row in data.verdict_page.proof_snapshot_rows] == [
-        "Confidence",
-        "Evidence basis",
-        "Support",
-        "Stable frequency",
+        _tr("CONFIDENCE_LABEL"),
+        _tr("REPORT_EVIDENCE_BASIS_LABEL"),
+        _tr("REPORT_SUPPORT_WINDOW_SUMMARY_LABEL"),
+        _tr("REPORT_STABLE_FREQUENCY_LABEL"),
     ]
-    assert "Medium (" in data.verdict_page.proof_snapshot_rows[0].value
-    assert "Raw-backed replay" in data.verdict_page.proof_snapshot_rows[1].value
-    assert data.verdict_page.proof_snapshot_rows[2].value == "3 supporting windows"
-    assert data.verdict_page.proof_snapshot_rows[3].value == "15.1-15.4 Hz matched band"
+    assert data.verdict_page.proof_snapshot_rows[0].value.startswith(
+        f"{_tr('CONFIDENCE_MEDIUM')} ("
+    )
+    assert data.verdict_page.proof_snapshot_rows[1].value == _tr(
+        "REPORT_EVIDENCE_BASIS_RAW",
+        samples="24",
+    )
+    assert data.verdict_page.proof_snapshot_rows[2].value == _tr(
+        "REPORT_SUPPORT_WINDOW_SUMMARY_COUNT_ONLY",
+        count="3",
+    )
+    assert data.verdict_page.proof_snapshot_rows[3].value == _tr(
+        "REPORT_STABLE_FREQUENCY_BAND",
+        low="15.1",
+        high="15.4",
+    )
     assert [row.label for row in data.appendix_c.evidence_snapshot_rows] == [
-        "Confidence",
-        "Evidence basis",
-        "Support",
-        "Stable frequency",
-        "Strongest sensors",
-        "Caveat",
+        _tr("CONFIDENCE_LABEL"),
+        _tr("REPORT_EVIDENCE_BASIS_LABEL"),
+        _tr("REPORT_SUPPORT_WINDOW_SUMMARY_LABEL"),
+        _tr("REPORT_STABLE_FREQUENCY_LABEL"),
+        _tr("REPORT_SUPPORTING_SENSORS_LABEL"),
+        _tr("REPORT_COUNTEREVIDENCE_LABEL"),
     ]
-    assert data.appendix_c.evidence_snapshot_rows[4].value == "Front-Left (2), Rear-Left (1)"
-    assert "driveline" in data.appendix_c.evidence_snapshot_rows[5].value.lower()
+    assert data.appendix_c.evidence_snapshot_rows[4].value == ", ".join(
+        [
+            _tr("REPORT_SUPPORTING_SENSOR_ENTRY", location="Front-Left", count="2"),
+            _tr("REPORT_SUPPORTING_SENSOR_ENTRY", location="Rear-Left", count="1"),
+        ]
+    )
+    assert data.appendix_c.evidence_snapshot_rows[5].value == "; ".join(
+        [
+            _tr("REPORT_COUNTEREVIDENCE_ALT_SOURCE", source="Driveline"),
+            _tr("REPORT_COUNTEREVIDENCE_WEAK_SPATIAL"),
+        ]
+    )
 
 
 def test_build_report_document_focuses_appendix_c_on_primary_proof_windows() -> None:
@@ -281,7 +308,8 @@ def test_build_report_document_uses_supporting_window_location_proof_in_appendix
     assert data.proof_location_hotspot_rows[0].location == "Front Left"
     assert data.appendix_b.dominant_corner == "Front-Left"
     assert data.appendix_b.runner_up_corner == "Rear-Left"
-    assert "raw-backed replay" in (data.appendix_b.proof_basis_note or "").lower()
+    assert prepared.report_facts.evidence.data_basis == "raw_backed"
+    assert prepared.report_facts.evidence.raw_backed_sample_count == 24
 
 
 def test_build_report_document_builds_sensor_observation_matrix_rows() -> None:

--- a/apps/server/tests/use_cases/history/test_report_confidence_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_confidence_facts.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
+from vibesensor import report_i18n
 from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def _tr(key: str, **kwargs: object) -> str:
+    return report_i18n.tr("en", key, **kwargs)
 
 
 def test_prepare_persisted_report_input_builds_high_confidence_from_raw_backed_signals() -> None:
@@ -121,9 +126,11 @@ def test_prepare_persisted_report_input_builds_high_confidence_from_raw_backed_s
     assert "stable_frequency" in confidence.signal_keys
     assert "localized_support" in confidence.signal_keys
     assert confidence.caveat_keys == ()
-    assert data.observed.certainty_label == "High"
-    assert "raw-backed replay confirmed the match" in data.observed.certainty_reason
-    assert data.verdict_page.proof_snapshot_rows[0].label == "Confidence"
+    assert confidence.raw_backed_sample_count == 48
+    assert confidence.top_support_location == "Front Left"
+    assert data.observed.certainty_label == _tr(confidence.label_key)
+    assert data.observed.certainty_reason
+    assert data.verdict_page.proof_snapshot_rows[0].label == _tr("CONFIDENCE_LABEL")
 
 
 def test_prepare_persisted_report_input_builds_low_confidence_from_mixed_summary_only_signals() -> (
@@ -205,9 +212,10 @@ def test_prepare_persisted_report_input_builds_low_confidence_from_mixed_summary
     assert "summary_only" in confidence.caveat_keys
     assert "close_alternative" in confidence.caveat_keys
     assert "mixed_support_locations" in confidence.caveat_keys
-    assert data.observed.certainty_label == "Low"
-    assert "only summary-level evidence was available" in data.observed.certainty_reason
-    assert "matched frequency drifted across 12.1-15.6 Hz" in data.observed.certainty_reason
+    assert data.observed.certainty_label == _tr(confidence.label_key)
+    assert confidence.stable_frequency_min_hz == 12.1
+    assert confidence.stable_frequency_max_hz == 15.6
+    assert data.observed.certainty_reason
     assert data.verdict_page.also_consider == "Driveline"
 
 
@@ -335,8 +343,8 @@ def test_prepare_persisted_report_input_adds_whole_run_context_gap_caveats() -> 
     assert [warning.code for warning in prepared.report_facts.decision.warnings] == [
         "whole_run_context_incomplete"
     ]
-    assert "speed context was missing or stale" in data.observed.certainty_reason
-    assert "RPM context was missing or stale" in data.observed.certainty_reason
+    assert _tr("REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS") in data.observed.certainty_reason
+    assert _tr("REPORT_CONFIDENCE_CAVEAT_RPM_CONTEXT_GAPS") in data.observed.certainty_reason
 
 
 def test_prepare_persisted_report_input_marks_legacy_raw_backed_context_fallback() -> None:
@@ -423,4 +431,4 @@ def test_prepare_persisted_report_input_marks_legacy_raw_backed_context_fallback
     assert [warning.code for warning in prepared.report_facts.decision.warnings] == [
         "whole_run_context_legacy_fallback"
     ]
-    assert "predates whole-run context coverage tracking" in data.observed.certainty_reason
+    assert _tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT") in data.observed.certainty_reason

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
@@ -3,8 +3,47 @@ from __future__ import annotations
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
+from vibesensor import report_i18n
 from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def _tr(key: str, **kwargs: object) -> str:
+    return report_i18n.tr("en", key, **kwargs)
+
+
+def _support_quality_reason(
+    *,
+    count: str,
+    duration: str,
+    quality_text: str,
+) -> str:
+    return "; ".join(
+        [
+            _tr("REPORT_SUPPORT_WINDOW_SUMMARY_FULL", count=count, duration=duration),
+            quality_text,
+        ]
+    )
+
+
+def _assert_whole_run_candidate_reasons(document: ReportDocument) -> None:
+    appendix_a = document.appendix_a
+    assert appendix_a.ranked_candidates[0].reason == _support_quality_reason(
+        count="12",
+        duration="6.0",
+        quality_text=_tr(
+            "REPORT_FINDING_DATA_QUALITY_LIMITED",
+            usable="10",
+            excluded="1",
+            limitations=_tr("REPORT_DATA_QUALITY_LIMIT_SPEED_CONTEXT"),
+        ),
+    )
+    assert appendix_a.ranked_candidates[1].reason == _support_quality_reason(
+        count="9",
+        duration="4.5",
+        quality_text=_tr("REPORT_FINDING_DATA_QUALITY_CLEAN", usable="9", excluded="0"),
+    )
 
 
 def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() -> None:
@@ -187,9 +226,7 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
     assert document.appendix_b.runner_up_corner == "Front-Left"
     assert document.appendix_a.ranked_candidates[0].source_name == "Driveline"
     assert document.appendix_a.ranked_candidates[1].source_name == "Wheel / Tire"
-    assert "quality limited" in document.appendix_a.ranked_candidates[0].reason
-    assert "speed context" in document.appendix_a.ranked_candidates[0].reason
-    assert "quality clean" in document.appendix_a.ranked_candidates[1].reason
+    _assert_whole_run_candidate_reasons(document)
     assert prepared.report_facts.confidence.signal_keys == ("raw_backed",)
     assert prepared.report_facts.confidence.caveat_keys == ("close_alternative",)
     assert any(


### PR DESCRIPTION
## What changed
- Kept report i18n/catalog tests as the copy owner.
- Replaced hard-coded English report copy in document/PDF tests with semantic assertions or `report_i18n.tr("en", ...)` expectations.
- Extracted expected whole-run candidate reason construction so the report test stays under the function-size guard.

## Why
- Issue #3912 asks to avoid updating duplicate document/PDF tests when report wording changes.

## Validation
- `pytest -q apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_report_document_evidence.py apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py apps/server/tests/use_cases/history/test_report_confidence_facts.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_summary_view.py`
- `pytest -q apps/server/tests/adapters/pdf/test_report_document_evidence.py apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py apps/server/tests/use_cases/history/test_report_confidence_facts.py`
- `make lint`
- `make typecheck-backend`
- `make plan-validation`
- `./.venv/bin/python tools/tests/plan_validation.py --run` (backend-tests-4 hit unrelated raw-capture and worker-pool timing flakes; exact tests and shard rerun passed)

## Risks / tradeoffs / edge cases
- These tests still verify rendered structure and catalog-driven strings, but no longer pin duplicate literal English wording.
- No runtime code changed.

Closes #3912