### PR TITLE
Merge low-level protocol helper tests

### DIFF
--- a/apps/server/tests/adapters/http/test_helpers_exception_handling.py
+++ b/apps/server/tests/adapters/http/test_helpers_exception_handling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from fastapi import HTTPException
 
@@ -20,61 +22,44 @@ from vibesensor.shared.exceptions import (
 from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
 
 
-def test_configuration_error_caught_as_vibesensor_error() -> None:
-    """ConfigurationError maps to HTTP 400."""
+@pytest.mark.parametrize(
+    ("error_factory", "expected_status_code"),
+    [
+        (lambda: ConfigurationError("bad config"), 400),
+        (lambda: ProtocolError("bad packet"), 400),
+        (lambda: UpdateError("busy", status="conflict"), 409),
+        (lambda: ServiceUnavailableError("service down"), 503),
+        (lambda: VibeSensorError("generic domain error"), 500),
+        (lambda: OperationalError("operational failure"), 500),
+    ],
+    ids=[
+        "configuration-error",
+        "protocol-error",
+        "update-conflict",
+        "service-unavailable",
+        "vibesensor-base",
+        "operational-base",
+    ],
+)
+def test_route_error_boundary_maps_known_errors(
+    error_factory: Callable[[], Exception],
+    expected_status_code: int,
+) -> None:
     with pytest.raises(HTTPException) as exc_info:
         with route_errors_to_http():
-            raise ConfigurationError("bad config")
-    assert exc_info.value.status_code == 400
+            raise error_factory()
+
+    assert exc_info.value.status_code == expected_status_code
 
 
-def test_protocol_error_maps_to_400() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        with route_errors_to_http():
-            raise ProtocolError("bad packet")
-    assert exc_info.value.status_code == 400
-
-
-def test_update_error_conflict_maps_to_409() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        with route_errors_to_http():
-            raise UpdateError("busy", status="conflict")
-    assert exc_info.value.status_code == 409
-
-
-def test_plain_value_error_propagates_past_route_boundary() -> None:
-    """A plain ValueError must be handled explicitly by the route that owns it."""
+def test_value_error_handling_stays_explicit_at_route_boundary() -> None:
     with pytest.raises(ValueError, match="not a number"):
         with route_errors_to_http():
             raise ValueError("not a number")
 
-
-def test_http_exception_for_value_error_maps_explicit_request_failures() -> None:
     exc = http_exception_for_value_error(ValueError("not a number"), status_code=400)
     assert exc.status_code == 400
     assert exc.detail == "not a number"
-
-
-def test_service_unavailable_error_maps_to_503() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        with route_errors_to_http():
-            raise ServiceUnavailableError("service down")
-    assert exc_info.value.status_code == 503
-
-
-def test_vibesensor_error_base_caught() -> None:
-    """VibeSensorError (base) is caught and mapped to HTTP 500."""
-    with pytest.raises(HTTPException) as exc_info:
-        with route_errors_to_http():
-            raise VibeSensorError("generic domain error")
-    assert exc_info.value.status_code == 500
-
-
-def test_operational_error_base_maps_to_500() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        with route_errors_to_http():
-            raise OperationalError("operational failure")
-    assert exc_info.value.status_code == 500
 
 
 @pytest.mark.parametrize(

--- a/apps/server/tests/adapters/obd/test_admin_helper.py
+++ b/apps/server/tests/adapters/obd/test_admin_helper.py
@@ -104,49 +104,7 @@ def test_parse_bluetooth_scan_events_parses_new_device_lines_with_ansi() -> None
     assert devices[0].name == "Audioengine HD6"
 
 
-def test_scan_devices_uses_timed_scan_output_when_devices_list_is_empty() -> None:
-    responses = {
-        ("rfkill", "unblock", "bluetooth"): (0, "", ""),
-        ("systemctl", "start", "bluetooth"): (0, "", ""),
-        ("bluetoothctl", "power", "on"): (0, "", ""),
-        (
-            "bluetoothctl",
-            "--timeout",
-            "8",
-            "scan",
-            "on",
-        ): (
-            0,
-            "[NEW] Device 00:22:D9:00:1B:B1 Audioengine HD6",
-            "",
-        ),
-        ("bluetoothctl", "devices"): (0, "", ""),
-        ("bluetoothctl", "devices", "Paired"): (0, "", ""),
-        ("bluetoothctl", "paired-devices"): (0, "", ""),
-        ("bluetoothctl", "scan", "off"): (0, "", ""),
-    }
-    calls: list[tuple[str, ...]] = []
-
-    def runner(argv: list[str], timeout_s: int, allow_timeout: bool) -> tuple[int, str, str]:
-        del timeout_s, allow_timeout
-        key = tuple(argv)
-        calls.append(key)
-        return responses[key]
-
-    devices = BluetoothObdAdminHelper(runner=runner).scan_devices(timeout_s=8)
-
-    assert len(devices) == 1
-    assert devices[0].name == "Audioengine HD6"
-    assert (
-        "bluetoothctl",
-        "--timeout",
-        "8",
-        "scan",
-        "on",
-    ) in calls
-
-
-def test_scan_devices_sorts_human_readable_names_ahead_of_mac_aliases() -> None:
+def test_scan_devices_uses_timed_scan_output_and_sorts_human_names() -> None:
     responses = {
         ("rfkill", "unblock", "bluetooth"): (0, "", ""),
         ("systemctl", "start", "bluetooth"): (0, "", ""),
@@ -168,20 +126,7 @@ def test_scan_devices_sorts_human_readable_names_ahead_of_mac_aliases() -> None:
             ),
             "",
         ),
-        (
-            "bluetoothctl",
-            "devices",
-        ): (
-            0,
-            "\n".join(
-                [
-                    "Device 53:40:AC:57:11:77 53-40-AC-57-11-77",
-                    "Device 00:22:D9:00:1B:B1 Audioengine HD6",
-                    "Device 11:22:33:44:55:66",
-                ]
-            ),
-            "",
-        ),
+        ("bluetoothctl", "devices"): (0, "", ""),
         ("bluetoothctl", "devices", "Paired"): (0, "", ""),
         ("bluetoothctl", "paired-devices"): (0, "", ""),
         ("bluetoothctl", "scan", "off"): (0, "", ""),
@@ -215,10 +160,13 @@ def test_scan_devices_sorts_human_readable_names_ahead_of_mac_aliases() -> None:
             "",
         ),
     }
