### PR TITLE
Improve PDF layout and evidence tests

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
+++ b/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import importlib
 import sys
-from io import BytesIO
 
 from _paths import SERVER_ROOT
-from pypdf import PdfReader
+from _report_pdf_test_helpers import extract_pdf_pages_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.shared.boundaries.reporting.document import (
@@ -116,6 +115,10 @@ def test_build_report_pdf_accepts_report_template_data() -> None:
     )
     pdf = build_report_pdf(data)
     assert pdf[:5] == b"%PDF-"
+    text = " ".join(extract_pdf_pages_text(pdf))
+    assert "Test Report" in text
+    assert "Run date Unknown" in text
+    assert "Most likely source Unknown" in text
 
 
 # ---------------------------------------------------------------------------
@@ -175,14 +178,17 @@ def test_report_output_matches_template_data() -> None:
         lang="en",
     )
     pdf_bytes = build_report_pdf(data)
-    reader = PdfReader(BytesIO(pdf_bytes))
-    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    pages_text = extract_pdf_pages_text(pdf_bytes)
+    text = "\n".join(pages_text)
 
     assert "Wheel / Tire" in text
     assert "Front-Left" in text
     assert "Action-ready" in text
     assert "Inspection Path" in text
     assert "VibeSensor Diagnostic Report" in text
+    assert "2026-01-15 10:30:00" in pages_text[0]
+    assert "Check wheel balance" in text
+    assert "Front-Left outranked the next location by 2.1x" in text
 
 
 def test_report_keeps_strongest_sensor_on_page_one_when_no_system_cards() -> None:
@@ -214,13 +220,12 @@ def test_report_keeps_strongest_sensor_on_page_one_when_no_system_cards() -> Non
         lang="en",
     )
     pdf_bytes = build_report_pdf(data)
-    reader = PdfReader(BytesIO(pdf_bytes))
-    page_one = reader.pages[0].extract_text() or ""
-    page_one_single_line = " ".join(page_one.split())
+    page_one_single_line = extract_pdf_pages_text(pdf_bytes)[0]
 
     assert "Rear-Right" in page_one_single_line
     assert "Recapture before acting" in page_one_single_line
-    assert "Why this corner wins" in page_one
+    assert "Why this corner wins" in page_one_single_line
+    assert "1 of 1 expected positions stayed connected." in page_one_single_line
 
 
 def test_report_cards_switch_to_check_first_summary_when_parts_exist() -> None:
@@ -274,10 +279,10 @@ def test_report_cards_switch_to_check_first_summary_when_parts_exist() -> None:
         lang="en",
     )
     pdf_bytes = build_report_pdf(data)
-    reader = PdfReader(BytesIO(pdf_bytes))
-    page_two = reader.pages[1].extract_text() or ""
-    page_three = reader.pages[2].extract_text() or ""
-    page_three_single_line = " ".join(page_three.split())
+    pages_text = extract_pdf_pages_text(pdf_bytes)
+    page_two = pages_text[1]
+    page_three = pages_text[2]
+    page_three_single_line = page_three
 
     assert "Evidence and Run Context" in page_two
     assert "Inspection Path" in page_three
@@ -285,3 +290,5 @@ def test_report_cards_switch_to_check_first_summary_when_parts_exist() -> None:
     assert "Front-Left" in page_three
     assert "Check wheel bearing assembly" in page_three_single_line
     assert "Inspect tire belt package" in page_three_single_line
+    assert "Move to the driveline path next" in page_three_single_line
+    assert "If the bearing is clean" in page_three_single_line

--- a/apps/server/tests/adapters/pdf/test_report_appendix_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_appendix_layout.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 from _paths import SERVER_ROOT
+from _report_pdf_test_helpers import extract_pdf_pages_text
 from test_support.pdf import extract_pdf_text
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
@@ -58,6 +59,8 @@ def test_report_pdf_workflow_appendix_a_headings_render(lang: str) -> None:
 
     assert i18n["REPORT_PRIMARY_VS_ALTERNATIVE_TITLE"][lang] in text
     assert i18n["REPORT_ACTION_MATRIX_TITLE"][lang] in text
+    assert "Wheel / Tire" in text
+    assert "Check wheel balance" in text
 
 
 def test_report_pdf_marks_appendix_table_overflow_instead_of_silent_omission() -> None:
@@ -95,6 +98,9 @@ def test_report_pdf_marks_appendix_table_overflow_instead_of_silent_omission() -
     text = extract_pdf_text(build_report_pdf(data))
 
     assert text.count("+ 3 more rows not shown") >= 2
+    assert "Dense evidence chain." in text
+    assert "Source 1" in text
+    assert "P1" in text
 
 
 def test_report_pdf_ranked_source_stack_has_room_for_four_candidates() -> None:
@@ -120,8 +126,11 @@ def test_report_pdf_ranked_source_stack_has_room_for_four_candidates() -> None:
 
     text = extract_pdf_text(build_report_pdf(data))
 
+    assert "Engine" in text
+    assert "Wheel / Tire" in text
     assert "Driveline" in text
     assert "Body resonance" in text
