### PR TITLE
Improve diagnostics run tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_analysis_units_db_only.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_units_db_only.py
@@ -100,13 +100,21 @@ def test_analysis_modules_use_canonical_db_helper() -> None:
     """Analysis modules must use the canonical vibration_strength_db_scalar helper."""
     analysis_root = SERVER_ROOT / "vibesensor" / "use_cases" / "diagnostics"
 
-    alias_users = [
-        str(py_file.relative_to(analysis_root))
-        for py_file in sorted(analysis_root.rglob("*.py"))
-        if "as canonical_vibration_db" in py_file.read_text(encoding="utf-8")
-    ]
+    alias_users: list[str] = []
+    legacy_scalar_users: list[str] = []
+    for py_file in sorted(analysis_root.rglob("*.py")):
+        relative = str(py_file.relative_to(analysis_root))
+        source = py_file.read_text(encoding="utf-8")
+        if "as canonical_vibration_db" in source:
+            alias_users.append(relative)
+        if "vibration_strength_scalar" in source:
+            legacy_scalar_users.append(relative)
 
     assert not alias_users, (
         "Analysis modules must import vibration_strength_db_scalar directly; "
         "aliased imports found in: " + ", ".join(alias_users)
+    )
+    assert not legacy_scalar_users, (
+        "Analysis modules must not use raw scalar strength helpers; "
+        "legacy helpers found in: " + ", ".join(legacy_scalar_users)
     )