+    calls: list[tuple[str, ...]] = []
 
     def runner(argv: list[str], timeout_s: int, allow_timeout: bool) -> tuple[int, str, str]:
         del timeout_s, allow_timeout
-        return responses[tuple(argv)]
+        key = tuple(argv)
+        calls.append(key)
+        return responses[key]
 
     devices = BluetoothObdAdminHelper(runner=runner).scan_devices(timeout_s=8)
 
@@ -227,3 +175,11 @@ def test_scan_devices_sorts_human_readable_names_ahead_of_mac_aliases() -> None:
         "112233445566",
         "5340ac571177",
     ]
+    assert devices[0].name == "Audioengine HD6"
+    assert (
+        "bluetoothctl",
+        "--timeout",
+        "8",
+        "scan",
+        "on",
+    ) in calls

--- a/apps/server/tests/adapters/simulator/test_scripted_targeting.py
+++ b/apps/server/tests/adapters/simulator/test_scripted_targeting.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.adapters.simulator.scripted_targeting import matches_scripted_target
 
 
-def test_matches_scripted_target_supports_group_aliases_and_named_slots() -> None:
-    assert matches_scripted_target("front-left", "all")
-    assert matches_scripted_target("front-left", "front-axle")
-    assert matches_scripted_target("rear-left", "left-side")
-    assert matches_scripted_target("trunk", "body")
-    assert matches_scripted_target("front_left", "front-left")
-    assert not matches_scripted_target("trunk", "front-axle")
-    assert not matches_scripted_target("front-right", "rear-right")
+@pytest.mark.parametrize(
+    ("client_name", "target", "expected"),
+    [
+        ("front-left", "all", True),
+        ("front-left", "front-axle", True),
+        ("rear-left", "left-side", True),
+        ("trunk", "body", True),
+        ("front_left", "front-left", True),
+        ("trunk", "front-axle", False),
+        ("front-right", "rear-right", False),
+    ],
+)
+def test_matches_scripted_target_supports_aliases_and_named_slots(
+    client_name: str,
+    target: str,
+    expected: bool,
+) -> None:
+    assert matches_scripted_target(client_name, target) is expected

