### PR TITLE
Move firmware bundle validation tests to owner

### DIFF
--- a/apps/server/tests/test_support/firmware_bundles.py
+++ b/apps/server/tests/test_support/firmware_bundles.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+def write_firmware_bundle(bundle_dir: Path, *, environment: str = "m5stack_atom") -> None:
+    env_dir = bundle_dir / environment
+    env_dir.mkdir(parents=True, exist_ok=True)
+    binaries = {}
+    for name in ("bootloader.bin", "partitions.bin", "firmware.bin"):
+        content = f"fake-{name}".encode()
+        (env_dir / name).write_bytes(content)
+        binaries[name] = hashlib.sha256(content).hexdigest()
+
+    manifest = {
+        "generated_from": "test",
+        "environments": [
+            {
+                "name": environment,
+                "segments": [
+                    {
+                        "file": f"{environment}/firmware.bin",
+                        "offset": "0x10000",
+                        "sha256": binaries["firmware.bin"],
+                    },
+                    {
+                        "file": f"{environment}/bootloader.bin",
+                        "offset": "0x1000",
+                        "sha256": binaries["bootloader.bin"],
+                    },
+                    {
+                        "file": f"{environment}/partitions.bin",
+                        "offset": "0x8000",
+                        "sha256": binaries["partitions.bin"],
+                    },
+                ],
+            },
+        ],
+    }
+    (bundle_dir / "flash.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")

--- a/apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 from test_support import response_payload
+from test_support.firmware_bundles import write_firmware_bundle
 
 from vibesensor.adapters.http.updates import create_update_routes
 from vibesensor.shared.exceptions import ConfigurationError, UpdateError
@@ -18,7 +18,6 @@ from vibesensor.use_cases.updates.firmware.esp_flash_types import (
     SerialPortInfo,
     SerialPortProvider,
 )
-from vibesensor.use_cases.updates.firmware.firmware_bundle import validate_bundle
 from vibesensor.use_cases.updates.firmware.firmware_cache import FirmwareCache
 from vibesensor.use_cases.updates.firmware.firmware_types import FirmwareCacheConfig
 
@@ -91,49 +90,12 @@ def _assert_no_platformio_invocation(calls: list[list[str]]) -> None:
             assert call[1:3] != ["-m", "platformio"], f"PlatformIO module invoked: {call}"
 
 
