### PR TITLE
Strengthen integration scenario matrix tests

### DIFF
--- a/apps/server/tests/integration/test_multi_no_transient.py
+++ b/apps/server/tests/integration/test_multi_no_transient.py
@@ -17,6 +17,7 @@ from test_support import (
     SPEED_MID,
     SPEED_VERY_HIGH,
     assert_confidence_between,
+    assert_confidence_label_valid,
     assert_no_wheel_fault,
     assert_pairwise_monotonic,
     assert_strongest_location,
@@ -62,6 +63,8 @@ def _assert_fault_at(summary: dict[str, Any], sensor: str, msg: str) -> None:
     assert top is not None, f"{msg}: no finding"
     assert_wheel_source(summary, msg=msg)
     assert_strongest_location(summary, sensor, msg=msg)
+    assert_confidence_between(summary, 0.10, 1.0, msg=msg)
+    assert_confidence_label_valid(summary, msg=msg)
 
 
 # D.3 – 2-sensor pairs with fault localization (4 cases)

--- a/apps/server/tests/integration/test_multi_transient.py
+++ b/apps/server/tests/integration/test_multi_transient.py
@@ -72,6 +72,7 @@ def _assert_fault_at(summary: dict[str, Any], sensor: str, msg: str) -> None:
     assert top is not None, f"{msg}: no finding"
     assert_wheel_source(summary, msg=msg)
     assert_strongest_location(summary, sensor, msg=msg)
+    assert_confidence_label_valid(summary, msg=msg)
 
 
 # E.2 – 4-sensor transient on non-fault sensor (4 cases)

--- a/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
+++ b/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
@@ -13,6 +13,7 @@ import pytest
 from _paths import SERVER_ROOT
 from test_support.persisted_analysis import make_persisted_analysis
 
+from vibesensor import report_i18n
 from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -125,3 +126,17 @@ class TestEvidencePeakPresentFormat:
         assert ".1f}" in nl_template, f"Expected .1f in NL template, got: {nl_template}"
         assert ".4f" not in en_template, "Stale .4f found in EN template"
         assert ".4f" not in nl_template, "Stale .4f found in NL template"
+
+        rendered = report_i18n.tr(
+            "en",
+            "EVIDENCE_PEAK_PRESENT",
+            freq=12.345,
+            pct=0.25,
+            p95=9.876,
+            units="dB",
+            burst=1.234,
+            cls="persistent",
+        )
+        assert "12.3 Hz" in rendered
+        assert "9.9 dB" in rendered
+        assert "1.2×" in rendered

--- a/apps/server/tests/integration/test_synthetic_scenario_matrix.py
+++ b/apps/server/tests/integration/test_synthetic_scenario_matrix.py
@@ -23,6 +23,7 @@ from test_support import (
     assert_has_warnings,
     assert_no_wheel_fault,
     assert_strongest_location,
+    assert_summary_sections,
     assert_tolerant_no_fault,
     assert_wheel_source,
     extract_top,
@@ -317,6 +318,7 @@ def test_representative_fault_scenario_matrix(
             ),
         )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
+    assert_summary_sections(summary, min_findings=1, min_top_causes=1)
     top = extract_top(summary)
     tag = f"{case.case_id}/{case.corner}/{case.speed_case_id}"
     assert top is not None, f"No finding for {tag}"
@@ -354,6 +356,7 @@ def test_representative_no_fault_scenario_matrix(
             ),
         )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
+    assert_summary_sections(summary)
     tag = f"{case.case_id}/{case.speed_case_id}"
     if case.transient:
         assert_tolerant_no_fault(summary, msg=tag)
@@ -415,6 +418,7 @@ def test_representative_phased_scenario_matrix(
             ),
         )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
+    assert_summary_sections(summary, min_findings=1, min_top_causes=1)
     tag = f"{case.case_id}/{case.corner}"
     top = extract_top(summary)
     assert top is not None, f"No finding for {tag}"

--- a/apps/server/tests/test_support/assertions.py
+++ b/apps/server/tests/test_support/assertions.py
@@ -43,13 +43,25 @@ def _cause_confidence(cause: dict[str, Any]) -> float:
     return float(cause.get("confidence", 0))
 
 