+    assert "Front cabin" in text
 
 
 def test_report_pdf_worksheet_pagination_does_not_skip_action_after_ranked_stack() -> None:
@@ -149,7 +158,11 @@ def test_report_pdf_worksheet_pagination_does_not_skip_action_after_ranked_stack
         ],
     )
 
-    text = extract_pdf_text(build_report_pdf(data))
+    pages_text = extract_pdf_pages_text(build_report_pdf(data))
+    text = "\n".join(pages_text)
 
+    assert "Inspection Path" in text
+    assert "Body resonance" in text
     for index in range(1, 9):
         assert f"Action {index}: inspect a unique worksheet item." in text
+        assert f"Confirm action {index}." in text

--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -115,6 +115,8 @@ def test_build_report_pdf_renders_dense_evidence_chart_text() -> None:
     assert "6/8 (75%); lock 81%" in text
     assert "12.4-12.9 Hz" in text
     assert "Reference coverage 88%" in text
+    assert "Wheel / Tire" in text
+    assert "Front-Left" in text
 
 
 def test_build_report_pdf_renders_missing_reference_caveat() -> None:
@@ -129,6 +131,8 @@ def test_build_report_pdf_renders_missing_reference_caveat() -> None:
 
     assert document.appendix_c.dense_evidence_rows[0].caveat == "Reference data unavailable"
     assert "Reference data unavailable" in text
+    assert "support 75% / reference 0%" in text
+    assert "6/8 (75%); lock 81%" in text
 
 
 def test_build_report_document_projects_dense_quality_caveat() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
@@ -290,3 +290,6 @@ def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> No
     assert "why this corner wins" in text
     assert "dominant corner" in text
     assert "coverage" in text
+    assert "front-left" in text
+    assert "front-right" in text
+    assert "strong" in text

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
@@ -53,4 +53,6 @@ def test_report_pdf_renders_sensor_topology_context_without_primitive_pinning() 
     assert "Front-Left" in text
     assert "Rear-Left" in text
     assert "2.0x stronger" in text
+    assert "4 of 4 expected positions stayed connected." in text
+    assert "Strong" in text
     assert "Topology confirms the strongest sensor is on the front axle." in text

--- a/apps/server/tests/adapters/pdf/test_report_pdf_usefulness_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_usefulness_layout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 
+from _report_pdf_test_helpers import extract_pdf_pages_text
 from pypdf import PdfReader
 from test_support.pdf import extract_pdf_text
 
@@ -63,6 +64,8 @@ def test_page_one_keeps_action_ready_guidance_readable() -> None:
     report_text = _normalized_pdf_text(pdf)
 
     assert "What to do next" in page_one_text
+    assert "Action-ready" in page_one_text
+    assert "Rear-Left outranked the next location by 2.1x." in page_one_text
     assert "Check Rear-Left for tire damage" in page_one_text
     assert "pressure mismatch" in page_one_text
     assert "Check Rear-Left for imbalance" in report_text
@@ -105,10 +108,14 @@ def test_appendix_c_keeps_context_quality_and_traceability_visible() -> None:
         ],
     )
 
-    text = _normalized_pdf_text(build_report_pdf(data))
+    pdf = build_report_pdf(data)
+    pages_text = extract_pdf_pages_text(pdf)
+    text = " ".join(pages_text)
 
     assert "A steady 100-110 km/h capture" in text
     assert "More context retained in source data." in text
+    assert "Evidence and Run Context" in text
+    assert "Traceability" in text
     assert "Frame integrity" in text
     assert "Speed stayed in the diagnostic band." in text
     assert "appendix-c-content-readable" in text
@@ -143,9 +150,12 @@ def test_worksheet_keeps_ranked_sources_and_follow_up_actions_visible() -> None:
         ],
     )
 
-    text = _normalized_pdf_text(build_report_pdf(data))
+    pages_text = extract_pdf_pages_text(build_report_pdf(data))
+    text = " ".join(pages_text)
 
     assert "Engine-order evidence leads the workflow." in text
+    assert "Primary vs alternative source" in text
     assert "Body resonance" in text
     for index in range(1, 9):
         assert f"Action {index}: inspect a unique worksheet item." in text
+        assert f"Falsify action {index}." in text


### PR DESCRIPTION
## What changed
- Tightened PDF layout, appendix, dense evidence, diagram, and usefulness tests with specific rendered-content assertions.
- Reused shared page-text extraction so page placement checks are clearer.
- Added coverage for appendix overflow markers, ranked-source visibility, dense evidence caveats, topology context, and worksheet follow-up actions.

## Why
Issue #3959 identified 15 PDF tests that were too smoke-test-like. These changes make each case prove concrete report behavior without production changes.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_report_analysis_separation.py apps/server/tests/adapters/pdf/test_report_appendix_layout.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py apps/server/tests/adapters/pdf/test_report_pdf_usefulness_layout.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`

## Risks / edge cases
- Test-only change. Assertions stay on user-visible rendered PDF text and page placement.
- No docs, contracts, or production behavior changed.

Closes #3959