### PR TITLE
Split history API route-state tests

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -442,6 +442,12 @@ class FakeState:
         )
 
 
+def make_app_from_state(state: FakeState) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_router(state))
+    return app
+
+
 def _build_app_router_and_state(
     language: str = "en",
     sample_count: int = 20,

--- a/apps/server/tests/adapters/http/test_api_history_delete_run.py
+++ b/apps/server/tests/adapters/http/test_api_history_delete_run.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from _history_endpoint_helpers import (
+    FakeHistoryDB,
+    FakeState,
+    FakeWsHub,
+    make_app_and_state,
+    make_app_from_state,
+    make_metadata,
+    sample,
+)
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.analysis_summary import summarize_run_data
+
+
+def test_delete_active_run_returns_409() -> None:
+    @dataclass
+    class ActiveDB(FakeHistoryDB):
+        async def aget_active_run_id(self) -> str | None:
+            return "run-1"
+
+        async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
+            if run_id == "run-1":
+                return False, "active"
+            return False, "not_found"
+
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(5)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app = make_app_from_state(FakeState(ActiveDB(metadata, samples, analysis), FakeWsHub()))
+
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 409
+
+
+def test_delete_analyzing_run_returns_409() -> None:
+    @dataclass
+    class AnalyzingDB(FakeHistoryDB):
+        async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
+            if run_id == "run-1":
+                return False, "analyzing"
+            return False, "not_found"
+
+        async def adelete_run(self, run_id: str) -> bool:
+            raise AssertionError("delete_run should not be called for analyzing run")
+
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(5)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app = make_app_from_state(FakeState(AnalyzingDB(metadata, samples, analysis), FakeWsHub()))
+
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 409
+
+
+def test_delete_run_returns_404_for_not_found_reason() -> None:
+    app, _ = make_app_and_state(language="en")
+
+    with TestClient(app) as client:
+        response = client.delete("/api/history/missing-run")
+
+    assert response.status_code == 404
+
+
+def test_delete_run_returns_generic_409_for_unknown_reason() -> None:
+    @dataclass
+    class LockedDB(FakeHistoryDB):
+        async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
+            if run_id == "run-1":
+                return False, "locked"
+            return False, "not_found"
+
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(5)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app = make_app_from_state(FakeState(LockedDB(metadata, samples, analysis), FakeWsHub()))
+
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Cannot delete run at this time"

--- a/apps/server/tests/adapters/http/test_api_history_insights_projection.py
+++ b/apps/server/tests/adapters/http/test_api_history_insights_projection.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+from _history_endpoint_helpers import make_app_and_state, make_metadata, make_status_app, sample
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.analysis_summary import summarize_run_data
+from vibesensor.domain import CarSnapshot
+
+
+@pytest.mark.parametrize(
+    ("status", "analysis", "expected_status", "expected_detail"),
+    [
+        ("analyzing", {"status": "analyzing"}, 202, None),
+        ("error", {"status": "error"}, 422, "Analysis failed"),
+        ("complete", None, 422, "No analysis available for this run"),
+    ],
+)
+def test_history_insights_status_and_analysis_errors(
+    status: str,
+    analysis: dict[str, object] | None,
+    expected_status: int,
+    expected_detail: str | None,
+) -> None:
+    app = make_status_app(status=status, analysis=analysis, include_error_message=False)
+
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
+
+    assert response.status_code == expected_status
+    if expected_status == 202:
+        body = response.json()
+        assert body["status"] == "analyzing"
+        assert body["run_id"] == "run-1"
+        return
+    assert response.json()["detail"] == expected_detail
+
+
+def test_history_insights_does_not_mutate_db_analysis() -> None:
+    app, state = make_app_and_state(language="en")
+    original_analysis = state.history_db.analysis
+    original_keys = set(original_analysis.keys())
+
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
+
+    assert response.status_code == 200
+    assert set(state.history_db.analysis.keys()) == original_keys
+
+
+def test_history_insights_complete_response_includes_status_and_run_id() -> None:
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(5)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    analysis.pop("status", None)
+    analysis.pop("run_id", None)
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
+
+    payload = response.json()
+    assert payload["status"] == "complete"
+    assert payload["run_id"] == "run-1"
+
+
+def test_history_insights_preserves_analysis_case_id() -> None:
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(5)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    analysis["case_id"] = "case-123"
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
+
+    with TestClient(app) as client:
+        payload = client.get("/api/history/run-1/insights").json()
+
+    assert payload["case_id"] == "case-123"
+
+
+def test_history_insights_localizes_and_adds_run_context_warnings() -> None:
+    metadata = make_metadata(
+        analysis_settings_snapshot={
+            "tire_width_mm": 245.0,
+            "tire_aspect_pct": 35.0,
+            "rim_in": 19.0,
+            "final_drive_ratio": 3.23,
+            "current_gear_ratio": 0.82,
+        },
+        active_car_snapshot={
+            "id": "car-a",
+            "name": "Track Car",
+            "type": "coupe",
+        },
+        car_name="Track Car",
+        tire_width_mm=245.0,
+        tire_aspect_pct=35.0,
+        rim_in=19.0,
+        final_drive_ratio=3.23,
+        current_gear_ratio=0.82,
+        incomplete_for_order_analysis=True,
+    )
+    samples = [sample(i) for i in range(5)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+
+    app, state = make_app_and_state(
+        language="en",
+        metadata=metadata,
+        analysis=analysis,
+        samples=samples,
+    )
+    state.settings_store.active_car_snapshot = lambda: CarSnapshot(
+        car_id="car-b",
+        name="Daily Car",
+        car_type="wagon",
+        aspects={
+            "tire_width_mm": 225.0,
+            "tire_aspect_pct": 45.0,
+            "rim_in": 18.0,
+            "final_drive_ratio": 2.91,
+            "current_gear_ratio": 0.72,
+        },
+    )
+
+    with TestClient(app) as client:
+        payload = client.get("/api/history/run-1/insights", params={"lang": "nl"}).json()
+
+    warnings = payload.get("warnings")
+    assert isinstance(warnings, list)
+    assert len(warnings) == 2
+    titles = {str(item.get("title")) for item in warnings if isinstance(item, dict)}
+    assert "De referentiecontext voor ordeanalyse was onvolledig voor deze meting" in titles
+    assert "Voertuigprofielinstellingen zijn na deze meting gewijzigd" in titles

--- a/apps/server/tests/adapters/http/test_api_history_list_projection.py
+++ b/apps/server/tests/adapters/http/test_api_history_list_projection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from _history_endpoint_helpers import make_app_and_state, make_metadata, sample
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.analysis_summary import summarize_run_data
+
+
+def test_history_list_includes_recorded_car_name() -> None:
+    metadata = make_metadata(active_car_snapshot={"name": "Track Car"})
+    samples = [sample(i) for i in range(3)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/api/history")
+
+    assert response.json()["runs"][0]["car_name"] == "Track Car"
+
+
+def test_history_list_includes_degraded_raw_capture_finalize_state() -> None:
+    metadata = make_metadata(
+        raw_capture_finalize={
+            "status": "timeout",
+            "queue_depth": 4,
+            "error_summary": "raw capture finalize timed out",
+        }
+    )
+    samples = [sample(i) for i in range(3)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
+
+    with TestClient(app) as client:
+        payload = client.get("/api/history").json()
+
+    run = payload["runs"][0]
+    assert run["lifecycle"] == {
+        "stage": "post_analysis_ready",
+        "raw_capture": "degraded",
+        "whole_run_artifacts": "not_recorded",
+        "post_analysis": "ready",
+        "report": "ready",
+    }
+    assert run["artifact_availability"]["raw_capture"] == "degraded"
+    assert run["raw_capture_finalize"] == {
+        "status": "timeout",
+        "queue_depth": 4,
+        "error_summary": "raw capture finalize timed out",
+    }
+
+
+def test_history_list_uses_nested_active_car_snapshot_name() -> None:
+    metadata = make_metadata(
+        active_car_snapshot={
+            "id": "car-1",
+            "name": "Nested Track Car",
+            "type": "coupe",
+        }
+    )
+    samples = [sample(i) for i in range(3)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
+
+    with TestClient(app) as client:
+        payload = client.get("/api/history").json()
+
+    assert payload["runs"][0]["car_name"] == "Nested Track Car"

--- a/apps/server/tests/adapters/http/test_api_history_run_detail_projection.py
+++ b/apps/server/tests/adapters/http/test_api_history_run_detail_projection.py
@@ -8,17 +8,15 @@ from _history_endpoint_helpers import (
     FakeState,
     FakeWsHub,
     make_app_and_state,
+    make_app_from_state,
     make_metadata,
     make_status_app,
     sample,
 )
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
-from vibesensor.adapters.http import create_router
-from vibesensor.domain import CarSnapshot
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.raw_capture import (
     RawCaptureLossStats,
@@ -26,160 +24,6 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureSensorLossStats,
     RawCaptureSensorManifest,
 )
-
-
-def _app_from_state(state: FakeState) -> FastAPI:
-    app = FastAPI()
-    app.include_router(create_router(state))
-    return app
-
-
-def test_delete_active_run_returns_409() -> None:
-    @dataclass
-    class ActiveDB(FakeHistoryDB):
-        async def aget_active_run_id(self) -> str | None:
-            return "run-1"
-
-        async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
-            if run_id == "run-1":
-                return False, "active"
-            return False, "not_found"
-
-    metadata = make_metadata()
-    samples = [sample(i) for i in range(5)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    app = _app_from_state(FakeState(ActiveDB(metadata, samples, analysis), FakeWsHub()))
-
-    with TestClient(app) as client:
-        response = client.delete("/api/history/run-1")
-
-    assert response.status_code == 409
-
-
-def test_delete_analyzing_run_returns_409() -> None:
-    @dataclass
-    class AnalyzingDB(FakeHistoryDB):
-        async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
-            if run_id == "run-1":
-                return False, "analyzing"
-            return False, "not_found"
-
-        async def adelete_run(self, run_id: str) -> bool:
-            raise AssertionError("delete_run should not be called for analyzing run")
-
-    metadata = make_metadata()
-    samples = [sample(i) for i in range(5)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    app = _app_from_state(FakeState(AnalyzingDB(metadata, samples, analysis), FakeWsHub()))
-
-    with TestClient(app) as client:
-        response = client.delete("/api/history/run-1")
-
-    assert response.status_code == 409
-
-
-@pytest.mark.parametrize(
-    ("status", "analysis", "expected_status", "expected_detail"),
-    [
-        ("analyzing", {"status": "analyzing"}, 202, None),
-        ("error", {"status": "error"}, 422, "Analysis failed"),
-        ("complete", None, 422, "No analysis available for this run"),
-    ],
-)
-def test_history_insights_status_and_analysis_errors(
-    status: str,
-    analysis: dict[str, object] | None,
-    expected_status: int,
-    expected_detail: str | None,
-) -> None:
-    app = make_status_app(status=status, analysis=analysis, include_error_message=False)
-
-    with TestClient(app) as client:
-        response = client.get("/api/history/run-1/insights")
-
-    assert response.status_code == expected_status
-    if expected_status == 202:
-        body = response.json()
-        assert body["status"] == "analyzing"
-        assert body["run_id"] == "run-1"
-        return
-    assert response.json()["detail"] == expected_detail
-
-
-def test_delete_run_returns_404_for_not_found_reason() -> None:
-    app, _ = make_app_and_state(language="en")
-
-    with TestClient(app) as client:
-        response = client.delete("/api/history/missing-run")
-
-    assert response.status_code == 404
-
-
-def test_delete_run_returns_generic_409_for_unknown_reason() -> None:
-    @dataclass
-    class LockedDB(FakeHistoryDB):
-        async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
-            if run_id == "run-1":
-                return False, "locked"
-            return False, "not_found"
-
-    metadata = make_metadata()
-    samples = [sample(i) for i in range(5)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    app = _app_from_state(FakeState(LockedDB(metadata, samples, analysis), FakeWsHub()))
-
-    with TestClient(app) as client:
-        response = client.delete("/api/history/run-1")
-
-    assert response.status_code == 409
-    assert response.json()["detail"] == "Cannot delete run at this time"
-
-
-def test_history_insights_does_not_mutate_db_analysis() -> None:
-    app, state = make_app_and_state(language="en")
-    original_analysis = state.history_db.analysis
-    original_keys = set(original_analysis.keys())
-
-    with TestClient(app) as client:
-        response = client.get("/api/history/run-1/insights")
-
-    assert response.status_code == 200
-    assert set(state.history_db.analysis.keys()) == original_keys
-
-
-def test_history_insights_complete_response_includes_status_and_run_id() -> None:
-    metadata = make_metadata()
-    samples = [sample(i) for i in range(5)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    analysis.pop("status", None)
-    analysis.pop("run_id", None)
-    app, _ = make_app_and_state(
-        language="en", metadata=metadata, samples=samples, analysis=analysis
-    )
-
-    with TestClient(app) as client:
-        response = client.get("/api/history/run-1/insights")
-
-    payload = response.json()
-    assert payload["status"] == "complete"
-    assert payload["run_id"] == "run-1"
-
-
-def test_history_endpoints_preserve_analysis_case_id() -> None:
-    metadata = make_metadata()
-    samples = [sample(i) for i in range(5)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    analysis["case_id"] = "case-123"
-    app, _ = make_app_and_state(
-        language="en", metadata=metadata, samples=samples, analysis=analysis
-    )
-
-    with TestClient(app) as client:
-        history_payload = client.get("/api/history/run-1").json()
-        insights_payload = client.get("/api/history/run-1/insights").json()
-
-    assert history_payload["analysis"]["case_id"] == "case-123"
-    assert insights_payload["case_id"] == "case-123"
 
 
 def test_history_run_includes_sample_count() -> None:
@@ -230,7 +74,7 @@ def test_history_run_detail_includes_raw_capture_quality() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(3)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    app = _app_from_state(FakeState(RawManifestDB(metadata, samples, analysis), FakeWsHub()))
+    app = make_app_from_state(FakeState(RawManifestDB(metadata, samples, analysis), FakeWsHub()))
 
     with TestClient(app) as client:
         response = client.get("/api/history/run-1")
@@ -242,21 +86,22 @@ def test_history_run_detail_includes_raw_capture_quality() -> None:
     assert quality["queue_overflow_chunk_count"] == 120
 
 
-def test_history_list_includes_recorded_car_name() -> None:
-    metadata = make_metadata(active_car_snapshot={"name": "Track Car"})
-    samples = [sample(i) for i in range(3)]
+def test_history_run_detail_preserves_analysis_case_id() -> None:
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    analysis["case_id"] = "case-123"
     app, _ = make_app_and_state(
         language="en", metadata=metadata, samples=samples, analysis=analysis
     )
 
     with TestClient(app) as client:
-        response = client.get("/api/history")
+        payload = client.get("/api/history/run-1").json()
 
-    assert response.json()["runs"][0]["car_name"] == "Track Car"
+    assert payload["analysis"]["case_id"] == "case-123"
 
 
-def test_history_endpoints_include_degraded_raw_capture_finalize_state() -> None:
+def test_history_run_detail_includes_degraded_raw_capture_finalize_state() -> None:
     metadata = make_metadata(
         raw_capture_finalize={
             "status": "timeout",
@@ -271,31 +116,17 @@ def test_history_endpoints_include_degraded_raw_capture_finalize_state() -> None
     )
 
     with TestClient(app) as client:
-        list_payload = client.get("/api/history").json()
-        run_payload = client.get("/api/history/run-1").json()
+        payload = client.get("/api/history/run-1").json()
 
-    assert list_payload["runs"][0]["lifecycle"] == {
+    assert payload["lifecycle"] == {
         "stage": "post_analysis_ready",
         "raw_capture": "degraded",
         "whole_run_artifacts": "not_recorded",
         "post_analysis": "ready",
         "report": "ready",
     }
-    assert list_payload["runs"][0]["artifact_availability"]["raw_capture"] == "degraded"
-    assert list_payload["runs"][0]["raw_capture_finalize"] == {
-        "status": "timeout",
-        "queue_depth": 4,
-        "error_summary": "raw capture finalize timed out",
-    }
-    assert run_payload["lifecycle"] == {
-        "stage": "post_analysis_ready",
-        "raw_capture": "degraded",
-        "whole_run_artifacts": "not_recorded",
-        "post_analysis": "ready",
-        "report": "ready",
-    }
-    assert run_payload["artifact_availability"]["raw_capture"] == "degraded"
-    assert run_payload["raw_capture_finalize"] == {
+    assert payload["artifact_availability"]["raw_capture"] == "degraded"
+    assert payload["raw_capture_finalize"] == {
         "status": "timeout",
         "queue_depth": 4,
         "error_summary": "raw capture finalize timed out",
@@ -330,10 +161,10 @@ def test_history_run_detail_exposes_finalization_stage_metadata() -> None:
     )
 
     with TestClient(app) as client:
-        run_payload = client.get("/api/history/run-1").json()
+        payload = client.get("/api/history/run-1").json()
 
-    assert "finalization_stages" not in run_payload["metadata"]
-    assert run_payload["finalization_stages"] == [
+    assert "finalization_stages" not in payload["metadata"]
+    assert payload["finalization_stages"] == [
         {
             "stage_name": "FinalizeRawCaptureStage",
             "status": "degraded",
@@ -351,26 +182,6 @@ def test_history_run_detail_exposes_finalization_stage_metadata() -> None:
             "diagnostic_context": {"reason": "raw_capture_finalize_unsettled"},
         },
     ]
-
-
-def test_history_list_uses_nested_active_car_snapshot_name() -> None:
-    metadata = make_metadata(
-        active_car_snapshot={
-            "id": "car-1",
-            "name": "Nested Track Car",
-            "type": "coupe",
-        }
-    )
-    samples = [sample(i) for i in range(3)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    app, _ = make_app_and_state(
-        language="en", metadata=metadata, samples=samples, analysis=analysis
-    )
-
-    with TestClient(app) as client:
-        payload = client.get("/api/history").json()
-
-    assert payload["runs"][0]["car_name"] == "Nested Track Car"
 
 
 def test_history_run_projects_canonical_nested_run_context() -> None:
@@ -426,61 +237,6 @@ def test_history_run_includes_error_message_for_error_status() -> None:
     assert response.json()["error_message"] == "Analysis failed"
 
 
-def test_history_insights_localizes_and_adds_run_context_warnings() -> None:
-    metadata = make_metadata(
-        analysis_settings_snapshot={
-            "tire_width_mm": 245.0,
-            "tire_aspect_pct": 35.0,
-            "rim_in": 19.0,
-            "final_drive_ratio": 3.23,
-            "current_gear_ratio": 0.82,
-        },
-        active_car_snapshot={
-            "id": "car-a",
-            "name": "Track Car",
-            "type": "coupe",
-        },
-        car_name="Track Car",
-        tire_width_mm=245.0,
-        tire_aspect_pct=35.0,
-        rim_in=19.0,
-        final_drive_ratio=3.23,
-        current_gear_ratio=0.82,
-        incomplete_for_order_analysis=True,
-    )
-    samples = [sample(i) for i in range(5)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-
-    app, state = make_app_and_state(
-        language="en",
-        metadata=metadata,
-        analysis=analysis,
-        samples=samples,
-    )
-    state.settings_store.active_car_snapshot = lambda: CarSnapshot(
-        car_id="car-b",
-        name="Daily Car",
-        car_type="wagon",
-        aspects={
-            "tire_width_mm": 225.0,
-            "tire_aspect_pct": 45.0,
-            "rim_in": 18.0,
-            "final_drive_ratio": 2.91,
-            "current_gear_ratio": 0.72,
-        },
-    )
-
-    with TestClient(app) as client:
-        payload = client.get("/api/history/run-1/insights", params={"lang": "nl"}).json()
-
-    warnings = payload.get("warnings")
-    assert isinstance(warnings, list)
-    assert len(warnings) == 2
-    titles = {str(item.get("title")) for item in warnings if isinstance(item, dict)}
-    assert "De referentiecontext voor ordeanalyse was onvolledig voor deze meting" in titles
-    assert "Voertuigprofielinstellingen zijn na deze meting gewijzigd" in titles
-
-
 def test_history_run_strips_internal_analysis_fields() -> None:
     @dataclass
     class InternalFieldDB(FakeHistoryDB):
@@ -496,7 +252,7 @@ def test_history_run_strips_internal_analysis_fields() -> None:
 
     metadata = make_metadata()
     samples = [sample(0)]
-    app = _app_from_state(FakeState(InternalFieldDB(metadata, samples, {}), FakeWsHub()))
+    app = make_app_from_state(FakeState(InternalFieldDB(metadata, samples, {}), FakeWsHub()))
 
     with TestClient(app) as client:
         response = client.get("/api/history/run-1")
@@ -516,7 +272,7 @@ def test_history_run_preserves_missing_optional_analysis_fields() -> None:
     analysis.pop("plots", None)
     analysis.pop("analysis_metadata", None)
     db = FakeHistoryDB(metadata, samples, analysis)
-    app = _app_from_state(FakeState(db, FakeWsHub()))
+    app = make_app_from_state(FakeState(db, FakeWsHub()))
     route = next(
         route
         for route in app.router.routes
@@ -552,7 +308,7 @@ def test_history_run_allows_nested_processing_profile_metadata() -> None:
             }
         ],
     }
-    app = _app_from_state(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app = make_app_from_state(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
 
     with TestClient(app) as client:
         response = client.get("/api/history/run-1")


### PR DESCRIPTION
Closes #3916.

What changed:
- Removed the broad history route-state test bucket.
- Split HTTP coverage into delete-run, insights projection, list projection, and run-detail projection files.
- Added a small app helper for state-specific endpoint fakes.

Why:
- Endpoint contracts now have clear owners.
- The old catch-all mixed delete status mapping, insights errors, list/detail projections, and raw-capture metadata.

Validation/tests:
- Focused history HTTP endpoint/export/report tests.
- make lint.
- make typecheck-backend.
- make plan-validation.
- Planned local CI jobs all green.

Risks/tradeoffs/edge cases:
- Test-only split.
- Preserves critical response fields at the HTTP boundary.
- Some projection assertions remain at HTTP level where they verify serialized response shape.