### PR TITLE
Isolate dev tooling pytest coverage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ This file is the canonical AI guidance entrypoint and short index. Preserve guar
 - Start with `make plan-validation`; run planned non-Docker jobs with `./.venv/bin/python tools/tests/plan_validation.py --run`, or use `--act` / `./tools/tests/run_ci_with_act.sh` only when GitHub workflow or Docker parity is needed.
 - Use `./tools/tests/run_ci_with_act.sh --full-stack` only when you must force all gated CI jobs.
 - Docs or instruction-only changes: run `make docs-lint` plus `make plan-validation`.
-- Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`; broad synthetic matrices are opt-in via `make test-diagnostic-matrix`.
+- Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`; broad synthetic matrices use `make test-diagnostic-matrix`, and dev/CI tooling tests use `make test-tooling`.
 - Backend API/contracts/shared UI constants: add `make sync-contracts` and `make ui-typecheck`.
 - Frontend logic/contracts/composition: `make ui-typecheck`; add `cd apps/ui && npm run build`, `npm run test:unit`, or `npm run test:visual` when the changed seam requires it.
 - Firmware: `cd firmware/esp && pio run`; for protocol/native parity add `python tools/firmware/generate_protocol_contract_fixtures.py --check` and `cd firmware/esp && pio test -e native`.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -12,4 +12,5 @@ Backend test rules. Use `docs/testing.md` for the concise test map and command r
 - Do not create per-file fake runtime classes. Use shared `FakeState` from `conftest.py` and customize it via constructor arguments.
 - Do not add private production bridge/shim methods solely for test access; test sub-components directly.
 - Oversized test/spec guardrails live in `tools/dev/check_hygiene.py`; intentional exceptions belong in `tools/dev/oversized_test_allowlist.yml`.
+- Mark dev/CI tooling orchestration tests `dev_tooling`; default backend shards exclude them, and `make test-tooling` runs them.
 - Focused validation: `pytest -q apps/server/tests/<module>/` from repo root, or `../.venv/bin/python -m pytest tests/<module>/ -q` from `apps/server` when the repo-managed backend environment must be pinned.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,6 +626,37 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  backend-tooling-tests:
+    name: Backend tooling tests
+    needs:
+      - ci-scope
+    if: ${{ needs.ci-scope.outputs.run_backend_tests == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up configured backend Python runtime
+        uses: ./.github/actions/setup-backend
+
+      - name: Prepare backend tooling test artifacts
+        run: mkdir -p artifacts/ai/logs/ci
+
+      - name: Backend tooling tests
+        run: >-
+          python -m pytest -q -m dev_tooling apps/server/tests/hygiene
+          --junitxml artifacts/ai/logs/ci/backend-tooling-tests.xml
+
+      - name: Upload backend tooling test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-tooling-test-artifacts
+          path: artifacts/ai/logs/ci/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e:
     name: E2E
     needs:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean pristine format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay test-diagnostic-matrix plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean pristine format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay test-diagnostic-matrix test-tooling plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -112,7 +112,7 @@ typecheck: typecheck-backend ui-typecheck
 
 test: ## Run the fast backend pytest suite
 	@$(RESOLVE_PYTHON) \
-	"$$PYTHON" -m pytest -q apps/server/tests
+	"$$PYTHON" -m pytest -q -m "not dev_tooling" apps/server/tests
 
 test-changed: ## Run heuristic checks for files changed vs origin/main
 	@$(RESOLVE_PYTHON) \
@@ -125,6 +125,10 @@ test-golden-replay: ## Run fast generated dense post-run golden replay tests
 test-diagnostic-matrix: ## Run opt-in broad synthetic diagnostic matrices excluded from default backend CI
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/run_backend_parallel.py --include-diagnostic-matrix
+
+test-tooling: ## Run developer/CI tooling tests excluded from default backend shards
+	@$(RESOLVE_PYTHON) \
+	"$$PYTHON" -m pytest -q -m dev_tooling apps/server/tests/hygiene
 
 plan-validation: ## Plan changed-file validation from CI path rules
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -92,6 +92,7 @@ pythonpath = [".", "tests"]
 testpaths = ["tests"]
 markers = [
     "e2e: end-to-end tests",
+    "dev_tooling: developer/CI tooling orchestration tests excluded from default backend shards",
     "diagnostic_matrix: broad synthetic diagnostic matrices excluded from default backend CI",
     "long_sim: longer simulated-run tests (>20 s of synthetic data)",
     "smoke: minimal critical path checks",

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -9,9 +9,12 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
 from tests._paths import REPO_ROOT
 
 _CI_PARALLEL = REPO_ROOT / "tools" / "tests" / "run_ci_parallel.py"
+pytestmark = pytest.mark.dev_tooling
 
 
 def _load_ci_parallel_module():

--- a/apps/server/tests/hygiene/test_main_release_scripts.py
+++ b/apps/server/tests/hygiene/test_main_release_scripts.py
@@ -16,6 +16,7 @@ import pytest
 from tests._paths import REPO_ROOT
 
 _MAIN_RELEASE_SCRIPT = REPO_ROOT / "tools" / "release" / "main_release.py"
+pytestmark = pytest.mark.dev_tooling
 
 
 def _load_main_release_module():

--- a/apps/server/tests/hygiene/test_publish_github_release.py
+++ b/apps/server/tests/hygiene/test_publish_github_release.py
@@ -6,9 +6,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from tests._paths import REPO_ROOT
 
 _PUBLISH_RELEASE = REPO_ROOT / "tools" / "publish_github_release.py"
+pytestmark = pytest.mark.dev_tooling
 
 
 def _load_publish_github_release_module():

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -7,12 +7,14 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tests._paths import REPO_ROOT
 
 _CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _RUN_BACKEND_PARALLEL = REPO_ROOT / "tools" / "tests" / "run_backend_parallel.py"
+pytestmark = pytest.mark.dev_tooling
 
 
 def _load_run_backend_parallel_module():
@@ -122,8 +124,9 @@ def test_main_builds_pytest_command_for_selected_backend_shard(
     assert command[:4] == [sys.executable, "-m", "pytest", "-q"]
     assert command[command.index("-n") + 1] == "3"
     assert command[command.index("--junitxml") + 1] == str(tmp_path / "backend-tests-1.xml")
-    assert captured["collect_args"] == ["-m", "not diagnostic_matrix", "apps/server/tests"]
-    assert command[command.index("-m", 2) + 1] == "not diagnostic_matrix"
+    excluded_markers = "not diagnostic_matrix and not dev_tooling"
+    assert captured["collect_args"] == ["-m", excluded_markers, "apps/server/tests"]
+    assert command[command.index("-m", 2) + 1] == excluded_markers
     assert "apps/server/tests/app/test_app_main.py" in command
     assert any("running shard 1/1" in line for line in emitted)
 
@@ -156,7 +159,7 @@ def test_main_can_include_diagnostic_matrix(monkeypatch, tmp_path: Path) -> None
     assert module.main(["--include-diagnostic-matrix"]) == 0
 
     command = captured["cmd"]
-    assert captured["collect_args"] == ["apps/server/tests"]
+    assert captured["collect_args"] == ["-m", "not dev_tooling", "apps/server/tests"]
     assert "not diagnostic_matrix" not in command
 
 
@@ -167,7 +170,29 @@ def test_main_reads_diagnostic_matrix_env(monkeypatch, tmp_path: Path) -> None:
 
     assert module.main([]) == 0
 
-    assert captured["collect_args"] == ["apps/server/tests"]
+    assert captured["collect_args"] == ["-m", "not dev_tooling", "apps/server/tests"]
+
+
+def test_main_can_include_dev_tooling(monkeypatch, tmp_path: Path) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.delenv(module._INCLUDE_DEV_TOOLING_ENV, raising=False)
+    captured, _emitted = _install_main_fakes(module, monkeypatch, tmp_path)
+
+    assert module.main(["--include-dev-tooling"]) == 0
+
+    command = captured["cmd"]
+    assert captured["collect_args"] == ["-m", "not diagnostic_matrix", "apps/server/tests"]
+    assert "not dev_tooling" not in command
+
+
+def test_main_reads_dev_tooling_env(monkeypatch, tmp_path: Path) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.setenv(module._INCLUDE_DEV_TOOLING_ENV, "1")
+    captured, _emitted = _install_main_fakes(module, monkeypatch, tmp_path)
+
+    assert module.main([]) == 0
+
+    assert captured["collect_args"] == ["-m", "not diagnostic_matrix", "apps/server/tests"]
 
 
 def test_main_passes_configured_shard_timeout(monkeypatch, tmp_path: Path) -> None:

--- a/apps/server/tests/hygiene/test_run_e2e_parallel.py
+++ b/apps/server/tests/hygiene/test_run_e2e_parallel.py
@@ -7,9 +7,12 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import pytest
+
 from tests._paths import REPO_ROOT
 
 _RUN_E2E_PARALLEL = REPO_ROOT / "tools" / "tests" / "run_e2e_parallel.py"
+pytestmark = pytest.mark.dev_tooling
 
 
 def _load_run_e2e_parallel_module():

--- a/apps/server/tests/hygiene/test_watch_pr_checks.py
+++ b/apps/server/tests/hygiene/test_watch_pr_checks.py
@@ -11,6 +11,7 @@ import pytest
 from tests._paths import REPO_ROOT
 
 _WATCH_PR_CHECKS = REPO_ROOT / "tools" / "watch_pr_checks.py"
+pytestmark = pytest.mark.dev_tooling
 
 
 def _load_watch_pr_checks_module():

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,7 @@ High-traffic validation router. Keep this concise; use Makefile targets and scri
 - Larger non-Docker gate: `make test-ci-lite` for workflow jobs except e2e.
 - Backend iteration: `make test` or targeted `pytest -q apps/server/tests/<module>/`.
 - Broad synthetic diagnostic matrices: `make test-diagnostic-matrix` (default backend CI excludes `diagnostic_matrix` cases).
+- Dev/CI tooling orchestration tests: `make test-tooling` (default backend shards exclude `dev_tooling` cases).
 - UI validation: `make ui-typecheck`; add UI test/build commands below when the changed seam requires them.
 - Firmware and Pi image validation: use the narrow commands below; avoid hardware/full image builds unless required.
 - Local `shell-lint` parity needs host `shellcheck`; `make doctor` reports prerequisites. Use ACT for the workflow-managed install path.
@@ -26,6 +27,7 @@ make plan-validation
 make docs-lint
 make test-changed
 make test-diagnostic-matrix
+make test-tooling
 make test-ci-fast
 make test-ci-lite
 make test-all
@@ -80,6 +82,7 @@ Direct pytest benchmark runs need `-o addopts=''` so default xdist addopts do no
 - New test-looking files must map to a runner or be explicitly allowed in `tools/dev/test_inventory_allowlist.yml`.
 - Marker policy lives in `tools/dev/test_marker_policy_allowlist.yml`. Use `smoke`, `long_sim`, and `e2e` sparingly.
 - `diagnostic_matrix` marks broad synthetic axis matrices; run them with `make test-diagnostic-matrix` or `tools/tests/run_backend_parallel.py --include-diagnostic-matrix`.
+- `dev_tooling` marks developer/CI tooling orchestration tests; run them with `make test-tooling`. Default backend shards and `make test` exclude them.
 - Oversized test/spec guardrails live in `tools/dev/check_hygiene.py`; intentional exceptions require a reason in `tools/dev/oversized_test_allowlist.yml`.
 - For cached helpers, clear caches in tests that monkeypatch underlying files, paths, or cached state.
 
@@ -135,6 +138,7 @@ Use the wrapper unless raw ACT flags are necessary. The default wrapper mode is 
 ./tools/tests/run_ci_with_act.sh --full-stack
 ./tools/tests/run_ci_with_act.sh -j backend-lint
 ./tools/tests/run_ci_with_act.sh -j backend-tests
+./tools/tests/run_ci_with_act.sh -j backend-tooling-tests
 ./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 ```
 
@@ -147,11 +151,12 @@ act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
 act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json --env VIBESENSOR_CI_FORCE_FULL_STACK=1
 act -j backend-lint -W .github/workflows/ci.yml
 act -j backend-tests -W .github/workflows/ci.yml
+act -j backend-tooling-tests -W .github/workflows/ci.yml
 ```
 
-- ACT `-j` uses raw workflow job IDs such as `backend-tests`, not local shard IDs like `backend-tests-1`.
+- ACT `-j` uses raw workflow job IDs such as `backend-tests` and `backend-tooling-tests`, not local shard IDs like `backend-tests-1`.
 - No ACT secrets are currently required. If needed later, copy `.secrets.act.example` to `.secrets.act`; never commit it.
-- `run_ci_parallel.py` is a faster non-container local runner. It respects selected GitHub `needs`, reports omitted prerequisites, and expands backend matrix shards as `backend-tests-1` through `backend-tests-5`.
+- `run_ci_parallel.py` is a faster non-container local runner. It respects selected GitHub `needs`, reports omitted prerequisites, expands backend matrix shards as `backend-tests-1` through `backend-tests-5`, and keeps tooling tests in `backend-tooling-tests`.
 - Changed-path gating lives in `tools/tests/ci_path_rules.py` and `tools/tests/ci_changed_scope.py`; update workflow wiring and focused hygiene tests together.
 
 ## CI job reference
@@ -161,6 +166,7 @@ Blocking job names come from `.github/workflows/ci.yml`. Common local job select
 ```bash
 ./.venv/bin/python tools/tests/run_ci_parallel.py --ci-lite
 ./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck
+./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-tooling-tests
 ./.venv/bin/python tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke
 ./.venv/bin/python tools/tests/run_ci_parallel.py --job release-smoke
 ```

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -42,6 +42,7 @@ _INSTALL_STEP_NAMES = frozenset(
 _CI_LITE_EXCLUDED_JOBS = frozenset({"e2e"})
 _CI_FAST_EXCLUDED_JOBS = frozenset(
     {
+        "backend-tooling-tests",
         "e2e",
         "firmware-native-tests",
         "release-smoke",

--- a/tools/tests/plan_validation.py
+++ b/tools/tests/plan_validation.py
@@ -42,6 +42,7 @@ _CI_MANIFEST = _load_module("ci_manifest_for_plan_validation", _CI_MANIFEST_PATH
 _RUN_CHANGED = _load_module("run_changed_for_plan_validation", _RUN_CHANGED_PATH)
 
 BACKEND_TEST_JOBS = tuple(f"backend-tests-{index}" for index in range(1, 6))
+BACKEND_TOOLING_TEST_JOB = "backend-tooling-tests"
 
 
 @dataclass(frozen=True)
@@ -124,9 +125,9 @@ SELECTION_MAPPINGS = (
     SelectionMapping("ui_smoke", ("ui-smoke",), ("ui-smoke",), ("ui-smoke",)),
     SelectionMapping(
         "backend_tests",
-        ("backend-tests",),
-        BACKEND_TEST_JOBS,
-        ("backend-tests",),
+        ("backend-tests", BACKEND_TOOLING_TEST_JOB),
+        (*BACKEND_TEST_JOBS, BACKEND_TOOLING_TEST_JOB),
+        ("backend-tests", BACKEND_TOOLING_TEST_JOB),
     ),
     SelectionMapping(
         "release_smoke",

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -50,6 +50,7 @@ _DURATION_CACHE_ENV = "VIBESENSOR_BACKEND_DURATION_CACHE"
 _XDIST_WORKERS_ENV = "VIBESENSOR_BACKEND_XDIST_WORKERS"
 _SHARD_TIMEOUT_ENV = "VIBESENSOR_BACKEND_SHARD_TIMEOUT_S"
 _INCLUDE_DIAGNOSTIC_MATRIX_ENV = "VIBESENSOR_INCLUDE_DIAGNOSTIC_MATRIX"
+_INCLUDE_DEV_TOOLING_ENV = "VIBESENSOR_INCLUDE_DEV_TOOLING"
 _DEFAULT_DURATION = 1.0
 _DEFAULT_XDIST_WORKERS = 3
 _DEFAULT_SHARD_TIMEOUT_S = 900
@@ -100,8 +101,22 @@ def _shard_timeout_default(env: Mapping[str, str] | None = None) -> int:
 
 
 def _include_diagnostic_matrix_default(env: Mapping[str, str] | None = None) -> bool:
+    return _flag_default(
+        _INCLUDE_DIAGNOSTIC_MATRIX_ENV,
+        env=env,
+    )
+
+
+def _include_dev_tooling_default(env: Mapping[str, str] | None = None) -> bool:
+    return _flag_default(
+        _INCLUDE_DEV_TOOLING_ENV,
+        env=env,
+    )
+
+
+def _flag_default(env_name: str, *, env: Mapping[str, str] | None = None) -> bool:
     source = os.environ if env is None else env
-    raw = source.get(_INCLUDE_DIAGNOSTIC_MATRIX_ENV, "")
+    raw = source.get(env_name, "")
     if raw == "":
         return False
     normalized = raw.lower()
@@ -109,9 +124,7 @@ def _include_diagnostic_matrix_default(env: Mapping[str, str] | None = None) -> 
         return True
     if normalized in {"0", "false", "no", "off"}:
         return False
-    raise SystemExit(
-        f"{_INCLUDE_DIAGNOSTIC_MATRIX_ENV} must be one of 1/0, true/false, yes/no, or on/off"
-    )
+    raise SystemExit(f"{env_name} must be one of 1/0, true/false, yes/no, or on/off")
 
 
 def _duration_cache_path(env: Mapping[str, str] | None = None) -> Path:
@@ -335,6 +348,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             f"them unless {_INCLUDE_DIAGNOSTIC_MATRIX_ENV}=1."
         ),
     )
+    parser.add_argument(
+        "--include-dev-tooling",
+        action="store_true",
+        default=_include_dev_tooling_default(),
+        help=(
+            "Include tests marked dev_tooling. Default backend CI excludes "
+            f"them unless {_INCLUDE_DEV_TOOLING_ENV}=1."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
@@ -351,8 +373,15 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
+    excluded_markers = []
+    if not args.include_diagnostic_matrix:
+        excluded_markers.append("diagnostic_matrix")
+    if not args.include_dev_tooling:
+        excluded_markers.append("dev_tooling")
     marker_args = (
-        [] if args.include_diagnostic_matrix else ["-m", "not diagnostic_matrix"]
+        ["-m", " and ".join(f"not {marker}" for marker in excluded_markers)]
+        if excluded_markers
+        else []
     )
     collected = collect_test_ids([*marker_args, "apps/server/tests"])
     grouped_tests = _group_tests_by_path(collected)


### PR DESCRIPTION
## What changed
- Added a dev_tooling pytest marker for developer and CI tooling orchestration tests.
- Marked the monkeypatch-heavy CLI orchestration hygiene modules.
- Updated default backend shards and make test to exclude dev_tooling cases.
- Added make test-tooling plus a dedicated backend-tooling-tests CI/local job.
- Updated plan-validation routing and concise testing guidance.

## Why
- Issue #3915: product/application backend pytest should not carry repo tooling CLI orchestration tests in the default shard path.
- Tooling coverage still runs in its own dedicated lane.

## Validation
- pytest -q apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_watch_pr_checks.py apps/server/tests/hygiene/test_main_release_scripts.py apps/server/tests/hygiene/test_publish_github_release.py
- make test-tooling
- pytest collect-only marker checks for dev_tooling and not dev_tooling
- ./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-tooling-tests
- make lint
- make typecheck-backend
- make docs-lint
- make plan-validation
- ./.venv/bin/python tools/tests/plan_validation.py --run (backend-tests-2 and backend-tests-5 hit known unrelated history-db/raw-capture flakes; exact failures and failed shards passed on rerun)

## Risks / tradeoffs
- CI workflow surface changes: a new backend-tooling-tests job appears when backend tests are in scope.
- Default backend shards no longer run dev_tooling tests; the dedicated job preserves coverage.

Closes #3915