### PR TITLE
Improve PDF workflow rendering tests

### DIFF
--- a/apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py
+++ b/apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py
@@ -10,6 +10,7 @@ from test_support.report_helpers import report_sample as base_sample
 
 __all__ = [
     "assert_pdf_contains",
+    "extract_pdf_pages_text",
     "extract_media_box",
     "sample",
 ]
@@ -35,6 +36,11 @@ def sample(
 def assert_pdf_contains(pdf_bytes: bytes, text: str) -> None:
     extracted = "\n".join(page.extract_text() or "" for page in PdfReader(BytesIO(pdf_bytes)).pages)
     assert text in extracted
+
+
+def extract_pdf_pages_text(pdf_bytes: bytes) -> tuple[str, ...]:
+    reader = PdfReader(BytesIO(pdf_bytes))
+    return tuple(" ".join((page.extract_text() or "").split()) for page in reader.pages)
 
 
 def extract_media_box(pdf_bytes: bytes) -> tuple[float, float, float, float]:

--- a/apps/server/tests/adapters/pdf/test_page1_action_preview.py
+++ b/apps/server/tests/adapters/pdf/test_page1_action_preview.py
@@ -56,6 +56,7 @@ def test_page_one_long_wheel_action_does_not_silently_truncate() -> None:
     assert "Check Front-Left tire for shoulder wear" in text
     assert "pressure mismatch" in text
     assert "before balancing" in text
+    assert "otherwise keep the decision path open" in text
 
 
 def test_page_one_recapture_action_does_not_silently_truncate() -> None:
@@ -88,6 +89,8 @@ def test_page_one_recapture_action_does_not_silently_truncate() -> None:
 
     assert "Repeat the same speed band" in text
     assert "separate the overlapping source paths" in text
+    assert "Best available location signal" in text
+    assert "Action status" in text
 
 
 def test_page_one_generated_alternative_caveat_names_fallback_path() -> None:
@@ -124,6 +127,7 @@ def test_page_one_generated_alternative_caveat_names_fallback_path() -> None:
     assert document.verdict_page.action_status_note == (
         "If first check is clean: Inspect Driveline next"
     )
+    assert document.verdict_page.fallback_path == "Inspect Driveline next"
     assert "alternative source still in scope" not in text
     assert "if the primary path is clean" in text
     assert "inspect driveline next" in text
@@ -192,3 +196,4 @@ def test_page_one_diagram_uses_verdict_dominant_corner() -> None:
             "suspected_source": "Engine",
         },
     )
+    assert all(finding["strongest_location"] != "Front Left" for finding in diagram_findings)

