### PR TITLE
Clarify raw capture replay test ownership

### DIFF
--- a/apps/server/tests/test_support/raw_capture_assertions.py
+++ b/apps/server/tests/test_support/raw_capture_assertions.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+
+class _WarningWithCode(Protocol):
+    code: str
+
+
+def warning_codes(warnings: Iterable[_WarningWithCode]) -> list[str]:
+    return [str(warning.code) for warning in warnings]

--- a/apps/server/tests/use_cases/history/test_raw_replay_warning_propagation.py
+++ b/apps/server/tests/use_cases/history/test_raw_replay_warning_propagation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from test_support.findings import make_finding_payload
+from test_support.raw_capture_assertions import warning_codes
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
@@ -94,9 +95,9 @@ def test_prepare_persisted_report_input_surfaces_partial_raw_replay_honestly() -
 
     assert prepared.report_facts.evidence.data_basis == "partial_raw_backed"
     assert "raw_replay_incomplete" in prepared.report_facts.confidence.caveat_keys
-    assert WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE in [
-        warning.code for warning in prepared.report_facts.decision.warnings
-    ]
+    assert WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE in warning_codes(
+        prepared.report_facts.decision.warnings
+    )
     assert any(
         "Partially raw-backed replay" in row.value
         for row in document.verdict_page.proof_snapshot_rows
@@ -151,9 +152,9 @@ def test_prepare_persisted_report_input_surfaces_legacy_sample_timing_warning() 
         )
     )
 
-    assert WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK in [
-        warning.code for warning in prepared.report_facts.decision.warnings
-    ]
+    assert WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK in warning_codes(
+        prepared.report_facts.decision.warnings
+    )
 
 
 def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> None:
@@ -213,9 +214,9 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
 
     document = build_report_document(prepared)
 
-    assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
-        warning.code for warning in prepared.report_facts.decision.warnings
-    ]
+    assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in warning_codes(
+        prepared.report_facts.decision.warnings
+    )
     assert any(
         "late or out-of-order packets quarantined from live processing" in (row.detail or "")
         for row in document.data_trust
@@ -271,9 +272,9 @@ def test_prepare_persisted_report_input_surfaces_sync_unverified_warning() -> No
         )
     )
 
-    assert WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED in [
-        warning.code for warning in prepared.report_facts.decision.warnings
-    ]
+    assert WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED in warning_codes(
+        prepared.report_facts.decision.warnings
+    )
 
 
 def test_prepare_persisted_report_input_surfaces_whole_run_alignment_warning() -> None:
@@ -349,9 +350,9 @@ def test_prepare_persisted_report_input_surfaces_whole_run_alignment_warning() -
 
     document = build_report_document(prepared)
 
-    assert WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE in [
-        warning.code for warning in prepared.report_facts.decision.warnings
-    ]
+    assert WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE in warning_codes(
+        prepared.report_facts.decision.warnings
+    )
     assert any(
         "Whole-run raw coverage was incomplete for some time-aligned windows" in (row.detail or "")
         for row in document.data_trust

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay_outcomes.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay_outcomes.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import replace
 
 import numpy as np
+from test_support.raw_capture_assertions import warning_codes
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
@@ -246,9 +247,7 @@ def test_build_post_analysis_input_marks_no_valid_bin_fft_windows_unusable() -> 
     assert result.raw_replay.replay_confidence == "fallback"
     assert result.raw_replay.raw_capture_mode == "summary_only"
     assert result.raw_replay_window_coverages[0].reason == "fft_no_valid_bins"
-    assert WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE in [
-        warning.code for warning in result.raw_replay.warnings
-    ]
+    assert WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE in warning_codes(result.raw_replay.warnings)
     assert rebuilt.vibration_strength_db is None
     assert rebuilt.dominant_freq_hz is None
     assert rebuilt.top_peaks == ()
@@ -304,9 +303,7 @@ def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> 
     assert result.raw_replay.write_error_chunk_count == 0
     assert result.raw_replay.replay_confidence == "partial"
     assert result.raw_replay.raw_capture_mode == "partial_raw_backed"
-    assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
-        warning.code for warning in result.raw_replay.warnings
-    ]
+    assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in warning_codes(result.raw_replay.warnings)
 
 
 def test_build_post_analysis_input_marks_fatal_raw_capture_loss_policy() -> None:
@@ -345,9 +342,7 @@ def test_build_post_analysis_input_marks_fatal_raw_capture_loss_policy() -> None
     assert result.raw_replay.raw_capture_loss_policy_severity == "fatal"
     assert result.raw_replay.raw_capture_loss_policy_reason == "raw_capture_queue_overflow_fatal"
     assert result.raw_replay.raw_capture_loss_policy_gate_whole_run is True
-    assert WARNING_CODE_RAW_CAPTURE_LOSS_POLICY in [
-        warning.code for warning in result.raw_replay.warnings
-    ]
+    assert WARNING_CODE_RAW_CAPTURE_LOSS_POLICY in warning_codes(result.raw_replay.warnings)
 
 
 def test_build_post_analysis_input_falls_back_when_raw_capture_missing() -> None:

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay_timing.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay_timing.py
@@ -4,6 +4,7 @@ import math
 
 import numpy as np
 import pytest
+from test_support.raw_capture_assertions import warning_codes
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
@@ -463,7 +464,7 @@ def test_build_post_analysis_input_marks_gap_windows_partial_and_falls_back() ->
     assert result.raw_replay.raw_capture_mode == "partial_raw_backed"
     assert result.raw_replay.partial_window_count == 1
     assert result.raw_replay.gap_count == 1
-    assert [warning.code for warning in result.raw_replay.warnings] == [
+    assert warning_codes(result.raw_replay.warnings) == [
         WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK,
         WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     ]
@@ -516,9 +517,7 @@ def test_build_post_analysis_input_warns_when_replay_falls_back_to_legacy_sample
 
     assert result.raw_backed_summary_row_count == 1
     assert result.raw_replay.timing_fallback_count == 1
-    assert [warning.code for warning in result.raw_replay.warnings] == [
-        WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK
-    ]
+    assert warning_codes(result.raw_replay.warnings) == [WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK]
     assert result.raw_replay_window_coverages[0].reason == "timing_fallback"
 
 
@@ -565,9 +564,7 @@ def test_build_post_analysis_input_falls_back_for_legacy_raw_capture_without_anc
     assert result.raw_replay.raw_capture_mode == "summary_only"
     assert result.raw_replay.replay_confidence == "fallback"
     assert result.raw_replay.unanchored_sensor_count == 1
-    assert [warning.code for warning in result.raw_replay.warnings] == [
-        WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK
-    ]
+    assert warning_codes(result.raw_replay.warnings) == [WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK]
     assert result.samples[0].vibration_strength_db == 11.0
     assert result.samples[0].dominant_freq_hz == 13.0
 
@@ -626,7 +623,7 @@ def test_build_post_analysis_input_falls_back_when_sync_proof_is_stale() -> None
     assert result.raw_replay.raw_capture_mode == "summary_only"
     assert result.raw_replay.sync_unverified_sensor_count == 1
     assert result.raw_replay.stale_sync_sensor_count == 1
-    assert [warning.code for warning in result.raw_replay.warnings] == [
+    assert warning_codes(result.raw_replay.warnings) == [
         WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
         WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     ]


### PR DESCRIPTION
## What changed
- Renamed raw-capture replay tests by owner: timing/alignment, replay outcomes, and report warning propagation.
- Added `test_support.raw_capture_assertions.warning_codes` and replaced repeated warning-code extraction in replay and report tests.
- Left writer and history DB tests in their current files because they already own lower-layer lifecycle and persistence contracts.

## Why
- #3922 asks for raw replay warning/fallback coverage to have clearer producer and presentation owners without losing behavior coverage.

## Validation
- `pytest -q apps/server/tests/use_cases/run/test_raw_capture_replay_timing.py apps/server/tests/use_cases/run/test_raw_capture_replay_outcomes.py apps/server/tests/use_cases/run/test_raw_capture_writer.py apps/server/tests/use_cases/history/test_raw_replay_warning_propagation.py apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py`
- `make lint`
- `make typecheck-backend`
- `make plan-validation`

## Risks and tradeoffs
- Test-only cleanup. The old file names changed, but pytest discovery and the changed-file validation plan see the new owner files.

Closes #3922