### PR TITLE
Fix flaky history DB cancellation cleanup

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_async_concurrency.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_async_concurrency.py
@@ -116,11 +116,25 @@ async def test_cancellation_of_in_flight_append_keeps_db_usable(tmp_path: Path) 
         repo = db.run_repository
         await repo.acreate_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id))
 
-        task = asyncio.create_task(repo.aappend_samples(run_id, _frames(run_id, 200)))
-        await asyncio.sleep(0)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        write_lock_held = asyncio.Event()
+        release_write_lock = asyncio.Event()
+
+        async def hold_write_lock() -> None:
+            async with db.lifecycle.write_transaction_cursor():
+                write_lock_held.set()
+                await release_write_lock.wait()
+
+        blocker = asyncio.create_task(hold_write_lock())
+        await write_lock_held.wait()
+        try:
+            task = asyncio.create_task(repo.aappend_samples(run_id, _frames(run_id, 200)))
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            release_write_lock.set()
+            await blocker
 
         written = await repo.aappend_samples(run_id, _frames(run_id, 5, start=1000))
         assert written == 5

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -32,6 +32,7 @@ _ENGINE_SCHEMA_CHECK_TIMEOUT_S = 30.0
 _ENGINE_QUICK_CHECK_TIMEOUT_S = 10.0
 _ENGINE_CLOSE_TIMEOUT_S = 5.0
 _ENGINE_SHUTDOWN_TIMEOUT_S = 5.0
+_THREAD_LOCK_ACQUIRE_SLICE_S = 0.05
 
 
 class HistoryDbEngineTimeoutError(TimeoutError):
@@ -102,7 +103,19 @@ async def _async_lock_context(lock: object) -> AsyncIterator[None]:
             yield
         return
     if hasattr(manager, "acquire") and hasattr(manager, "release"):
-        await asyncio.to_thread(manager.acquire)
+        while True:
+            acquire_attempt = asyncio.create_task(
+                asyncio.to_thread(manager.acquire, True, _THREAD_LOCK_ACQUIRE_SLICE_S)
+            )
+            try:
+                acquired = await acquire_attempt
+            except asyncio.CancelledError:
+                acquired = await acquire_attempt
+                if acquired:
+                    manager.release()
+                raise
+            if acquired:
+                break
         try:
             yield
         finally:


### PR DESCRIPTION
## Summary
- make history DB thread-lock acquisition cancellation-safe so cancelled waiters cannot strand the write lock
- make the async concurrency regression deterministic by cancelling while a write transaction is held
- keep the follow-up append assertion to verify the database remains usable after cancellation

## Validation
- ./.venv/bin/python -m pytest -q apps/server/tests/adapters/persistence/history_db/test_async_concurrency.py apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py -q -n0
- VIBESENSOR_BACKEND_XDIST_WORKERS=3 ./.venv/bin/python -m pytest -q apps/server/tests/adapters/persistence/history_db/test_async_concurrency.py -n 3
- cd apps/server && MYPYPATH=. ../../.venv/bin/python -m mypy --config-file pyproject.toml
- cd apps/server && ../../.venv/bin/lint-imports --config pyproject.toml
- cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py