+def _assert_summary_contract(summary: dict[str, Any], msg: str = "") -> None:
+    assert isinstance(summary.get("findings"), list), f"Missing or invalid findings list. {msg}"
+    assert isinstance(summary.get("top_causes"), list), f"Missing or invalid top_causes list. {msg}"
+    assert isinstance(summary.get("run_suitability"), list), (
+        f"Missing or invalid run_suitability list. {msg}"
+    )
+    assert "most_likely_origin" in summary, f"Missing most_likely_origin section. {msg}"
+
+
 def _top_causes(summary: dict[str, Any]) -> list[dict[str, Any]]:
     return summary.get("top_causes") or []
 
 
 def _top_cause_or_fail(summary: dict[str, Any], msg: str = "") -> dict[str, Any]:
+    _assert_summary_contract(summary, msg)
     top = extract_top(summary)
     assert top is not None, f"No top cause found. {msg}"
+    assert "suspected_source" in top, f"Top cause missing suspected_source. {msg}"
+    assert "confidence" in top, f"Top cause missing confidence. {msg}"
     return top
 
 
@@ -69,6 +81,7 @@ def assert_no_wheel_fault(summary: dict[str, Any], msg: str = "") -> None:
     Low-confidence matches (< 0.40) are tolerated because broadband noise
     can accidentally align with wheel-order frequencies at certain speeds.
     """
+    _assert_summary_contract(summary, msg)
     for c, conf in _iter_causes_at_or_above(summary, 0.40):
         src = _cause_source(c)
         if "wheel" in src:
@@ -118,6 +131,7 @@ def assert_strict_no_fault(summary: dict[str, Any], msg: str = "") -> None:
 
     Use for known-clean scenarios (pure noise, idle-only, etc.).
     """
+    _assert_summary_contract(summary, msg)
     for c in _top_causes(summary):
         conf = _cause_confidence(c)
         src = _cause_source(c)
@@ -130,6 +144,7 @@ def assert_tolerant_no_fault(summary: dict[str, Any], msg: str = "") -> None:
     Allows low-confidence findings (< 0.50) since diffuse noise or transients
     can produce incidental matches.
     """
+    _assert_summary_contract(summary, msg)
     for c, conf in _iter_causes_at_or_above(summary, 0.50):
         src = _cause_source(c)
         if "wheel" in src:
@@ -153,6 +168,7 @@ def assert_speed_band_present(summary: dict[str, Any], msg: str = "") -> None:
 
 def assert_has_warnings(summary: dict[str, Any], msg: str = "") -> None:
     """Assert the summary has a 'warnings' field (may be empty list)."""
+    _assert_summary_contract(summary, msg)
     assert "warnings" in summary, f"Missing 'warnings' field. {msg}"
     assert isinstance(summary["warnings"], list), f"'warnings' is not a list. {msg}"
 


### PR DESCRIPTION
## What changed
- Strengthened shared integration assertions so scenario tests now verify summary/top-cause contract sections before checking diagnosis details.
- Tightened multi-sensor steady/transient helper checks for confidence bounds and confidence label projection.
- Added representative matrix summary-section checks and rendered `EVIDENCE_PEAK_PRESENT` formatting coverage.

## Why
Issue #3960 calls out broad integration scenario matrix tests that were too narrow. These changes make the matrix prove contract shape, diagnosis metadata, and formatting behavior without changing production code.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/integration/test_messy_real_world.py apps/server/tests/integration/test_multi_no_transient.py apps/server/tests/integration/test_multi_transient.py apps/server/tests/integration/test_runtime_fallbacks_regressions.py::TestEvidencePeakPresentFormat apps/server/tests/integration/test_single_no_transient.py apps/server/tests/integration/test_single_transient.py apps/server/tests/integration/test_synthetic_scenario_matrix.py apps/server/tests/integration/test_weird_sensor_mix.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`

## Risks / edge cases
- Test-only change. The shared helper assertions affect scenario tests that use them, so the full affected integration set was run.
- No docs, contracts, or production behavior changed.

Closes #3960