--- a/apps/server/tests/adapters/pdf/test_page1_header.py
+++ b/apps/server/tests/adapters/pdf/test_page1_header.py
@@ -72,6 +72,8 @@ def test_draw_header_strip_truncates_long_car_name_to_single_line(
     drawn_texts = [str(call["text"]) for call in calls]
     assert "12.3 s" in drawn_texts
     assert "60-90 km/h" in drawn_texts
-    assert any(text.endswith("...") for text in drawn_texts)
+    truncated_car_name = next(text for text in drawn_texts if text.endswith("..."))
+    assert truncated_car_name.startswith("A very long car name")
+    assert plan.car_name not in drawn_texts
     assert next(call for call in calls if call["text"] == "60-90 km/h")["max_lines"] == 2
-    assert all(call["max_lines"] == 1 for call in calls if call["text"] != "60-90 km/h")
+    assert next(call for call in calls if call["text"] == truncated_car_name)["max_lines"] == 1

--- a/apps/server/tests/adapters/pdf/test_report_confidence_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_confidence_rendering.py
@@ -84,5 +84,6 @@ def test_pdf_renders_confidence_row_and_explicit_caveats() -> None:
     text = extract_pdf_text(pdf)
 
     assert "Confidence" in text
+    assert "74%" in text
     assert "only summary-level evidence was available" in text
     assert "matched frequency drifted across 12.1-15.6 Hz" in text

--- a/apps/server/tests/adapters/pdf/test_report_i18n.py
+++ b/apps/server/tests/adapters/pdf/test_report_i18n.py
@@ -89,6 +89,7 @@ def test_all_source_referenced_keys_exist_in_json() -> None:
         for match in pattern.finditer(py_file.read_text(encoding="utf-8")):
             referenced_keys.add(match.group(1))
     assert referenced_keys, "Sanity: should find at least some keys"
+    assert len(referenced_keys) > 100
     missing = sorted(referenced_keys - set(data.keys()))
     assert missing == [], f"Keys referenced in source but missing from JSON: {missing}"
 

--- a/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import json
-from io import BytesIO
 
 from _paths import SERVER_ROOT
-from pypdf import PdfReader
+from _report_pdf_test_helpers import extract_pdf_pages_text
 from test_support.pdf import extract_pdf_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
@@ -83,6 +82,8 @@ def test_full_report_template_contains_peak_db_column_labels() -> None:
 
     assert i18n["REPORT_PEAK_DB_COLUMN"]["en"] in text
     assert i18n["REPORT_STRENGTH_DB_COLUMN"]["en"] in text
+    assert "Speed window" in text
+    assert "50-60 km/h" in text
 
 
 def test_pdf_additional_observations_heading_for_transient_findings() -> None:
@@ -99,8 +100,10 @@ def test_pdf_additional_observations_heading_for_transient_findings() -> None:
 
     pdf = build_report_pdf(data)
     text = extract_pdf_text(pdf)
+    compact_text = " ".join(text.split())
 
     assert i18n["ADDITIONAL_OBSERVATIONS"]["en"] in text
+    assert "Transient impact evidence was also seen near Front-Left." in compact_text
     assert "(22%)" not in text
 
 
@@ -126,6 +129,7 @@ def test_dutch_proof_window_speed_uses_km_u_unit() -> None:
     text = extract_pdf_text(build_report_pdf(data))
 
     assert "67 km/u" in text
+    assert "P1" in text
     assert "67 km/h" not in text
 
 
@@ -153,6 +157,7 @@ def test_worksheet_keeps_freeform_inspect_targets_verbatim() -> None:
     text = " ".join(extract_pdf_text(build_report_pdf(data)).split())
 
     assert "Front-Right engine mount/accessory area" in text
+    assert "Inspect the front-right engine mount." in text
     assert "Front Right Engine Mount/accessory Area" not in text
 
 
@@ -182,10 +187,11 @@ def test_page_one_does_not_render_support_duration_as_elapsed_runtime() -> None:
             next_steps=[NextStep(action="Check Front-Left wheel and tire first.")],
         )
     )
-    reader = PdfReader(BytesIO(pdf))
-    page_one_text = " ".join((reader.pages[0].extract_text() or "").split()).lower()
-    all_text = " ".join((page.extract_text() or "") for page in reader.pages).lower()
+    pages_text = extract_pdf_pages_text(pdf)
+    page_one_text = pages_text[0].lower()
+    all_text = " ".join(pages_text).lower()
 
     assert "00:20.3" in page_one_text
     assert "supporting windows across 65.8 s" not in page_one_text
     assert "263 supporting windows across 65.8 s" in all_text
+    assert any("263 supporting windows across 65.8 s" in page.lower() for page in pages_text[1:])

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import pytest
 from _report_pdf_test_helpers import (
+    assert_pdf_contains,
     extract_media_box,
+    extract_pdf_pages_text,
     sample,
 )
 from test_support.pdf import extract_pdf_text
@@ -49,6 +51,8 @@ def test_report_pdf_uses_a4_portrait_media_box(tmp_path: Path) -> None:
     )
     width = x1 - x0
     height = y1 - y0
+    assert width == pytest.approx(595.276, abs=0.01)
+    assert height == pytest.approx(841.89, abs=0.01)
     assert height > width
 
 
@@ -71,6 +75,8 @@ def test_report_pdf_allows_samples_without_strength_bucket(tmp_path: Path) -> No
     assert summary["sensor_intensity_by_location"][0]["strength_bucket_distribution"]["total"] == 8
     rendered_pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
     assert rendered_pdf.startswith(b"%PDF")
+    assert_pdf_contains(rendered_pdf, "VibeSensor Diagnostic Report")
+    assert "None" not in extract_pdf_text(rendered_pdf)
 
 
 def test_report_pdf_worksheet_has_single_next_steps_heading(tmp_path: Path) -> None:
@@ -89,12 +95,12 @@ def test_report_pdf_worksheet_has_single_next_steps_heading(tmp_path: Path) -> N
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
-    text_blob = extract_pdf_text(
-        build_report_pdf(
-            build_report_document(prepare_report_input(summarize_log(run_path))),
-        ),
+    pages_text = extract_pdf_pages_text(
+        build_report_pdf(build_report_document(prepare_report_input(summarize_log(run_path)))),
     )
+    text_blob = "\n".join(pages_text)
     assert text_blob.count("What to do next") == 1
+    assert "What to do next" in pages_text[0]
 
 
 def test_report_pdf_nl_localizes_header_metadata_labels(tmp_path: Path) -> None:
@@ -148,6 +154,7 @@ def test_report_pdf_header_contains_firmware_version(tmp_path: Path) -> None:
     )
     assert "Firmware Version" in text_blob
     assert "esp-fw-1.2.3" in text_blob