--- a/apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py
@@ -24,9 +24,11 @@ from test_support import (
     SPEED_LOW,
     SPEED_MID,
     assert_confidence_label_valid,
+    assert_has_warnings,
     assert_no_wheel_fault,
     extract_top,
     make_profile_fault_samples,
+    parse_speed_band,
     profile_metadata,
     run_analysis,
     top_confidence,
@@ -60,6 +62,8 @@ def test_strong_single_sensor_reaches_high_confidence(profile: dict[str, Any], c
     meta = profile_metadata(profile)
     summary = run_analysis(samples, metadata=meta)
     conf = top_confidence(summary)
+    assert_confidence_label_valid(summary)
+    assert_has_warnings(summary)
     assert conf >= 0.60, (
         f"Strong single-sensor fault at {corner} ({profile['name']}) "
         f"gave conf={conf:.3f}, expected ≥0.60"
@@ -91,11 +95,15 @@ def test_strong_4sensor_fault_reaches_medium_confidence(
     )
     meta = profile_metadata(profile)
     summary = run_analysis(samples, metadata=meta)
+    top = extract_top(summary)
+    assert top is not None
     conf = top_confidence(summary)
     assert conf >= 0.40, (
         f"Strong fault at {corner}/{speed} ({profile['name']}) gave conf={conf:.3f}, expected ≥0.40"
     )
     assert_confidence_label_valid(summary)
+    band = parse_speed_band(top)
+    assert band[0] <= speed <= band[1]
 
 
 # ===================================================================
@@ -204,8 +212,8 @@ def test_spatial_separation_effect(profile: dict[str, Any], corner: str, speed: 
     assert conf_4 > 0.25, (
         f"4-sensor should produce a finding at {corner}/{speed} ({profile['name']})"
     )
-    assert abs(conf_1 - conf_4) > 0.01, (
-        f"Confidence should differ between 1-sensor and 4-sensor "
+    assert conf_1 > conf_4, (
+        f"Spatial separation should reduce 4-sensor confidence vs 1-sensor "
         f"at {corner}/{speed} ({profile['name']})"
     )
 

--- a/apps/server/tests/use_cases/diagnostics/test_contradictory_phase_signals.py
+++ b/apps/server/tests/use_cases/diagnostics/test_contradictory_phase_signals.py
@@ -30,6 +30,7 @@ from test_support import (
     SPEED_HIGH,
     SPEED_LOW,
     SPEED_MID,
+    assert_confidence_label_valid,
     make_fault_samples,
     make_noise_samples,
     make_profile_fault_samples,
@@ -220,6 +221,7 @@ def test_transient_plus_persistent(
     # Sort by time for realism
     samples.sort(key=lambda s: s["t_s"])
     summary = run_analysis(samples)
+    assert_confidence_label_valid(summary)
     conf = top_confidence(summary)
     assert conf > 0.0, f"Transient + persistent at {corner} ({pos_name}) should detect the fault"
 
@@ -263,6 +265,7 @@ def test_fault_then_noise(corner: str, split_name: str, fault_n: int, noise_n: i
 
     samples = fault_phase + noise_phase
     summary = run_analysis(samples)
+    assert_confidence_label_valid(summary)
     conf = top_confidence(summary)
     assert conf > 0.0, f"Fault→noise at {corner} ({split_name}) should still detect the fault"
 

--- a/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py
@@ -308,6 +308,8 @@ class TestGpsSpeedValidation:
             assert monitor.speed_mps == 10.0, (
                 f"{label} speed leaked into speed_mps: {monitor.speed_mps}"
             )
+            assert monitor.resolve_speed().source == "gps"
+            assert monitor.resolve_speed().speed_mps == 10.0
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
             server.close()

--- a/apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py
@@ -53,7 +53,17 @@ def _metadata() -> RunMetadata:
 
 
 def test_run_metadata_is_the_diagnostics_context() -> None:
-    metadata = _metadata()
+    metadata_payload = _context_metadata()
+    metadata_payload.update(
+        {
+            "final_drive_ratio": 9.99,
+            "current_gear_ratio": 1.99,
+            "car_name": "Flat Name",
+            "car_type": "truck",
+            "car_variant": "flat",
+        },
+    )
+    metadata = normalize_run_metadata(run_metadata_from_mapping(metadata_payload), file_name="ctx")
 
     assert metadata.run_id == "ctx-run"
     assert metadata.raw_sample_rate_hz == 200.0
@@ -68,21 +78,6 @@ def test_run_metadata_is_the_diagnostics_context() -> None:
     assert metadata.symptom.description == "driveline hum"
     assert metadata.symptom.onset == "after 60 km/h"
     assert metadata.symptom.context == "during acceleration"
-
-
-def test_run_metadata_prefers_nested_snapshot_over_conflicting_flat_aliases() -> None:
-    metadata_payload = _context_metadata()
-    metadata_payload.update(
-        {
-            "final_drive_ratio": 9.99,
-            "current_gear_ratio": 1.99,
-            "car_name": "Flat Name",
-            "car_type": "truck",
-            "car_variant": "flat",
-        },
-    )
-
-    metadata = normalize_run_metadata(run_metadata_from_mapping(metadata_payload), file_name="ctx")
     spec = metadata.order_reference_spec
 
     assert spec is not None

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -165,6 +165,10 @@ class TestComputeOrderConfidence:
         assert stronger > weaker
         assert CONFIDENCE_FLOOR <= weaker <= CONFIDENCE_CEILING
         assert CONFIDENCE_FLOOR <= stronger <= CONFIDENCE_CEILING
+        baseline = _compute_order_confidence(**self._BASE_INPUTS)
+        steady = _compute_order_confidence(**{**self._BASE_INPUTS, "steady_speed": True})
+        constant = _compute_order_confidence(**{**self._BASE_INPUTS, "constant_speed": True})
+        assert stronger > baseline > steady > constant
 
     def test_negligible_strength_cap_reduces_same_signal_to_cap(self) -> None:
         capped = _compute_order_confidence(
@@ -176,19 +180,6 @@ class TestComputeOrderConfidence:
 
         assert capped <= ORDER_CONFIDENCE_SETTINGS.negligible_strength_confidence_cap
         assert uncapped > capped
-
-    def test_constant_and_steady_speed_penalties_apply_in_order(self) -> None:
-        baseline = _compute_order_confidence(
-            **self._BASE_INPUTS,
-        )
-        steady = _compute_order_confidence(
-            **{**self._BASE_INPUTS, "steady_speed": True},
-        )
-        constant = _compute_order_confidence(
-            **{**self._BASE_INPUTS, "constant_speed": True},
-        )
-
-        assert baseline > steady > constant
 
     def test_confidence_minimum_inputs(self) -> None:
         conf = _compute_order_confidence(

--- a/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py
+++ b/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py
@@ -62,49 +62,38 @@ class TestSpeedBandAttribution:
 
 
 class TestWheelVsEngineDrivelineGating:
-    def test_wheel_1x_not_misclassified_as_engine(self) -> None:
+    @pytest.mark.parametrize(
+        "samples",
+        [
+            build_speed_sweep_fault_samples(
+                speed_start_kmh=40.0,
+                speed_end_kmh=120.0,
+                fault_sensor="front-right",
+                other_sensors=["front-left", "rear-left", "rear-right"],
+                n_samples=50,
+                fault_amp=0.06,
+                fault_vib_db=24.0,
+            ),
+            build_fault_samples_at_speed(
+                speed_kmh=80.0,
+                fault_sensor="rear-left",
+                other_sensors=["front-left", "front-right", "rear-right"],
+                n_samples=40,
+                fault_amp=0.05,
+                fault_vib_db=22.0,
+            ),
+        ],
+        ids=["speed-sweep", "constant-speed"],
+    )
+    def test_wheel_1x_not_misclassified_as_engine(self, samples) -> None:
         top = extract_top_finding(
             summarize_run_data(
                 standard_metadata(),
-                build_speed_sweep_fault_samples(
-                    speed_start_kmh=40.0,
-                    speed_end_kmh=120.0,
-                    fault_sensor="front-right",
-                    other_sensors=["front-left", "rear-left", "rear-right"],
-                    n_samples=50,
-                    fault_amp=0.06,
-                    fault_vib_db=24.0,
-                ),
+                samples,
                 include_samples=False,
             ),
         )
         assert "engine" not in str(top.get("suspected_source") or "").lower()
-
-    def test_constant_speed_wheel_not_engine(self) -> None:
-        findings = [
-            f
-            for f in summarize_run_data(
-                standard_metadata(),
-                build_fault_samples_at_speed(
-                    speed_kmh=80.0,
-                    fault_sensor="rear-left",
-                    other_sensors=["front-left", "front-right", "rear-right"],
-                    n_samples=40,
-                    fault_amp=0.05,
-                    fault_vib_db=22.0,
-                ),
-                include_samples=False,
-            ).get("findings", [])
-            if isinstance(f, dict) and not str(f.get("finding_id", "")).startswith("REF_")
-        ]
-        if findings:
-            source = str(
-                max(findings, key=lambda f: float(f.get("confidence") or 0)).get(
-                    "suspected_source",
-                )
-                or "",
-            ).lower()
-            assert "wheel" in source or "tire" in source or "unknown" in source
 
 
 class TestConfidenceWithSpatialAmbiguity:

--- a/apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py
+++ b/apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py
@@ -102,36 +102,25 @@ def test_strength_metrics_no_dead_aliases() -> None:
     assert not present, f"Dead alias fields in compute_vibration_strength_db: {present}"
 
 
-def test_constants_used_for_speed_conversion() -> None:
-    """Speed conversion must use constants, not hardcoded 3.6."""
+def test_analysis_constants_single_source_of_truth() -> None:
+    """Core analysis constants must expose the expected canonical values."""
+    import inspect
+
+    from vibesensor.shared.constants.analysis import SILENCE_DB
+    from vibesensor.shared.constants.dsp import PEAK_BANDWIDTH_HZ, PEAK_SEPARATION_HZ
     from vibesensor.shared.constants.units import KMH_TO_MPS, MPS_TO_KMH
+    from vibesensor.vibration_strength import compute_vibration_strength_db
 
     assert MPS_TO_KMH == 3.6
     assert abs(KMH_TO_MPS - 1.0 / 3.6) < 1e-15
     assert abs(MPS_TO_KMH * KMH_TO_MPS - 1.0) < 1e-15
-
-
-def test_constants_used_for_peak_detection() -> None:
-    """Peak detection defaults must come from constants module."""
-    from vibesensor.shared.constants.dsp import PEAK_BANDWIDTH_HZ, PEAK_SEPARATION_HZ
-    from vibesensor.vibration_strength import compute_vibration_strength_db
-
+    assert SILENCE_DB == -120.0
     assert PEAK_BANDWIDTH_HZ == 1.2
     assert PEAK_SEPARATION_HZ == 1.2
-
-    # Verify the function signature defaults match constants
-    import inspect
 
     sig = inspect.signature(compute_vibration_strength_db)
     assert sig.parameters["peak_bandwidth_hz"].default == PEAK_BANDWIDTH_HZ
     assert sig.parameters["peak_separation_hz"].default == PEAK_SEPARATION_HZ
-
-
-def test_silence_db_constant() -> None:
-    """SILENCE_DB must be the canonical silence floor value."""
-    from vibesensor.shared.constants.analysis import SILENCE_DB
-
-    assert SILENCE_DB == -120.0
 
 
 def test_esp_protocol_constants_match_python() -> None:
@@ -240,14 +229,19 @@ def test_protocol_docs_byte_sizes_match() -> None:
         "ACK sync clock bytes": ACK_SYNC_CLOCK_BYTES,
         "DATA_ACK bytes": DATA_ACK_BYTES,
     }
+    missing_labels: list[str] = []
+    mismatches: list[str] = []
     for label, value in expected.items():
         pattern = rf"{re.escape(label)}.*`(\d+)`"
         m = re.search(pattern, doc, re.IGNORECASE)
-        assert m, f"docs/protocol.md missing entry for '{label}'"
+        if not m:
+            missing_labels.append(label)
+            continue
         doc_value = int(m.group(1))
-        assert doc_value == value, (
-            f"docs/protocol.md says {label} = {doc_value} but code says {value}"
-        )
+        if doc_value != value:
+            mismatches.append(f"{label}: docs={doc_value} code={value}")
+    assert not missing_labels, "docs/protocol.md missing entries: " + ", ".join(missing_labels)
+    assert not mismatches, "docs/protocol.md byte-size mismatches: " + ", ".join(mismatches)
 
 
 def test_protocol_docs_match_generated_contract_reference() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_speed_metadata_edge_cases.py
+++ b/apps/server/tests/use_cases/diagnostics/test_speed_metadata_edge_cases.py
@@ -21,8 +21,11 @@ from test_support import (
     SPEED_HIGH,
     SPEED_LOW,
     SPEED_MID,
+    assert_confidence_label_valid,
     assert_no_wheel_fault,
+    extract_top,
     make_sample,
+    parse_speed_band,
     run_analysis,
     top_confidence,
     wheel_hz,
@@ -115,8 +118,13 @@ def test_frozen_speed_with_fault(corner: str, sensor: str, speed: float) -> None
     )
     summary = run_analysis(samples)
     # Frozen/constant speed gets a penalty but should still detect
+    assert_confidence_label_valid(summary)
     conf = top_confidence(summary)
     assert conf > 0.0, f"No fault detected at frozen speed={speed}, corner={corner}"
+    top = extract_top(summary)
+    assert top is not None
+    speed_band = parse_speed_band(top)
+    assert speed_band[0] <= speed <= speed_band[1]
 
 
 # ===================================================================

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 import numpy as np
+import pytest
 from test_support.report_helpers import diagnostics_context, wheel_metadata
 from test_support.sample_scenarios import make_analysis_sample
 
@@ -431,31 +432,39 @@ def test_build_whole_run_order_trace_artifact_bundle_is_deterministic() -> None:
     assert first.points == second.points
 
 
-def test_whole_run_order_summary_tracks_constant_speed_order_lock() -> None:
-    labels = _context_labels(speeds=(60.0, 60.0, 60.0), rpm_values=(1500.0, 1500.0, 1500.0))
-    summary = _wheel_1x_summary(_summary_bundle_for(context_labels=labels))
-
-    assert summary.support_ratio == 1.0
-    assert summary.lock_score > 0.95
-    assert summary.stable_frequency_min_hz == summary.stable_frequency_max_hz
-    assert summary.exemplar_interval_index == 0
-    assert [
-        (interval.start_window_index, interval.end_window_index)
-        for interval in summary.support_intervals
-    ] == [(0, 2)]
-    assert summary.phase_support[0].phase == DrivingPhase.CRUISE.value
-    assert summary.phase_support[0].support_ratio == 1.0
-
-
-def test_whole_run_order_summary_tracks_acceleration_sweep_order_lock() -> None:
-    summary = _wheel_1x_summary(_summary_bundle_for())
+@pytest.mark.parametrize(
+    ("context_labels", "stable_frequency_locked"),
+    [
+        (
+            _context_labels(speeds=(60.0, 60.0, 60.0), rpm_values=(1500.0, 1500.0, 1500.0)),
+            True,
+        ),
+        (_context_labels(), False),
+    ],
+    ids=["constant-speed", "acceleration-sweep"],
+)
+def test_whole_run_order_summary_tracks_order_lock(
+    context_labels,
+    stable_frequency_locked: bool,
+) -> None:
+    summary = _wheel_1x_summary(_summary_bundle_for(context_labels=context_labels))
 
     assert summary.support_ratio == 1.0
     assert summary.lock_score > 0.95
     assert summary.stable_frequency_min_hz is not None
     assert summary.stable_frequency_max_hz is not None
-    assert summary.stable_frequency_min_hz < summary.stable_frequency_max_hz
-    assert summary.support_intervals[0].matched_window_count == 3
+    if stable_frequency_locked:
+        assert summary.stable_frequency_min_hz == summary.stable_frequency_max_hz
+        assert summary.exemplar_interval_index == 0
+        assert [
+            (interval.start_window_index, interval.end_window_index)
+            for interval in summary.support_intervals
+        ] == [(0, 2)]
+        assert summary.phase_support[0].phase == DrivingPhase.CRUISE.value
+        assert summary.phase_support[0].support_ratio == 1.0
+    else:
+        assert summary.stable_frequency_min_hz < summary.stable_frequency_max_hz
+        assert summary.support_intervals[0].matched_window_count == 3
 
 
 def test_whole_run_order_summary_does_not_lock_fixed_resonance_to_speed_sweep() -> None:

--- a/apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,10 @@ def test_post_analysis_golden_replay_fast_subset(
     )
 
     assert snapshot_path.exists()
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert snapshot["case_id"] == fixture.case_id
+    assert snapshot["expected"]["suspected_source"] == fixture.expected.suspected_source
+    assert snapshot["artifact_paths"] == result.manifest.generated_artifact_paths
     metadata = result.analysis.get("analysis_metadata")
     assert isinstance(metadata, dict)
     assert metadata["whole_run_artifacts_available"] is True

--- a/apps/server/tests/use_cases/run/test_recorder_finalization_flow.py
+++ b/apps/server/tests/use_cases/run/test_recorder_finalization_flow.py
@@ -150,11 +150,16 @@ def test_stop_recording_persists_finalization_stages_in_history_metadata(
     stored_metadata = history_db.run_repository.get_run_metadata(snapshot.run_id)
     assert stored_metadata is not None
     stage_by_name = {stage.stage_name: stage for stage in stored_metadata.finalization_stages}
+    assert [stage.stage_name for stage in stored_metadata.finalization_stages] == list(
+        expected_statuses,
+    )
     assert {name: stage.status for name, stage in stage_by_name.items()} == expected_statuses
     assert (
         stage_by_name["ResolvePostAnalysisCandidateStage"].diagnostic_context["reason"]
         == expected_resolve_reason
     )
+    assert stored_metadata.raw_capture_finalize is not None
+    assert stored_metadata.raw_capture_finalize.status == raw_capture_status
 
 
 def test_late_raw_capture_finalize_schedules_post_analysis_after_metadata_update(

--- a/apps/server/tests/use_cases/run/test_run_context.py
+++ b/apps/server/tests/use_cases/run/test_run_context.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot, RunContextSnapshot
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.run_context_warning import (
@@ -30,41 +32,52 @@ class TestBuildRunContextSnapshot:
 
 
 class TestOrderReferenceContextComplete:
-    def test_uses_canonical_nested_metadata(self) -> None:
-        metadata = run_metadata_from_mapping(
-            {
-                "run_id": "run-1",
-                "start_time_utc": "2025-01-01T00:00:00Z",
-                "sensor_model": "fixture-sensor",
-                "raw_sample_rate_hz": 800,
-                "analysis_settings_snapshot": {
+    @pytest.mark.parametrize(
+        ("metadata_payload", "expected"),
+        [
+            (
+                {
+                    "run_id": "run-1",
+                    "start_time_utc": "2025-01-01T00:00:00Z",
+                    "sensor_model": "fixture-sensor",
+                    "raw_sample_rate_hz": 800,
+                    "analysis_settings_snapshot": {
+                        "tire_width_mm": 255.0,
+                        "tire_aspect_pct": 40.0,
+                        "rim_in": 19.0,
+                        "final_drive_ratio": 3.15,
+                        "current_gear_ratio": 0.81,
+                    },
+                },
+                True,
+            ),
+            (
+                {
+                    "run_id": "run-legacy",
+                    "start_time_utc": "2025-01-01T00:00:00Z",
+                    "sensor_model": "fixture-sensor",
+                    "raw_sample_rate_hz": 800,
                     "tire_width_mm": 255.0,
                     "tire_aspect_pct": 40.0,
                     "rim_in": 19.0,
                     "final_drive_ratio": 3.15,
                     "current_gear_ratio": 0.81,
                 },
-            },
-        )
-
-        assert order_reference_context_complete(metadata) is True
-
-    def test_ignores_flat_legacy_metadata_aliases(self) -> None:
+                False,
+            ),
+        ],
+        ids=["nested-snapshot", "flat-legacy-aliases"],
+    )
+    def test_order_reference_context_uses_only_canonical_nested_metadata(
+        self,
+        metadata_payload: dict[str, object],
+        expected: bool,
+    ) -> None:
         metadata = run_metadata_from_mapping(
-            {
-                "run_id": "run-legacy",
-                "start_time_utc": "2025-01-01T00:00:00Z",
-                "sensor_model": "fixture-sensor",
-                "raw_sample_rate_hz": 800,
-                "tire_width_mm": 255.0,
-                "tire_aspect_pct": 40.0,
-                "rim_in": 19.0,
-                "final_drive_ratio": 3.15,
-                "current_gear_ratio": 0.81,
-            },
+            metadata_payload,
         )
 
-        assert order_reference_context_complete(metadata) is False
+        assert order_reference_context_complete(metadata) is expected
 
 
 class TestCurrentContextWarnings:

--- a/apps/server/tests/use_cases/test_isolated_server_runtime.py
+++ b/apps/server/tests/use_cases/test_isolated_server_runtime.py
@@ -36,9 +36,12 @@ def test_build_isolated_server_config_rewrites_runtime_paths_and_copies_seed_dat
 
     assert result.root == runtime_root
     assert result.config_path == runtime_root / "shard.yaml"
+    assert result.data_dir == runtime_root / "data"
+    assert result.data_dir.is_dir()
     assert (result.data_dir / "vehicle_configurations" / "brand" / "family" / "GEN.json").read_text(
         encoding="utf-8"
     ) == "[]\n"
+    assert seed_vehicle_path.read_text(encoding="utf-8") == "[]\n"
 
     data = yaml.safe_load(result.config_path.read_text(encoding="utf-8"))
     assert data["server"] == {"host": "127.0.0.1", "port": 18080}


### PR DESCRIPTION
Fixes #3957.

What changed:
- Strengthened diagnostics/run tests around confidence labels, speed bands, metadata precedence, GPS speed rejection, golden replay snapshots, recorder finalization metadata, and isolated runtime paths.
- Merged adjacent duplicate context/order-lock/protocol constant checks into parameterized or combined behavior tests.
- Kept scope to test code only.

Why:
- The affected tests now assert the behavior they are meant to protect instead of only checking broad existence or single narrow values.

Validation:
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_analysis_units_db_only.py apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py apps/server/tests/use_cases/diagnostics/test_contradictory_phase_signals.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py apps/server/tests/use_cases/diagnostics/test_speed_metadata_edge_cases.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py apps/server/tests/use_cases/run/test_recorder_finalization_flow.py apps/server/tests/use_cases/run/test_run_context.py apps/server/tests/use_cases/test_isolated_server_runtime.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`

Risks / edge cases:
- Test-only change. No production code changed.
- Assertions stay on existing outputs and avoid adding new fixtures or broad scenario expansion.

Follow-ups:
- None.