--- a/apps/server/tests/adapters/udp/test_protocol_validation.py
+++ b/apps/server/tests/adapters/udp/test_protocol_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import struct
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -65,16 +66,46 @@ def test_parse_too_short(parse_fn, short_data: bytes, match: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("parse_fn", "header_bytes", "match"),
+    ("parse_fn", "data", "match"),
     [
-        (parse_hello, HELLO_FIXED_BYTES, "Invalid HELLO header"),
-        (parse_data, DATA_HEADER_BYTES, "Invalid DATA header"),
-        (parse_cmd, CMD_HEADER_BYTES, "Invalid CMD header"),
+        (
+            parse_hello,
+            b"\xff\x01" + b"\x00" * (HELLO_FIXED_BYTES - 2),
+            "Invalid HELLO header",
+        ),
+        (
+            parse_data,
+            b"\xff\x01" + b"\x00" * (DATA_HEADER_BYTES - 2),
+            "Invalid DATA header",
+        ),
+        (
+            parse_cmd,
+            b"\xff\x01" + b"\x00" * (CMD_HEADER_BYTES - 2),
+            "Invalid CMD header",
+        ),
+        (
+            parse_ack,
+            ACK_STRUCT.pack(0xFF, 0x01, b"\x00" * 6, 0, 0),
+            "Invalid ACK header",
+        ),
+        (
+            parse_data_ack,
+            DATA_ACK_STRUCT.pack(0xFF, 0x01, b"\x00" * 6, 0),
+            "Invalid DATA_ACK header",
+        ),
+        (
+            parse_hello_ack,
+            HELLO_ACK_STRUCT.pack(0xFF, 0x01, b"\x00" * 6),
+            "Invalid HELLO_ACK header",
+        ),
     ],
-    ids=["hello", "data", "cmd"],
+    ids=["hello", "data", "cmd", "ack", "data_ack", "hello_ack"],
 )
-def test_parse_invalid_header(parse_fn, header_bytes: int, match: str) -> None:
-    data = b"\xff\x01" + b"\x00" * (header_bytes - 2)
+def test_parse_rejects_invalid_headers(
+    parse_fn: Callable[[bytes], object],
+    data: bytes,
+    match: str,
+) -> None:
     with pytest.raises(ProtocolError, match=match):
         parse_fn(data)
 
@@ -129,21 +160,6 @@ def test_pack_data_rejects_wrong_shape() -> None:
 def test_parse_wrong_size(parse_fn, short_data: bytes, match: str) -> None:
     with pytest.raises(ProtocolError, match=match):
         parse_fn(short_data)
-
-
-@pytest.mark.parametrize(
-    ("struct_", "parse_fn", "pack_args", "match"),
-    [
-        (ACK_STRUCT, parse_ack, (0xFF, 0x01, b"\x00" * 6, 0, 0), "Invalid ACK header"),
-        (DATA_ACK_STRUCT, parse_data_ack, (0xFF, 0x01, b"\x00" * 6, 0), "Invalid DATA_ACK header"),
-        (HELLO_ACK_STRUCT, parse_hello_ack, (0xFF, 0x01, b"\x00" * 6), "Invalid HELLO_ACK header"),
-    ],
-    ids=["ack", "data_ack", "hello_ack"],
-)
-def test_parse_ack_invalid_header(struct_, parse_fn, pack_args, match: str) -> None:
-    pkt = struct_.pack(*pack_args)
-    with pytest.raises(ProtocolError, match=match):
-        parse_fn(pkt)
 
 
 def test_parse_ack_rejects_unknown_extended_size() -> None:

--- a/apps/server/tests/adapters/udp/test_protocol_validator.py
+++ b/apps/server/tests/adapters/udp/test_protocol_validator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import numpy as np
 import pytest
 