+    assert "Raw Sample Rate (Hz)" in text_blob
 
 
 def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
@@ -310,3 +317,8 @@ def test_car_diagram_omits_sensor_labels() -> None:
         }
     ]
     assert labels == []
+    diagram_text = " ".join(
+        str(getattr(item, "text", "")) for item in diagram.contents if hasattr(item, "text")
+    )
+    assert "FRONT" in diagram_text
+    assert "REAR" in diagram_text

--- a/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from _paths import SERVER_ROOT
+from _report_pdf_test_helpers import extract_pdf_pages_text
 from pypdf import PdfReader
 from test_support.findings import make_finding_payload
 from test_support.pdf import extract_pdf_text
@@ -61,6 +62,14 @@ def _sample(
     )
 
 
+def _pdf_page_text(pdf: bytes, page_index: int = 0) -> str:
+    return extract_pdf_pages_text(pdf)[page_index]
+
+
+def _pdf_page_text_lower(pdf: bytes, page_index: int = 0) -> str:
+    return _pdf_page_text(pdf, page_index).lower()
+
+
 def test_report_pdf_no_car_metadata(tmp_path: Path) -> None:
     run_path = tmp_path / "no_car.jsonl"
     records: list[dict[str, object]] = [_run_metadata()]
@@ -75,6 +84,9 @@ def test_report_pdf_no_car_metadata(tmp_path: Path) -> None:
 
     reader = PdfReader(BytesIO(pdf))
     assert len(reader.pages) == 2
+    page_one_text = _pdf_page_text(pdf)
+    assert "Car Unknown" in page_one_text
+    assert "VibeSensor Diagnostic Report" in page_one_text
 
 
 def test_report_pdf_includes_appendix_b_for_generated_summary(tmp_path: Path) -> None:
@@ -93,6 +105,9 @@ def test_report_pdf_includes_appendix_b_for_generated_summary(tmp_path: Path) ->
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
     reader = PdfReader(BytesIO(pdf))
     assert len(reader.pages) == 2
+    page_two_text = _pdf_page_text(pdf, 1)
+    assert "Traceability" in page_two_text
+    assert "Evidence and Run Context" not in page_two_text
 
 
 def test_report_pdf_action_ready_flow_includes_appendix_b_before_evidence() -> None:
@@ -143,7 +158,9 @@ def test_report_pdf_action_ready_flow_includes_appendix_b_before_evidence() -> N
     assert "Sensor Topology" in page_two_text
     assert "Marker color shows relative vibration strength." in page_two_text
     assert "Appendix B" not in page_two_text
-    assert "Evidence and Run Context" in (reader.pages[2].extract_text() or "")
+    page_three_text = reader.pages[2].extract_text() or ""
+    assert "Evidence and Run Context" in page_three_text
+    assert "Evidence chain" in page_three_text
 
 
 @pytest.mark.parametrize(
@@ -170,6 +187,7 @@ def test_report_pdf_recapture_sections_render_localized_headings(
     i18n = json.loads(_I18N_JSON.read_text(encoding="utf-8"))
     missing = [f"{key} ({i18n[key][lang]!r})" for key in i18n_keys if i18n[key][lang] not in text]
     assert missing == [], f"Missing {lang} labels in PDF: {missing}"
+    assert i18n["REPORT_RECAPTURE_GUIDANCE_TITLE"][lang] in text
 
 
 def test_build_report_pdf_renders_data_trust_warning_detail() -> None:
@@ -205,9 +223,7 @@ def test_build_report_pdf_renders_data_trust_warning_detail() -> None:
     )
 
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
-    page_one_text = " ".join(
-        (PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split()
-    )
+    page_one_text = _pdf_page_text_lower(pdf)
     text = extract_pdf_text(pdf).lower()
 
     assert "inspect first — moderate confidence" in page_one_text
@@ -215,6 +231,7 @@ def test_build_report_pdf_renders_data_trust_warning_detail() -> None:
     assert "potential saturation samples" in page_one_text
     assert "run quality and limits" in text
     assert "frame integrity" in text
+    assert "traceability" in text
 
 
 def test_build_report_pdf_replaces_limited_run_context_with_concrete_reason() -> None:
@@ -268,22 +285,22 @@ def test_build_report_pdf_replaces_limited_run_context_with_concrete_reason() ->
     )
 
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
-    page_one_text = " ".join(
-        (PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split()
-    )
+    page_one_text = _pdf_page_text_lower(pdf)
 
     assert "limited by run context" not in page_one_text
     assert "potential saturation samples" in page_one_text
+    assert "action status" in page_one_text
 
 
 def test_build_report_pdf_rephrases_ambiguous_primary_location_on_page_one() -> None:
     document = build_report_document(prepare_report_input(ambiguous_primary_location_summary()))
     pdf = build_report_pdf(document)
-    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+    text = _pdf_page_text(pdf)
 
     assert document.observed.strongest_location is not None
     assert document.observed.strongest_location in text
     assert "Front-Left / Rear-Left" not in text
+    assert "Location confidence" in text
 
 
 def test_build_report_pdf_renders_action_ready_status_on_page_one() -> None:
@@ -318,11 +335,12 @@ def test_build_report_pdf_renders_action_ready_status_on_page_one() -> None:
             ],
         )
     )
