### PR TITLE
Regroup diagnostic guardrail tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py
@@ -20,19 +20,14 @@ from test_support import (
     CAR_PROFILE_IDS,
     CAR_PROFILES,
     CORNER_SENSORS,
-    SENSOR_FL,
     SPEED_HIGH,
     SPEED_LOW,
     SPEED_MID,
     assert_confidence_label_valid,
     assert_no_wheel_fault,
-    assert_tolerant_no_fault,
     extract_top,
-    make_diffuse_samples,
-    make_noise_samples,
     make_profile_fault_samples,
     profile_metadata,
-    profile_wheel_hz,
     run_analysis,
     top_confidence,
 )
@@ -289,55 +284,30 @@ def test_confidence_label_transition(
             assert tone == "neutral"
 
 
-# ===================================================================
-# T6 – Noise-only baseline must not produce spurious medium+ fault
-# 3 speeds × 2 sensor configs × 5 profiles = 30 cases
-# ===================================================================
-_SENSOR_CONFIGS = [
-    ("single", [SENSOR_FL]),
-    ("quad", ALL_WHEEL_SENSORS),
-]
-
-
 @pytest.mark.parametrize("profile", CAR_PROFILES, ids=CAR_PROFILE_IDS)
-@pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
-@pytest.mark.parametrize(("cfg_name", "sensors"), _SENSOR_CONFIGS, ids=["single", "quad"])
-def test_noise_only_no_spurious_fault(
-    profile: dict[str, Any],
-    cfg_name: str,
-    sensors: list[str],
-    speed: float,
-) -> None:
-    """Pure noise should never produce a wheel fault at ≥0.40 confidence."""
-    samples = make_noise_samples(sensors=sensors, speed_kmh=speed, n_samples=40)
-    meta = profile_metadata(profile)
-    summary = run_analysis(samples, metadata=meta)
-    assert_no_wheel_fault(
-        summary,
-        msg=f"noise-only at {speed} km/h, {cfg_name} sensors ({profile['name']})",
+def test_mixed_sensor_fault_still_localizes_to_wheel(profile: dict[str, Any]) -> None:
+    """Mixed wheel/cabin sensors still produce a wheel-localized confidence result."""
+    samples = make_profile_fault_samples(
+        profile=profile,
+        fault_sensor="rear-left",
+        sensors=[
+            "front-left",
+            "front-right",
+            "rear-left",
+            "rear-right",
+            "driver-seat",
+            "trunk",
+            "engine-bay",
+            "transmission",
+        ],
+        speed_kmh=SPEED_MID,
+        fault_amp=0.08,
+        fault_vib_db=28.0,
+        n_samples=30,
     )
-
-
-# ===================================================================
-# T7 – Diffuse vibration at wheel frequency should NOT localize
-# 3 speeds × 5 profiles = 15 cases
-# ===================================================================
-@pytest.mark.parametrize("profile", CAR_PROFILES, ids=CAR_PROFILE_IDS)
-@pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
-def test_diffuse_at_wheel_freq_not_localized(profile: dict[str, Any], speed: float) -> None:
-    """Diffuse vibration matching wheel frequency should NOT produce localized fault."""
-    whz = profile_wheel_hz(profile, speed)
-    samples = make_diffuse_samples(
-        sensors=ALL_WHEEL_SENSORS,
-        speed_kmh=speed,
-        n_samples=35,
-        amp=0.04,
-        vib_db=22.0,
-        freq_hz=whz,
-    )
-    meta = profile_metadata(profile)
-    summary = run_analysis(samples, metadata=meta)
-    assert_tolerant_no_fault(
-        summary,
-        msg=f"diffuse@wheel_hz at {speed} km/h ({profile['name']})",
+    top = extract_top(run_analysis(samples, metadata=profile_metadata(profile)))
+    assert top is not None, f"Expected mixed-sensor wheel finding for {profile['name']}"
+    location = str(top.get("strongest_location") or "").lower()
+    assert "rear" in location and "left" in location, (
+        f"Expected rear-left localization for {profile['name']}, got {location!r}"
     )

--- a/apps/server/tests/use_cases/diagnostics/test_diffuse_excitation.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diffuse_excitation.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from test_support import make_sample as _make_sample
+from test_support import make_speed_sweep_fault_samples as _make_speed_sweep_fault_samples
+from test_support import standard_metadata as _standard_metadata
+from test_support import wheel_hz as _wheel_hz
+
+from vibesensor.adapters.analysis_summary import build_findings_for_samples
 from vibesensor.domain import OrderMatchObservation
 from vibesensor.use_cases.diagnostics.orders.heuristics import (
     detect_diffuse_excitation as _detect_diffuse_excitation,
@@ -99,3 +107,67 @@ class TestDetectDiffuseExcitation:
         )
         assert isinstance(is_diff, bool)
         assert penalty <= 1.0
+
+
+def _wheel_findings(findings: tuple | list, *, exclude_ref: bool = False) -> list:
+    return [
+        f
+        for f in findings
+        if (not exclude_ref or not f.finding_id.startswith("REF_"))
+        and f.finding_key.startswith("wheel_")
+    ]
+
+
+class TestDiffuseExcitationFindingFlags:
+    def test_uniform_peaks_all_sensors_flags_diffuse(self) -> None:
+        sensors = ["front-left", "front-right", "rear-left", "rear-right"]
+        samples: list[dict[str, Any]] = []
+        for i in range(40):
+            speed = 50.0 + i * 1.5
+            whz = _wheel_hz(speed)
+            for sensor in sensors:
+                samples.append(
+                    _make_sample(
+                        t_s=float(i),
+                        speed_kmh=speed,
+                        client_name=sensor,
+                        top_peaks=[
+                            {"hz": whz, "amp": 0.05},
+                            {"hz": whz * 2, "amp": 0.02},
+                        ],
+                        vibration_strength_db=24.0,
+                    ),
+                )
+
+        findings = build_findings_for_samples(
+            metadata=_standard_metadata(),
+            samples=samples,
+            lang="en",
+        )
+
+        for finding in _wheel_findings(findings, exclude_ref=True):
+            assert finding.diffuse_excitation is True, (
+                f"Expected diffuse excitation flag for {finding.finding_key}"
+            )
+
+    def test_single_sensor_fault_not_flagged_diffuse(self) -> None:
+        samples = _make_speed_sweep_fault_samples(
+            fault_sensor="front-right",
+            sensors=["front-left", "front-right", "rear-left", "rear-right"],
+            speed_start=50.0,
+            speed_end=108.5,
+            n_steps=40,
+            samples_per_step=1,
+            fault_amp=0.08,
+            noise_amp=0.005,
+            fault_vib_db=28.0,
+            noise_vib_db=10.0,
+        )
+        findings = build_findings_for_samples(
+            metadata=_standard_metadata(),
+            samples=samples,
+            lang="en",
+        )
+
+        for finding in _wheel_findings(findings, exclude_ref=True):
+            assert finding.diffuse_excitation is not True

--- a/apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py
+++ b/apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py
@@ -1,10 +1,4 @@
-"""Tests for source-aware localization, diffuse excitation detection,
-no-fault suppression, and confidence calibration.
-
-These tests validate the fixes for false localization (non-wheel sensors
-assigned as wheel fault sources), false-positive wheel findings (no-fault
-scenarios producing diagnoses), and diffuse excitation detection.
-"""
+"""Source-aware localization, unit consistency, and phased scenario contracts."""
 
 from __future__ import annotations
 
@@ -18,7 +12,7 @@ from test_support import wheel_hz as _wheel_hz
 
 from vibesensor.adapters.analysis_summary import build_findings_for_samples, summarize_run_data
 from vibesensor.domain import OrderMatchObservation
-from vibesensor.shared.locations import WHEEL_LOCATION_CODES, is_wheel_location
+from vibesensor.shared.locations import is_wheel_location
 from vibesensor.use_cases.diagnostics.location_analysis import summarize_order_match_locations
 
 # ---------------------------------------------------------------------------
@@ -28,7 +22,6 @@ from vibesensor.use_cases.diagnostics.location_analysis import summarize_order_m
 
 _ALL_WHEEL_SENSORS = ["front-left", "front-right", "rear-left", "rear-right"]
 _MIXED_SENSORS = ["front-left", "front-right", "rear-left", "rear-right", "driver-seat", "trunk"]
-_CABIN_SENSORS = ["driver-seat", "front-passenger", "rear-left-seat"]
 
 
 def _build_fault_samples(
@@ -71,71 +64,7 @@ def _wheel_causes(top_causes: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
-# 1. Sensor-type classification tests
-# ---------------------------------------------------------------------------
-
-
-class TestSensorTypeClassification:
-    """is_wheel_location must correctly classify all location variants."""
-
-    @pytest.mark.parametrize(
-        "label",
-        [
-            "front-left",
-            "front-right",
-            "rear-left",
-            "rear-right",
-            "Front Left",
-            "Front Right",
-            "Rear Left",
-            "Rear Right",
-            "front_left_wheel",
-            "front_right_wheel",
-            "rear_left_wheel",
-            "rear_right_wheel",
-            "FL Wheel",
-            "FR Wheel",
-            "RL Wheel",
-            "RR Wheel",
-        ],
-    )
-    def test_wheel_locations_detected(self, label: str) -> None:
-        assert is_wheel_location(label), f"Expected {label!r} to be classified as wheel"
-
-    @pytest.mark.parametrize(
-        "label",
-        [
-            "driver-seat",
-            "Driver Seat",
-            "trunk",
-            "Trunk",
-            "engine_bay",
-            "Engine Bay",
-            "transmission",
-            "Transmission",
-            "driveshaft_tunnel",
-            "front_subframe",
-            "rear_subframe",
-            "front-passenger",
-            "rear-left-seat",
-            "rear-center-seat",
-        ],
-    )
-    def test_non_wheel_locations_not_detected(self, label: str) -> None:
-        assert not is_wheel_location(label), f"Expected {label!r} NOT to be classified as wheel"
-
-    def test_empty_and_none(self) -> None:
-        assert not is_wheel_location("")
-        assert not is_wheel_location("   ")
-
-    def test_wheel_location_codes_are_complete(self) -> None:
-        assert len(WHEEL_LOCATION_CODES) == 4
-        for code in WHEEL_LOCATION_CODES:
-            assert is_wheel_location(code)
-
-
-# ---------------------------------------------------------------------------
-# 2. Source-aware localization tests
+# 1. Source-aware localization tests
 # ---------------------------------------------------------------------------
 
 
@@ -257,166 +186,7 @@ class TestSourceAwareLocalization:
         assert top_location == "Driver Seat"
 
 
-# ---------------------------------------------------------------------------
-# 3. Diffuse excitation detection tests
-# ---------------------------------------------------------------------------
-
-
-class TestDiffuseExcitationDetection:
-    """Diffuse/global excitation should not produce corner-specific wheel diagnosis."""
-
-    def test_uniform_peaks_all_sensors_flags_diffuse(self) -> None:
-        """When all sensors show identical peaks, the finding should be flagged
-        as diffuse excitation with reduced confidence.
-        """
-        sensors = _ALL_WHEEL_SENSORS
-        samples: list[dict[str, Any]] = []
-        # Use varying speed to avoid constant-speed filter
-        for i in range(40):
-            for s in sensors:
-                speed = 50.0 + i * 1.5
-                whz = _wheel_hz(speed)
-                peaks = [{"hz": whz, "amp": 0.05}, {"hz": whz * 2, "amp": 0.02}]
-                samples.append(
-                    _make_sample(
-                        t_s=float(i),
-                        speed_kmh=speed,
-                        client_name=s,
-                        top_peaks=peaks,
-                        vibration_strength_db=24.0,
-                    ),
-                )
-        metadata = _standard_metadata()
-        findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
-        order_findings = _wheel_findings(findings, exclude_ref=True)
-        # If any order finding exists, it should be flagged as diffuse
-        for f in order_findings:
-            assert f.diffuse_excitation is True, (
-                f"Expected diffuse_excitation flag for uniform-amplitude finding: {f.finding_key}"
-            )
-
-    def test_single_sensor_fault_not_flagged_diffuse(self) -> None:
-        """When only one sensor has matching peaks, should NOT be flagged diffuse."""
-        samples = _build_fault_samples(_ALL_WHEEL_SENSORS, "front-right", n_samples=40)
-        metadata = _standard_metadata()
-        findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
-        order_findings = _wheel_findings(findings, exclude_ref=True)
-        for f in order_findings:
-            assert f.diffuse_excitation is not True, (
-                "Single-sensor fault should NOT be flagged as diffuse"
-            )
-
-
-# ---------------------------------------------------------------------------
-# 4. No-fault suppression tests
-# ---------------------------------------------------------------------------
-
-
-class TestNoFaultSuppression:
-    """No-fault scenarios must not produce high-confidence wheel diagnoses."""
-
-    def test_idle_only_no_wheel_diagnosis(self) -> None:
-        """Pure idle samples should not produce a wheel diagnosis."""
-        sensors = _ALL_WHEEL_SENSORS
-        samples: list[dict[str, Any]] = []
-        for i in range(20):
-            for s in sensors:
-                peaks = [{"hz": 12.0, "amp": 0.003}]
-                samples.append(
-                    _make_sample(
-                        t_s=float(i),
-                        speed_kmh=0.0,
-                        client_name=s,
-                        top_peaks=peaks,
-                        vibration_strength_db=6.0,
-                    ),
-                )
-        metadata = _standard_metadata()
-        summary = summarize_run_data(metadata, samples, lang="en", file_name="idle_only")
-        top_causes = summary.get("top_causes", [])
-        # No wheel/tire diagnosis should appear for idle-only data
-        wc = _wheel_causes(top_causes)
-        assert len(wc) == 0, f"Idle-only scenario produced wheel diagnosis: {wc}"
-
-    def test_road_noise_no_specific_fault(self) -> None:
-        """Road noise on all sensors should not produce a confident wheel finding."""
-        sensors = _ALL_WHEEL_SENSORS
-        samples: list[dict[str, Any]] = []
-        for i in range(30):
-            speed = 40.0 + i * 2
-            for s in sensors:
-                # Random broadband road noise, not matching any specific order
-                peaks = [
-                    {"hz": 8.0 + i * 0.3, "amp": 0.01},
-                    {"hz": 15.0, "amp": 0.008},
-                    {"hz": 34.0, "amp": 0.005},
-                ]
-                samples.append(
-                    _make_sample(
-                        t_s=float(i),
-                        speed_kmh=speed,
-                        client_name=s,
-                        top_peaks=peaks,
-                        vibration_strength_db=14.0,
-                    ),
-                )
-        metadata = _standard_metadata()
-        summary = summarize_run_data(metadata, samples, lang="en", file_name="road_noise")
-        for c in _wheel_causes(summary.get("top_causes", [])):
-            conf = float(c.get("confidence", 0))
-            assert conf < 0.50, f"Road noise produced confident wheel diagnosis: {conf:.2f}"
-
-
-# ---------------------------------------------------------------------------
-# 5. Confidence calibration across sensor counts
-# ---------------------------------------------------------------------------
-
-
-class TestConfidenceCalibration:
-    """Confidence must be calibrated for 1-12 sensors."""
-
-    def test_single_sensor_produces_finding(self) -> None:
-        """A single sensor with a clear fault should still produce a finding."""
-        samples = _build_fault_samples(["front-right"], "front-right")
-        metadata = _standard_metadata()
-        findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
-        assert len(_wheel_findings(findings)) > 0, "Single sensor should produce a wheel finding"
-
-    def test_four_sensor_clear_fault(self) -> None:
-        """4 sensors with a clear single-sensor fault should identify correct location."""
-        samples = _build_fault_samples(_ALL_WHEEL_SENSORS, "front-right")
-        metadata = _standard_metadata()
-        findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
-        wf = _wheel_findings(findings)
-        assert len(wf) > 0, "4-sensor setup should produce a wheel finding"
-        top = wf[0]
-        strongest = (top.strongest_location or "").lower()
-        assert "right" in strongest or "fr" in strongest, f"Expected front-right, got {strongest}"
-
-    def test_eight_sensor_mixed_clear_fault(self) -> None:
-        """8 mixed sensors with a clear wheel fault should still identify the wheel."""
-        sensors = [
-            "front-left",
-            "front-right",
-            "rear-left",
-            "rear-right",
-            "driver-seat",
-            "trunk",
-            "engine-bay",
-            "transmission",
-        ]
-        samples = _build_fault_samples(sensors, "rear-left")
-        metadata = _standard_metadata()
-        findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
-        wf = _wheel_findings(findings)
-        assert len(wf) > 0, "8-sensor setup should produce a wheel finding"
-        top = wf[0]
-        strongest = (top.strongest_location or "").lower()
-        assert "rear" in strongest and "left" in strongest, f"Expected rear-left, got {strongest}"
-
-
-# ---------------------------------------------------------------------------
-# 6. Unit consistency tests
+# 2. Unit consistency tests
 # ---------------------------------------------------------------------------
 
 
@@ -449,7 +219,7 @@ class TestUnitConsistency:
 
 
 # ---------------------------------------------------------------------------
-# 7. Phase timeline tests
+# 3. Phase timeline tests
 # ---------------------------------------------------------------------------
 
 
@@ -507,7 +277,7 @@ class TestPhaseTimeline:
 
 
 # ---------------------------------------------------------------------------
-# 8. Integration: phased scenario tests
+# 4. Integration: phased scenario tests
 # ---------------------------------------------------------------------------
 
 

--- a/apps/server/tests/use_cases/diagnostics/test_locations.py
+++ b/apps/server/tests/use_cases/diagnostics/test_locations.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from vibesensor.shared.locations import LOCATION_OPTIONS, all_locations, label_for_code
+from vibesensor.shared.locations import (
+    LOCATION_OPTIONS,
+    WHEEL_LOCATION_CODES,
+    all_locations,
+    is_wheel_location,
+    label_for_code,
+)
 
 
 def test_location_options_are_unique_and_short() -> None:
@@ -20,6 +26,65 @@ def test_location_lookup_roundtrip() -> None:
     assert options
     for row in options:
         assert label_for_code(row["code"]) == row["label"]
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "front-left",
+        "front-right",
+        "rear-left",
+        "rear-right",
+        "Front Left",
+        "Front Right",
+        "Rear Left",
+        "Rear Right",
+        "front_left_wheel",
+        "front_right_wheel",
+        "rear_left_wheel",
+        "rear_right_wheel",
+        "FL Wheel",
+        "FR Wheel",
+        "RL Wheel",
+        "RR Wheel",
+    ],
+)
+def test_wheel_location_labels_are_detected(label: str) -> None:
+    assert is_wheel_location(label), f"Expected {label!r} to be classified as wheel"
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "driver-seat",
+        "Driver Seat",
+        "trunk",
+        "Trunk",
+        "engine_bay",
+        "Engine Bay",
+        "transmission",
+        "Transmission",
+        "driveshaft_tunnel",
+        "front_subframe",
+        "rear_subframe",
+        "front-passenger",
+        "rear-left-seat",
+        "rear-center-seat",
+    ],
+)
+def test_non_wheel_location_labels_are_not_detected(label: str) -> None:
+    assert not is_wheel_location(label), f"Expected {label!r} not to be classified as wheel"
+
+
+def test_empty_location_labels_are_not_wheels() -> None:
+    assert not is_wheel_location("")
+    assert not is_wheel_location("   ")
+
+
+def test_wheel_location_codes_are_complete() -> None:
+    assert len(WHEEL_LOCATION_CODES) == 4
+    for code in WHEEL_LOCATION_CODES:
+        assert is_wheel_location(code)
 
 
 class TestSetLocationRequestAcceptsEmptyCode:


### PR DESCRIPTION
## What changed
- Moved wheel/non-wheel location classification checks into `test_locations.py`.
- Moved diffuse finding-flag integration coverage into `test_diffuse_excitation.py`.
- Trimmed duplicate no-fault and diffuse matrices from confidence-threshold tests.
- Kept confidence-threshold ownership with a focused mixed-sensor localization regression.

## Why
- #3921 asks for diagnostic false-positive and localization guardrails to be grouped by risk/owner instead of duplicated across broad files.

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_negative_false_positives.py apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py apps/server/tests/use_cases/diagnostics/test_speed_metadata_edge_cases.py apps/server/tests/use_cases/diagnostics/test_diffuse_excitation.py apps/server/tests/use_cases/diagnostics/test_locations.py`
- `make lint`
- `make typecheck-backend`
- `make plan-validation`

## Risks and tradeoffs
- Test-only cleanup. Coverage is intentionally reassigned to narrower owners; removed cases were duplicate no-fault/diffuse confidence matrices already covered by negative-false-positive and diffuse owners.

Closes #3921