-def _make_bundle(bundle_dir: Path) -> None:
-    """Create a valid firmware bundle with flash.json manifest and binaries."""
-    env_dir = bundle_dir / "m5stack_atom"
-    env_dir.mkdir(parents=True, exist_ok=True)
-    bins = {}
-    for name in ("bootloader.bin", "partitions.bin", "firmware.bin"):
-        content = f"fake-{name}".encode()
-        (env_dir / name).write_bytes(content)
-        bins[name] = hashlib.sha256(content).hexdigest()
-    manifest = {
-        "generated_from": "test",
-        "environments": [
-            {
-                "name": "m5stack_atom",
-                "segments": [
-                    {
-                        "file": "m5stack_atom/firmware.bin",
-                        "offset": "0x10000",
-                        "sha256": bins["firmware.bin"],
-                    },
-                    {
-                        "file": "m5stack_atom/bootloader.bin",
-                        "offset": "0x1000",
-                        "sha256": bins["bootloader.bin"],
-                    },
-                    {
-                        "file": "m5stack_atom/partitions.bin",
-                        "offset": "0x8000",
-                        "sha256": bins["partitions.bin"],
-                    },
-                ],
-            },
-        ],
-    }
-    (bundle_dir / "flash.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
-
-
 def _make_cache(tmp_path: Path, *, with_current: bool = False, with_baseline: bool = False) -> Path:
     """Create a firmware cache directory with optional current/baseline bundles."""
     cache_dir = tmp_path / "fw-cache"
     cache_dir.mkdir(parents=True, exist_ok=True)
     if with_current:
-        _make_bundle(cache_dir / "current")
+        write_firmware_bundle(cache_dir / "current")
         meta = {
             "tag": "fw-main-abc1234",
             "asset": "vibesensor-fw-main-abc1234.zip",
@@ -146,7 +108,7 @@ def _make_cache(tmp_path: Path, *, with_current: bool = False, with_baseline: bo
             encoding="utf-8",
         )
     if with_baseline:
-        _make_bundle(cache_dir / "baseline")
+        write_firmware_bundle(cache_dir / "baseline")
         meta = {
             "tag": "baseline",
             "asset": "embedded",
@@ -200,40 +162,6 @@ def _patch_esptool_which(monkeypatch) -> None:
         "shutil.which",
         lambda name: "/usr/bin/esptool.py" if name == "esptool.py" else None,
     )
-
-
-# ── Firmware Cache Tests ──
-
-
-def test_validate_bundle_succeeds(tmp_path: Path) -> None:
-    bundle_dir = tmp_path / "bundle"
-    _make_bundle(bundle_dir)
-    manifest = validate_bundle(bundle_dir)
-    assert len(manifest.environments) == 1
-    assert manifest.environments[0].name == "m5stack_atom"
-
-
-def test_validate_bundle_fails_missing_manifest(tmp_path: Path) -> None:
-    bundle_dir = tmp_path / "empty"
-    bundle_dir.mkdir()
-    with pytest.raises(ValueError, match="missing manifest"):
-        validate_bundle(bundle_dir)
-
-
-def test_validate_bundle_fails_missing_binary(tmp_path: Path) -> None:
-    bundle_dir = tmp_path / "bundle"
-    _make_bundle(bundle_dir)
-    (bundle_dir / "m5stack_atom" / "firmware.bin").unlink()
-    with pytest.raises(ValueError, match="missing referenced binary"):
-        validate_bundle(bundle_dir)
-
-
-def test_validate_bundle_fails_checksum_mismatch(tmp_path: Path) -> None:
-    bundle_dir = tmp_path / "bundle"
-    _make_bundle(bundle_dir)
-    (bundle_dir / "m5stack_atom" / "firmware.bin").write_bytes(b"corrupted")
-    with pytest.raises(ValueError, match="Checksum mismatch"):
-        validate_bundle(bundle_dir)
 
 
 def test_cache_active_bundle_uses_current_over_baseline(tmp_path: Path) -> None:

--- a/apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from test_support.firmware_bundles import write_firmware_bundle
 
 from vibesensor.use_cases.updates.firmware.firmware_bundle import (
     flash_manifest_record_from_json,
@@ -77,4 +78,40 @@ def test_validate_bundle_rejects_corrupt_manifest_json(tmp_path: Path) -> None:
     (bundle_dir / "flash.json").write_text("{not-json", encoding="utf-8")
 
     with pytest.raises(ValueError, match="Firmware manifest is corrupt"):
+        validate_bundle(bundle_dir)
+
+
+def test_validate_bundle_succeeds(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    write_firmware_bundle(bundle_dir)
+
+    manifest = validate_bundle(bundle_dir)
+
+    assert len(manifest.environments) == 1
+    assert manifest.environments[0].name == "m5stack_atom"
+
+
+def test_validate_bundle_fails_missing_manifest(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "empty"
+    bundle_dir.mkdir()
+
+    with pytest.raises(ValueError, match="missing manifest"):
+        validate_bundle(bundle_dir)
+
+
+def test_validate_bundle_fails_missing_binary(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    write_firmware_bundle(bundle_dir)
+    (bundle_dir / "m5stack_atom" / "firmware.bin").unlink()
+
+    with pytest.raises(ValueError, match="missing referenced binary"):
+        validate_bundle(bundle_dir)
+
+
+def test_validate_bundle_fails_checksum_mismatch(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    write_firmware_bundle(bundle_dir)
+    (bundle_dir / "m5stack_atom" / "firmware.bin").write_bytes(b"corrupted")
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
         validate_bundle(bundle_dir)


### PR DESCRIPTION
## What changed
- Moved direct validate_bundle success and failure coverage from the ESP flash manager tests into the firmware bundle test owner.
- Added a shared test_support firmware bundle writer for valid cached bundle fixtures.
- Kept flash-manager tests focused on cached bundle runtime behavior and flash lifecycle outcomes.

## Why
- Issue #3914: firmware bundle validation rules were split across the bundle module tests and flash-manager tests.
- Bundle manifest, missing file, and checksum rules now have one primary test owner.

## Validation
- pytest -q apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py apps/server/tests/use_cases/updates/firmware/test_firmware_cache.py apps/server/tests/use_cases/updates/firmware/test_firmware_cache_refresh.py apps/server/tests/use_cases/updates/releases/test_release_validation.py apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/adapters/http/test_update_endpoints.py
- make lint
- make typecheck-backend
- make plan-validation
- ./.venv/bin/python tools/tests/plan_validation.py --run (backend-tests-5 hit known unrelated raw-capture queue flake; exact failing tests and backend-tests-5 rerun passed)

## Risks / tradeoffs
- Test-only change.
- Scope is intentionally narrow: full update manager and API behavior remains unchanged, while pure bundle validation has a single owner.

Closes #3914