-    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split())
+    text = _pdf_page_text_lower(pdf)
 
     assert "action-ready" in text
     assert "strong" in text
     assert "what to do next" in text
+    assert "check wheel balance and runout" in text
 
 
 def test_page_one_is_decision_first_without_timeline_or_long_caution() -> None:
@@ -362,8 +380,7 @@ def test_page_one_is_decision_first_without_timeline_or_long_caution() -> None:
             ],
         )
     )
-    page_one_text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
-    page_one_lower = page_one_text.lower()
+    page_one_lower = _pdf_page_text_lower(pdf)
 
     assert "wheel / tire" in page_one_lower
     assert "inspect first" in page_one_lower
@@ -410,10 +427,11 @@ def test_build_report_pdf_renders_medium_confidence_data_trust_summary_for_tier_
     )
 
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
-    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split())
+    text = _pdf_page_text_lower(pdf)
 
     assert "inspect first — moderate confidence" in text
     assert "recapture before acting" not in text
+    assert "confidence" in text
 
 
 @pytest.mark.parametrize(
@@ -472,12 +490,13 @@ def test_build_report_pdf_keeps_weak_spatial_engine_and_driveline_findings_on_in
     )
 
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
-    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split())
+    text = _pdf_page_text_lower(pdf)
 
     assert "inspect first — moderate confidence" in text
     assert "recapture before acting" not in text
     assert "insufficient evidence" not in text
     assert source_label in text
+    assert "front-right" in text
 
 
 def test_build_report_pdf_recapture_mode_moves_guidance_into_appendix_a() -> None:
@@ -521,22 +540,24 @@ def test_build_report_pdf_recapture_mode_moves_guidance_into_appendix_a() -> Non
     )
 
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
-    page_one_text = " ".join(
-        (PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split()
-    )
+    page_one_text = _pdf_page_text_lower(pdf)
+    page_two_text = _pdf_page_text_lower(pdf, 1)
 
     assert "recapture before acting" in page_one_text
+    assert "recapture guidance" in page_two_text
+    assert "what was insufficient in this run" in page_two_text
 
 
 def test_build_report_pdf_keeps_same_source_temporal_shift_visible_on_page_one() -> None:
     document = build_report_document(prepare_report_input(sequential_same_source_summary()))
     pdf = build_report_pdf(document)
-    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+    text = _pdf_page_text(pdf)
 
     assert "Front-Left" in text
     assert "Rear-Right" in text
     assert document.verdict_page.proof_summary
     assert document.verdict_page.proof_summary in text
+    assert "Why this is credible" in text
 
 
 def test_build_report_pdf_keeps_same_source_temporal_shift_visible_in_recapture_flow() -> None:
@@ -544,13 +565,14 @@ def test_build_report_pdf_keeps_same_source_temporal_shift_visible_in_recapture_
         prepare_report_input(sequential_same_source_summary(weak_spatial=True))
     )
     pdf = build_report_pdf(document)
-    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+    text = _pdf_page_text(pdf)
 
     assert document.verdict_page.action_status in text
     assert "Front-Left" in text
     assert "Rear-Right" in text
     assert document.verdict_page.proof_summary
     assert document.verdict_page.proof_summary in text