@@ -23,10 +25,54 @@ from vibesensor.adapters.udp.protocol_validator import (
 from vibesensor.shared.exceptions import ProtocolError
 
 
-class TestValidateHeader:
-    def test_valid_header(self) -> None:
-        validate_header(label="TEST", msg_type=1, expected_msg_type=1, version=VERSION)
+def _validate_header_example() -> None:
+    validate_header(label="TEST", msg_type=1, expected_msg_type=1, version=VERSION)
 
+
+def _validate_data_frame_example() -> None:
+    validate_data_frame(
+        sample_count=10,
+        data_length=20 + 10 * 6,
+        header_bytes=20,
+        bytes_per_sample=6,
+    )
+
+
+def _validate_fixed_message_size_example() -> None:
+    validate_fixed_message_size(label="ACK", data_length=10, expected_size=10)
+
+
+def _validate_cmd_seq_examples() -> None:
+    validate_cmd_seq(0)
+    validate_cmd_seq(42)
+
+
+@pytest.mark.parametrize(
+    "validate",
+    [
+        _validate_header_example,
+        _validate_data_frame_example,
+        lambda: validate_hello_sample_rate(200),
+        _validate_fixed_message_size_example,
+        lambda: validate_minimum_size(label="HELLO", data_length=20, minimum=15),
+        lambda: validate_client_id(b"\x01\x02\x03\x04\x05\x06"),
+        _validate_cmd_seq_examples,
+    ],
+    ids=[
+        "header",
+        "data-frame",
+        "hello-sample-rate",
+        "fixed-size",
+        "minimum-size",
+        "client-id",
+        "cmd-seq",
+    ],
+)
+def test_protocol_validator_accepts_valid_inputs(validate: Callable[[], None]) -> None:
+    validate()
+
+
+class TestValidateHeader:
     def test_wrong_msg_type(self) -> None:
         with pytest.raises(ProtocolError, match="Invalid TEST header"):
             validate_header(label="TEST", msg_type=2, expected_msg_type=1, version=VERSION)
@@ -39,14 +85,6 @@ class TestValidateHeader:
 
 
 class TestValidateDataFrame:
-    def test_valid_data_frame(self) -> None:
-        validate_data_frame(
-            sample_count=10,
-            data_length=20 + 10 * 6,
-            header_bytes=20,
-            bytes_per_sample=6,
-        )
-
     def test_sample_count_exceeds_max(self) -> None:
         with pytest.raises(ProtocolError, match="exceeds maximum"):
             validate_data_frame(
@@ -76,46 +114,30 @@ class TestValidateDataFrame:
 
 
 class TestValidateHelloSampleRate:
-    def test_valid_rate(self) -> None:
-        validate_hello_sample_rate(200)
-
     def test_zero_rate(self) -> None:
         with pytest.raises(ProtocolError, match="must not be zero"):
             validate_hello_sample_rate(0)
 
 
 class TestValidateFixedMessageSize:
-    def test_correct_size(self) -> None:
-        validate_fixed_message_size(label="ACK", data_length=10, expected_size=10)
-
     def test_wrong_size(self) -> None:
         with pytest.raises(ProtocolError, match="ACK has unexpected size"):
             validate_fixed_message_size(label="ACK", data_length=8, expected_size=10)
 
 
 class TestValidateMinimumSize:
-    def test_sufficient_size(self) -> None:
-        validate_minimum_size(label="HELLO", data_length=20, minimum=15)
-
     def test_too_short(self) -> None:
         with pytest.raises(ProtocolError, match="HELLO too short"):
             validate_minimum_size(label="HELLO", data_length=5, minimum=15)
 
 
 class TestValidateClientId:
-    def test_valid_client_id(self) -> None:
-        validate_client_id(b"\x01\x02\x03\x04\x05\x06")
-
     def test_wrong_length(self) -> None:
         with pytest.raises(ValueError, match=f"{CLIENT_ID_BYTES} bytes"):
             validate_client_id(b"\x01\x02\x03")
 
 
 class TestValidateCmdSeq:
-    def test_valid_seq(self) -> None:
-        validate_cmd_seq(0)
-        validate_cmd_seq(42)
-
     def test_negative_seq(self) -> None:
         with pytest.raises(ValueError, match="non-negative"):
             validate_cmd_seq(-1)

--- a/apps/server/tests/infra/processing/test_sensor_units.py
+++ b/apps/server/tests/infra/processing/test_sensor_units.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from vibesensor.shared.sensor_units import ADXL345_SCALE_G_PER_LSB, SENSOR_MODEL
 
 
-def test_adxl345_scale_constant() -> None:
+def test_sensor_units_constants() -> None:
     assert abs(ADXL345_SCALE_G_PER_LSB - 1.0 / 256.0) < 1e-12
-
-
-def test_sensor_model_constant() -> None:
     assert SENSOR_MODEL == "ADXL345"

--- a/apps/server/tests/infra/runtime/test_registry_diagnostics.py
+++ b/apps/server/tests/infra/runtime/test_registry_diagnostics.py
@@ -29,23 +29,17 @@ def _make_diagnostics() -> tuple[RegistryDiagnostics, dict[str, ClientRecord]]:
     )
 
 
-def test_note_parse_error_creates_and_normalizes_client_record() -> None:
+def test_note_parse_error_normalizes_client_and_invalid_queue_drops_are_ignored() -> None:
     diagnostics, clients = _make_diagnostics()
 
     diagnostics.note_parse_error("AABBCCDDEEFF")
+    diagnostics.note_server_queue_drop(None)
+    diagnostics.note_server_queue_drop("not-a-client-id")
 
     record = clients["aabbccddeeff"]
     assert record.parse_errors == 1
     assert record.server_queue_drops == 0
-
-
-def test_note_server_queue_drop_ignores_missing_and_invalid_client_ids() -> None:
-    diagnostics, clients = _make_diagnostics()
-
-    diagnostics.note_server_queue_drop(None)
-    diagnostics.note_server_queue_drop("not-a-client-id")
-
-    assert clients == {}
+    assert list(clients) == ["aabbccddeeff"]
 
 
 def test_data_loss_snapshot_aggregates_counters_and_affected_clients() -> None:

--- a/apps/server/tests/shared/test_sensor_orientation.py
+++ b/apps/server/tests/shared/test_sensor_orientation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from vibesensor.shared.sensor_orientation import (
     estimate_gravity_axis,
@@ -9,18 +10,21 @@ from vibesensor.shared.sensor_orientation import (
 )
 
 
-def test_parse_mount_orientation_accepts_identity_aliases() -> None:
-    orientation = parse_mount_orientation("vehicle-aligned")
+@pytest.mark.parametrize(
+    ("raw", "vehicle_axes_from_sensor"),
+    [
+        ("vehicle-aligned", ("+x", "+y", "+z")),
+        ("+y,-x,+z", ("+y", "-x", "+z")),
+    ],
+)
+def test_parse_mount_orientation_accepts_aliases_and_axis_mappings(
+    raw: str,
+    vehicle_axes_from_sensor: tuple[str, str, str],
+) -> None:
+    orientation = parse_mount_orientation(raw)
 
     assert orientation is not None
-    assert orientation.vehicle_axes_from_sensor == ("+x", "+y", "+z")
-
-
-def test_parse_mount_orientation_accepts_signed_axis_mapping() -> None:
-    orientation = parse_mount_orientation("+y,-x,+z")
-
-    assert orientation is not None
-    assert orientation.vehicle_axes_from_sensor == ("+y", "-x", "+z")
+    assert orientation.vehicle_axes_from_sensor == vehicle_axes_from_sensor
 
 
 def test_parse_mount_orientation_rejects_unknown_or_duplicate_mapping() -> None:

--- a/apps/server/tests/shared/utils/test_constants_and_helpers.py
+++ b/apps/server/tests/shared/utils/test_constants_and_helpers.py
@@ -24,11 +24,8 @@ def test_kmh_to_mps_value() -> None:
     assert abs(100.0 * KMH_TO_MPS - 27.7778) < 0.001
 
 
-def test_silence_db_is_negative() -> None:
+def test_core_analysis_constants_have_expected_ranges() -> None:
     assert SILENCE_DB < 0
-
-
-def test_peak_constants_positive() -> None:
     assert PEAK_BANDWIDTH_HZ > 0
     assert PEAK_SEPARATION_HZ > 0
 

--- a/apps/ui/tests/format.spec.ts
+++ b/apps/ui/tests/format.spec.ts
@@ -2,15 +2,13 @@ import { describe, expect, test } from "vitest";
 import { fmtTs, formatEpochTimestamp } from "../src/format";
 
 describe("timestamp formatting helpers", () => {
-  test("formats ISO strings and epoch seconds through the same locale path", () => {
+  test("formats valid timestamps through locale path and falls back for invalid values", () => {
     const iso = "2024-01-02T03:04:05Z";
     const expected = new Date(iso).toLocaleString();
 
     expect(fmtTs(iso)).toBe(expected);
     expect(formatEpochTimestamp(Date.parse(iso) / 1000)).toBe(expected);
-  });
 
-  test("uses fallbacks for empty and invalid timestamps", () => {
     expect(fmtTs("")).toBe("--");
     expect(fmtTs("not-a-date")).toBe("--");
     expect(formatEpochTimestamp(null)).toBe("—");

--- a/apps/ui/tests/tab_list_keyboard_navigation.spec.ts
+++ b/apps/ui/tests/tab_list_keyboard_navigation.spec.ts
@@ -23,16 +23,14 @@ function makeKeyboardEvent(key: string): {
 }
 
 describe("tab_list_keyboard_navigation", () => {
-  test("normalizes wrapped tab indexes", () => {
-    expect(normalizeTabListIndex(3, 3)).toBe(0);
-    expect(normalizeTabListIndex(-1, 3)).toBe(2);
-    expect(normalizeTabListIndex(0, 0)).toBe(0);
-  });
-
-  test("activates and focuses wrapped arrow navigation targets", () => {
+  test("normalizes and focuses wrapped arrow navigation targets", () => {
     const activated: string[] = [];
     const focused: number[] = [];
     const { event, wasPrevented } = makeKeyboardEvent("ArrowLeft");
+
+    expect(normalizeTabListIndex(3, 3)).toBe(0);
+    expect(normalizeTabListIndex(-1, 3)).toBe(2);
+    expect(normalizeTabListIndex(0, 0)).toBe(0);
 
     handleTabListKeyboardNavigation({
       count: 3,

--- a/apps/ui/tests/ui_app_state.spec.ts
+++ b/apps/ui/tests/ui_app_state.spec.ts
@@ -61,6 +61,11 @@ describe("ui_app_state reactivity", () => {
     const state = createAppState();
     const seenRatios: number[] = [];
 
+    expect({
+      ...state.settings.car.activeVehicleSettings.value,
+      ...state.settings.analysis.vehicleSettings.value,
+    }).toEqual(defaultAnalysisSettings);
+
     const dispose = effect(() => {
       seenRatios.push(
         state.settings.car.activeVehicleSettings.value.current_gear_ratio,
@@ -77,15 +82,6 @@ describe("ui_app_state reactivity", () => {
     expect(seenRatios).toEqual([0.64, 0.72]);
 
     dispose();
-  });
-
-  test("hydrates vehicle defaults from generated backend constants", () => {
-    const state = createAppState();
-
-    expect({
-      ...state.settings.car.activeVehicleSettings.value,
-      ...state.settings.analysis.vehicleSettings.value,
-    }).toEqual(defaultAnalysisSettings);
   });
 
   test("keeps slice notifications isolated", () => {


### PR DESCRIPTION
Fixes #3956.

What changed:
- Merged repeated backend helper and protocol micro-tests into parameterized or adjacent behavior tests.
- Covered HTTP route error mapping, OBD scan ordering, simulator targeting, UDP parser/validator inputs, constants, registry diagnostics, and sensor orientation with fewer test bodies.
- Merged small UI helper/state tests for timestamp formatting, tab index wrapping, and app-state default hydration into neighboring behavior tests.

Why:
- Keep the same behavior coverage with less duplicated setup and fewer one-assertion variants.

Validation:
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/http/test_helpers_exception_handling.py apps/server/tests/adapters/obd/test_admin_helper.py apps/server/tests/adapters/simulator/test_scripted_targeting.py apps/server/tests/adapters/udp/test_protocol_validation.py apps/server/tests/adapters/udp/test_protocol_validator.py apps/server/tests/infra/processing/test_sensor_units.py apps/server/tests/infra/runtime/test_registry_diagnostics.py apps/server/tests/shared/test_sensor_orientation.py apps/server/tests/shared/utils/test_constants_and_helpers.py`
- `cd apps/ui && npm run test:unit -- tests/format.spec.ts tests/tab_list_keyboard_navigation.spec.ts tests/ui_app_state.spec.ts`
- `make plan-validation`
- `make lint`
- `make ui-typecheck`

Risks / edge cases:
- Test-only refactor. No production code changed.
- UI typecheck surfaced existing Biome warnings in unrelated files, but completed successfully.

Follow-ups:
- None.