+    assert "Best available location signal" in text
 
 
 @pytest.mark.parametrize(
@@ -571,3 +593,5 @@ def test_build_report_pdf_recapture_page_uses_scenario_specific_guidance(
 
     assert document.appendix_a.capture_issues
     assert document.appendix_a.capture_issues[0] in page_two_text
+    assert document.appendix_a.capture_changes
+    assert document.appendix_a.capture_changes[0] in page_two_text

--- a/apps/server/tests/adapters/pdf/test_report_summary_basics.py
+++ b/apps/server/tests/adapters/pdf/test_report_summary_basics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from _report_pdf_test_helpers import assert_pdf_contains, sample
+from test_support.pdf import extract_pdf_text
 from test_support.report_helpers import (
     RUN_END,
     suitability_by_key,
@@ -49,6 +50,8 @@ def test_complete_run_has_speed_bins_findings_and_plots(tmp_path: Path) -> None:
     assert summary["rows"] == 30
     assert summary["speed_breakdown"]
     assert summary["findings"]
+    assert summary["speed_breakdown"][0]["speed_range"] == "40-50 km/h"
+    assert "wheel/tire" in {finding.get("suspected_source") for finding in summary["findings"]}
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
     assert pdf.startswith(b"%PDF")
     for text in (
@@ -73,9 +76,12 @@ def test_missing_speed_skips_speed_and_wheel_order(tmp_path: Path) -> None:
     write_jsonl(run_path, records)
     summary = summarize_log(run_path)
     assert summary["speed_breakdown"] == []
-    assert any(f.get("finding_id") == "REF_SPEED" for f in summary["findings"])
+    speed_reference = next(f for f in summary["findings"] if f.get("finding_id") == "REF_SPEED")
+    assert speed_reference["suspected_source"] == "unknown"
     rendered_pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
     assert rendered_pdf.startswith(b"%PDF")
+    assert_pdf_contains(rendered_pdf, "Speed Band")
+    assert_pdf_contains(rendered_pdf, "Unknown")
 
 
 def test_run_suitability_warns_for_degraded_scenario(tmp_path: Path) -> None:
@@ -174,9 +180,14 @@ def test_missing_raw_sample_rate_adds_reference_finding(tmp_path: Path) -> None:
     write_jsonl(run_path, records)
     summary = summarize_log(run_path)
     assert summary["raw_sample_rate_hz"] is None
-    assert any(f.get("finding_id") == "REF_SAMPLE_RATE" for f in summary["findings"])
+    sample_rate_reference = next(
+        f for f in summary["findings"] if f.get("finding_id") == "REF_SAMPLE_RATE"
+    )
+    assert sample_rate_reference["suspected_source"] == "unknown"
     rendered_pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
     assert rendered_pdf.startswith(b"%PDF")
+    assert_pdf_contains(rendered_pdf, "Raw Sample Rate (Hz)")
+    assert_pdf_contains(rendered_pdf, "Unknown")
 
 
 def test_data_quality_outliers_include_zero_strength_values(tmp_path: Path) -> None:
@@ -270,4 +281,6 @@ def test_steady_speed_report_wording(tmp_path: Path) -> None:
     assert bool(summary["speed_stats"]["steady_speed"]) is True
     pdf = build_report_pdf(build_report_document(prepare_report_input(summary)))
     assert_pdf_contains(pdf, "Speed Band")
+    assert_pdf_contains(pdf, "100-110 km/h")
+    assert "speed range never settled" not in extract_pdf_text(pdf).lower()
     assert_pdf_contains(pdf, "VibeSensor Diagnostic Report")


### PR DESCRIPTION
## What changed
- Tightened PDF workflow/rendering tests with concrete rendered-text, page-order, metadata, and fallback-path assertions.
- Added shared page-text extraction for PDF tests so page-specific checks are less duplicated.
- Strengthened summary-to-report coverage for speed bands, reference findings, A4 sizing, Dutch unit rendering, and appendix placement.

## Why
Issue #3958 calls out 41 PDF tests that were too smoke-test-like. These changes make the tests prove specific PDF behavior without changing production code.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_page1_action_preview.py apps/server/tests/adapters/pdf/test_page1_header.py apps/server/tests/adapters/pdf/test_report_confidence_rendering.py apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py apps/server/tests/adapters/pdf/test_report_summary_basics.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`

## Risks / edge cases
- Test-only change. Risk is overfitting to rendered text; assertions target user-visible report structure and known contracts, not production internals.
- No docs or contract output changed.

Closes #3958