### PR TITLE
Improve UI settings regression tests

### DIFF
--- a/apps/ui/tests/regression.settings-alignment.spec.ts
+++ b/apps/ui/tests/regression.settings-alignment.spec.ts
@@ -3,9 +3,8 @@ import { expect, test } from "@playwright/test";
 import {
   buildCaptureReadiness,
   fulfillJson,
-  installCommonRoutes,
+  installSettingsRoutes,
   installFakeWebSocket,
-  requestPath,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 12_000 });
@@ -41,33 +40,25 @@ test("settings desktop journey keeps analysis controls and car actions reachable
     final_drive_ratio: 3.3,
     current_gear_ratio: 0.84,
   };
-  await installCommonRoutes(page, {
-    settingsHandler: async (route) => {
-      if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [
-            {
-              id: "car-1",
-              name: "Active Car",
-              type: "sedan",
-              aspects: readyAspects,
-            },
-            {
-              id: "car-2",
-              name: "Inactive Car",
-              type: "suv",
-              aspects: readyAspects,
-            },
-          ],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
+  await installSettingsRoutes(page, {
+    "/api/settings/cars": {
+      cars: [
+        {
+          id: "car-1",
+          name: "Active Car",
+          type: "sedan",
+          aspects: readyAspects,
+        },
+        {
+          id: "car-2",
+          name: "Inactive Car",
+          type: "suv",
+          aspects: readyAspects,
+        },
+      ],
+      active_car_id: "car-1",
     },
-  });
-  await page.route("**/api/settings/analysis", async (route) => {
-    await fulfillJson(route, analysisSettingsPayload);
+    "GET /api/settings/analysis": analysisSettingsPayload,
   });
   await installFakeWebSocket(page);
   await page.goto("/");
@@ -94,10 +85,25 @@ test("settings desktop journey keeps analysis controls and car actions reachable
 
   await expect(activeDeleteButton).toBeVisible();
   await expect(inactiveDeleteButton).toBeVisible();
+  await expect(activeDeleteButton).toHaveAttribute("data-car-action", "delete");
+  await expect(inactiveDeleteButton).toHaveAttribute(
+    "data-car-action",
+    "delete",
+  );
   await expect(activeRow.locator(".car-activate-btn")).toHaveCount(0);
   await expect(inactiveRow.locator(".car-activate-btn")).toHaveCount(1);
 
   await expect(activeRow).toContainText("Active");
+  await expect(activeRow).toHaveAttribute("data-car-complete", "true");
+  await expect(activeRow.locator(".car-active-pill")).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+  await expect(inactiveRow).toHaveAttribute("data-car-complete", "true");
+  await expect(inactiveRow.locator(".car-active-pill")).toHaveAttribute(
+    "data-state",
+    "inactive",
+  );
   await expect(inactiveRow.locator(".car-activate-btn")).toBeEnabled();
 });
 
@@ -105,29 +111,28 @@ test("dashboard desktop journey keeps summary stats and sensor cards readable", 
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
-  await installCommonRoutes(page, {
-    locations: [
-      { code: "front_left_wheel", label: "Front Left Wheel" },
-      { code: "engine_bay", label: "Engine Bay" },
-    ],
-    settingsHandler: async (route) => {
-      if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [
-            {
-              id: "car-1",
-              name: "Test Hatch",
-              type: "Simulated setup",
-              aspects: {},
-            },
-          ],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
+  await installSettingsRoutes(
+    page,
+    {
+      "/api/settings/cars": {
+        cars: [
+          {
+            id: "car-1",
+            name: "Test Hatch",
+            type: "Simulated setup",
+            aspects: {},
+          },
+        ],
+        active_car_id: "car-1",
+      },
     },
-  });
+    {
+      locations: [
+        { code: "front_left_wheel", label: "Front Left Wheel" },
+        { code: "engine_bay", label: "Engine Bay" },
+      ],
+    },
+  );
   await page.route("**/api/recording/status", async (route) => {
     await fulfillJson(route, {
       enabled: false,
@@ -220,6 +225,7 @@ test("dashboard desktop journey keeps summary stats and sensor cards readable", 
   );
   await expect(dataFreshnessValue).toBeVisible();
   await expect(strongestSignalValue).toBeVisible();
+  await expect(strongestSignalValue).toContainText("12");
   await expect(speedValue).toBeVisible();
 
   await expect(page.locator(".site-header__status")).toBeHidden();
@@ -237,6 +243,9 @@ test("dashboard desktop journey keeps summary stats and sensor cards readable", 
   await expect(frontCard).toHaveText("Front Left Wheel");
   await expect(engineCard).toHaveText("Engine Bay");
   await expect(unassignedCard).toHaveText("Gamma Probe");
+  await expect(frontCard).toHaveAttribute("data-strongest", "true");
+  await expect(engineCard).not.toHaveAttribute("data-strongest", "true");
+  await expect(unassignedCard).not.toHaveAttribute("data-strongest", "true");
 
   await page.locator("#tab-history").click();
   await expect(page.locator(".site-header__status")).toBeVisible();

--- a/apps/ui/tests/regression.settings-analysis.spec.ts
+++ b/apps/ui/tests/regression.settings-analysis.spec.ts
@@ -1,16 +1,19 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Route } from "@playwright/test";
 
 import {
   bootLiveDashboard,
   cancelPrompt,
   confirmPrompt,
-  fulfillJson,
-  installCommonRoutes,
+  installSettingsRoutes,
   openAnalysisTab,
-  requestPath,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 20_000 });
+
+const activeCarSettings = {
+  cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+  active_car_id: "car-1",
+};
 
 test("analysis tab adds guided helper copy and can reset tuning to defaults", async ({
   page,
@@ -33,26 +36,16 @@ test("analysis tab adds guided helper copy and can reset tuning to defaults", as
     tire_deflection_factor: 0.97,
   };
   let analysisPutCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: async (route) => {
-      if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
-    },
-  });
-  await page.route("**/api/settings/analysis", async (route) => {
-    if (route.request().method() === "PUT") {
+  await installSettingsRoutes(page, {
+    "/api/settings/cars": activeCarSettings,
+    "GET /api/settings/analysis": () => lastAnalysisPayload,
+    "PUT /api/settings/analysis": async (route: Route) => {
       analysisPutCalls += 1;
       lastAnalysisPayload = route.request().postDataJSON() as Record<
         string,
         number
       >;
-      await fulfillJson(route, {
+      return {
         ...lastAnalysisPayload,
         tire_width_mm: 285,
         tire_aspect_pct: 30,
@@ -60,10 +53,8 @@ test("analysis tab adds guided helper copy and can reset tuning to defaults", as
         final_drive_ratio: 3.08,
         current_gear_ratio: 0.64,
         tire_deflection_factor: 0.97,
-      });
-      return;
-    }
-    await fulfillJson(route, lastAnalysisPayload);
+      };
+    },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openAnalysisTab(page);
@@ -120,69 +111,68 @@ test("analysis tab adds guided helper copy and can reset tuning to defaults", as
   await expect.poll(() => analysisPutCalls).toBe(1);
   await expect(page.locator("#wheelBandwidthInput")).toHaveValue("5");
   await expect(page.locator("#maxBandHalfWidthInput")).toHaveValue("6");
-  expect(lastAnalysisPayload.wheel_bandwidth_pct).toBe(5);
-  expect(lastAnalysisPayload.max_band_half_width_pct).toBe(6);
+  expect(lastAnalysisPayload).toMatchObject({
+    driveshaft_bandwidth_pct: 5,
+    engine_bandwidth_pct: 5,
+    final_drive_uncertainty_pct: 1,
+    gear_uncertainty_pct: 2,
+    max_band_half_width_pct: 6,
+    min_abs_band_hz: 0.5,
+    speed_uncertainty_pct: 3,
+    tire_diameter_uncertainty_pct: 4,
+    wheel_bandwidth_pct: 5,
+  });
 });
 
 test("analysis settings ask for confirmation before saving risky values", async ({
   page,
 }) => {
   let analysisPutCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: async (route) => {
-      if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
-    },
-  });
-  await page.route("**/api/settings/analysis", async (route) => {
-    if (route.request().method() === "PUT") {
+  let lastSavedPayload: Record<string, number> | null = null;
+  await installSettingsRoutes(page, {
+    "/api/settings/cars": activeCarSettings,
+    "PUT /api/settings/analysis": async (route: Route) => {
       analysisPutCalls += 1;
-      await fulfillJson(route, route.request().postDataJSON());
-      return;
-    }
-    await fulfillJson(route, {});
+      lastSavedPayload = route.request().postDataJSON() as Record<
+        string,
+        number
+      >;
+      return lastSavedPayload;
+    },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openAnalysisTab(page);
   await page.locator("#wheelBandwidthInput").fill("40");
   await page.locator("#saveAnalysisBtn").click();
+  await expect(page.locator(".confirmation-dialog")).toContainText(
+    "Wheel Bandwidth (%)",
+  );
+  await expect(page.locator(".confirmation-dialog")).toContainText(
+    "guided 2% to 12%",
+  );
   await cancelPrompt(page);
   await expect.poll(() => analysisPutCalls).toBe(0);
+  expect(lastSavedPayload).toBeNull();
+  await expect(page.locator("#wheelBandwidthInput")).toHaveValue("40");
 
   await page.locator("#saveAnalysisBtn").click();
   await confirmPrompt(page);
   await expect.poll(() => analysisPutCalls).toBe(1);
+  expect(lastSavedPayload).toMatchObject({
+    wheel_bandwidth_pct: 40,
+  });
 });
 
 test("analysis settings show a field-specific error when a hard limit is exceeded", async ({
   page,
 }) => {
   let analysisPutCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: async (route) => {
-      if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
-    },
-  });
-  await page.route("**/api/settings/analysis", async (route) => {
-    if (route.request().method() === "PUT") {
+  await installSettingsRoutes(page, {
+    "/api/settings/cars": activeCarSettings,
+    "PUT /api/settings/analysis": async (route: Route) => {
       analysisPutCalls += 1;
-      await fulfillJson(route, route.request().postDataJSON());
-      return;
-    }
-    await fulfillJson(route, {});
+      return route.request().postDataJSON();
+    },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openAnalysisTab(page);
@@ -201,35 +191,25 @@ test("analysis settings show a field-specific error when a hard limit is exceede
     "aria-invalid",
     "true",
   );
+  await expect(page.locator("#wheelBandwidthInput")).toBeFocused();
+  await expect(page.locator("#analysisSaveFeedback")).toBeHidden();
 });
 
 test("failed analysis save preserves the draft and explains that saved settings remain active", async ({
   page,
 }) => {
   let analysisPutCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: async (route) => {
-      if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
-    },
-  });
-  await page.route("**/api/settings/analysis", async (route) => {
-    if (route.request().method() === "PUT") {
+  await installSettingsRoutes(page, {
+    "/api/settings/cars": activeCarSettings,
+    "PUT /api/settings/analysis": async (route: Route) => {
       analysisPutCalls += 1;
       await route.fulfill({
         status: 500,
         contentType: "application/json",
         body: JSON.stringify({ detail: "Analysis save failed" }),
       });
-      return;
-    }
-    await fulfillJson(route, {
+    },
+    "GET /api/settings/analysis": {
       tire_width_mm: 285,
       tire_aspect_pct: 30,
       rim_in: 21,
@@ -245,7 +225,7 @@ test("failed analysis save preserves the draft and explains that saved settings 
       min_abs_band_hz: 0.5,
       max_band_half_width_pct: 6,
       tire_deflection_factor: 0.97,
-    });
+    },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openAnalysisTab(page);
@@ -267,4 +247,7 @@ test("failed analysis save preserves the draft and explains that saved settings 
     "open",
     "",
   );
+  await expect(
+    page.locator("#analysisSaveFeedback .settings-feedback"),
+  ).toHaveAttribute("data-tone", "error");
 });

--- a/apps/ui/tests/regression.settings-car-feedback-reset.spec.ts
+++ b/apps/ui/tests/regression.settings-car-feedback-reset.spec.ts
@@ -12,6 +12,8 @@ test("clears transient car creation feedback after leaving and re-entering the c
 }) => {
   let cars = [] as Array<Record<string, unknown>>;
   let activeCarId: string | null = null;
+  let createCarCalls = 0;
+  let activateCarCalls = 0;
 
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
@@ -22,6 +24,7 @@ test("clears transient car creation feedback after leaving and re-entering the c
         return;
       }
       if (path === "/api/settings/cars" && method === "POST") {
+        createCarCalls += 1;
         cars = [
           {
             id: "car-1",
@@ -40,6 +43,7 @@ test("clears transient car creation feedback after leaving and re-entering the c
         return;
       }
       if (path === "/api/settings/cars/active" && method === "PUT") {
+        activateCarCalls += 1;
         activeCarId = "car-1";
         await fulfillJson(route, { cars, active_car_id: activeCarId });
         return;
@@ -69,13 +73,21 @@ test("clears transient car creation feedback after leaving and re-entering the c
   const createdRow = page.locator('#carListBody tr[data-car-id="car-1"]');
   await expect(guidance).toContainText("Car added");
   await expect(createdRow).toHaveClass(/car-list-row--highlighted/);
+  await expect(createdRow).toHaveAttribute("data-highlighted", "true");
   await expect(createdRow).toContainText("New");
+  await expect(createdRow.locator(".car-active-pill")).toHaveAttribute(
+    "data-state",
+    "inactive",
+  );
+  await expect.poll(() => createCarCalls).toBe(1);
+  await expect.poll(() => activateCarCalls).toBe(0);
 
   await page.locator('[data-settings-tab="analysisTab"]').click();
   await page.locator('[data-settings-tab="carTab"]').click();
 
   await expect(guidance).toBeHidden();
   await expect(createdRow).not.toHaveClass(/car-list-row--highlighted/);
+  await expect(createdRow).toHaveAttribute("data-highlighted", "false");
   await expect(createdRow).not.toContainText("New");
 
   await page.locator("#tab-dashboard").click();
@@ -84,5 +96,9 @@ test("clears transient car creation feedback after leaving and re-entering the c
 
   await expect(guidance).toBeHidden();
   await expect(createdRow).not.toHaveClass(/car-list-row--highlighted/);
+  await expect(createdRow).toHaveAttribute("data-highlighted", "false");
   await expect(createdRow).not.toContainText("New");
+  await expect(createdRow.locator("strong")).toHaveText("Track Demo");
+  await expect.poll(() => createCarCalls).toBe(1);
+  await expect.poll(() => activateCarCalls).toBe(0);
 });

--- a/apps/ui/tests/regression.settings-language.spec.ts
+++ b/apps/ui/tests/regression.settings-language.spec.ts
@@ -1,28 +1,28 @@
 import { expect, test, type Route } from "@playwright/test";
 
-import {
-  bootLiveDashboard,
-  createSettingsHandlerFromMap,
-  installCommonRoutes,
-} from "./smoke.helpers";
+import { bootLiveDashboard, installSettingsRoutes } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 20_000 });
 
 test("failed language save reverts the selector and shows an error", async ({
   page,
 }) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "PUT /api/settings/language": async (route: Route) => {
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Language save failed" }),
-        });
-      },
-      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
-    }),
+  let languagePutCalls = 0;
+  let attemptedLanguage: string | null = null;
+  await installSettingsRoutes(page, {
+    "GET /api/settings/language": { language: "en" },
+    "PUT /api/settings/language": async (route: Route) => {
+      languagePutCalls += 1;
+      attemptedLanguage = (
+        route.request().postDataJSON() as { language: string }
+      ).language;
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Language save failed" }),
+      });
+    },
+    "GET /api/settings/speed-unit": { speed_unit: "kmh" },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await page.locator("#languageSelect").selectOption("nl");
@@ -34,6 +34,11 @@ test("failed language save reverts the selector and shows an error", async ({
   await expect(page.locator("#languageFeedback")).toContainText(
     "English remains active",
   );
+  await expect.poll(() => languagePutCalls).toBe(1);
+  expect(attemptedLanguage).toBe("nl");
+  await expect(
+    page.locator("#languageFeedback .settings-feedback"),
+  ).toHaveAttribute("data-tone", "error");
   await expect(page.locator("#languageSelect")).toHaveValue("en");
   await expect(page.locator("#tab-settings")).toContainText("Settings");
 });

--- a/apps/ui/tests/regression.settings-obd-scan-timeout.spec.ts
+++ b/apps/ui/tests/regression.settings-obd-scan-timeout.spec.ts
@@ -2,10 +2,11 @@ import { expect, test } from "@playwright/test";
 
 import { createDeferred } from "./deferred_test_helpers";
 import {
-  createSettingsHandlerFromMap,
   gpsStatus,
-  installCommonRoutes,
+  installSettingsRoutes,
   installFakeWebSocket,
+  obdStatus,
+  speedSourceSettings,
 } from "./smoke.helpers";
 
 test("manual OBD scan renders a successful response without surfacing an abort banner", async ({
@@ -24,42 +25,22 @@ test("manual OBD scan renders a successful response without surfacing an abort b
     ],
   };
   const scanResponse = createDeferred<typeof scanPayload>();
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
-      "GET /api/settings/speed-source": {
-        speed_source: "obd2",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-        obd_device_mac: null,
-        obd_device_name: null,
-      },
-      "GET /api/settings/speed-source/status": gpsStatus({
-        speed_source: "obd2",
-        connection_state: "disconnected",
-      }),
-      "GET /api/settings/obd/status": {
-        configured_device_mac: null,
-        configured_device_name: null,
-        paired: false,
-        trusted: false,
-        connected: false,
-        rfcomm_channel: null,
-        last_rpm: null,
-        rpm_sample_age_s: null,
-        rpm_target_interval_ms: 50,
-        rpm_effective_hz: null,
-        request_rtt_ms: null,
-        timeout_count: 0,
-        error_count: 0,
-        poll_mode: null,
-        backoff_active: false,
-        last_raw_response: null,
-        debug_hint: null,
-      },
-      "POST /api/settings/obd/scan": async () => await scanResponse.promise,
+  let scanCalls = 0;
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source": speedSourceSettings({
+      speed_source: "obd2",
+      obd_device_mac: null,
+      obd_device_name: null,
     }),
+    "GET /api/settings/speed-source/status": gpsStatus({
+      speed_source: "obd2",
+      connection_state: "disconnected",
+    }),
+    "GET /api/settings/obd/status": obdStatus(),
+    "POST /api/settings/obd/scan": async () => {
+      scanCalls += 1;
+      return await scanResponse.promise;
+    },
   });
   await installFakeWebSocket(page);
 
@@ -73,9 +54,18 @@ test("manual OBD scan renders a successful response without surfacing an abort b
     "Scanning for Bluetooth OBD adapters...",
   );
   scanResponse.resolve(scanPayload);
+  await expect.poll(() => scanCalls).toBe(1);
   await expect(scanStatus).toContainText("1 adapter(s) found.");
-  await expect(page.locator(".speed-source-device__name").first()).toHaveText(
+  const deviceRow = page.locator(".speed-source-device").first();
+  await expect(deviceRow.locator(".speed-source-device__name")).toHaveText(
     "OBDLink CX",
   );
+  await expect(deviceRow.locator(".speed-source-device__mac")).toHaveText(
+    "0022d9001bb1",
+  );
+  await expect(
+    deviceRow.locator(".speed-source-device__actions .btn"),
+  ).toHaveText("Pair and use");
   await expect(page.locator("#appErrorBanner")).toBeHidden();
+  await expect(scanStatus).not.toContainText("aborted");
 });

--- a/apps/ui/tests/regression.settings-shell.spec.ts
+++ b/apps/ui/tests/regression.settings-shell.spec.ts
@@ -1,22 +1,11 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import {
-  createSettingsHandlerFromMap,
-  gpsStatus,
-  installCommonRoutes,
-  installFakeWebSocket,
-} from "./smoke.helpers";
+import { installSettingsRoutes, installFakeWebSocket } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 12_000 });
 
 async function openSettings(page: Page): Promise<void> {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "/api/settings/language": { language: "en" },
-      "/api/settings/speed-unit": { speed_unit: "kmh" },
-      "/api/settings/speed-source/status": gpsStatus({}),
-    }),
-  });
+  await installSettingsRoutes(page);
   await installFakeWebSocket(page);
   await page.goto("/");
   await page.locator("#tab-settings").click();
@@ -34,17 +23,27 @@ test("settings shell keeps selected tabs and panels in sync on click", async ({
   );
 
   await expect(carTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(carTabButton).toHaveAttribute("aria-controls", "carTab");
+  await expect(carTabButton).toHaveAttribute("tabindex", "0");
   await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
 
   await analysisTabButton.click();
   await expect(analysisTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(analysisTabButton).toHaveAttribute(
+    "aria-controls",
+    "analysisTab",
+  );
+  await expect(analysisTabButton).toHaveAttribute("tabindex", "0");
   await expect(carTabButton).toHaveAttribute("aria-selected", "false");
+  await expect(carTabButton).toHaveAttribute("tabindex", "-1");
   await expect(page.locator("#analysisTab")).toHaveJSProperty("hidden", false);
   await expect(page.locator("#carTab")).toHaveJSProperty("hidden", true);
 
   await speedSourceTabButton.click();
   await expect(speedSourceTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(speedSourceTabButton).toHaveAttribute("tabindex", "0");
   await expect(analysisTabButton).toHaveAttribute("aria-selected", "false");
+  await expect(analysisTabButton).toHaveAttribute("tabindex", "-1");
   await expect(page.locator("#speedSourceTab")).toHaveJSProperty(
     "hidden",
     false,
@@ -63,20 +62,28 @@ test("settings shell supports keyboard tab navigation", async ({ page }) => {
   await carTabButton.press("ArrowRight");
   await expect(analysisTabButton).toBeFocused();
   await expect(analysisTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(analysisTabButton).toHaveAttribute("tabindex", "0");
+  await expect(carTabButton).toHaveAttribute("tabindex", "-1");
   await expect(page.locator("#analysisTab")).toHaveJSProperty("hidden", false);
 
   await analysisTabButton.press("ArrowLeft");
   await expect(carTabButton).toBeFocused();
   await expect(carTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(carTabButton).toHaveAttribute("tabindex", "0");
+  await expect(analysisTabButton).toHaveAttribute("tabindex", "-1");
   await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
 
   await carTabButton.press("End");
   await expect(espFlashTabButton).toBeFocused();
   await expect(espFlashTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(espFlashTabButton).toHaveAttribute("tabindex", "0");
+  await expect(carTabButton).toHaveAttribute("tabindex", "-1");
   await expect(page.locator("#espFlashTab")).toHaveJSProperty("hidden", false);
 
   await espFlashTabButton.press("Home");
   await expect(carTabButton).toBeFocused();
   await expect(carTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(carTabButton).toHaveAttribute("tabindex", "0");
+  await expect(espFlashTabButton).toHaveAttribute("tabindex", "-1");
   await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
 });

--- a/apps/ui/tests/regression.settings.spec.ts
+++ b/apps/ui/tests/regression.settings.spec.ts
@@ -4,13 +4,14 @@ import { createDeferred } from "./deferred_test_helpers";
 import {
   bootLiveDashboard,
   confirmPrompt,
-  createSettingsHandlerFromMap,
   fulfillJson,
   gpsStatus,
-  installCommonRoutes,
+  installSettingsRoutes,
+  obdStatus,
   openSensorsTab,
   openSettingsTab,
   openSpeedSourceTab,
+  speedSourceSettings,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 20_000 });
@@ -18,18 +19,17 @@ test.describe.configure({ timeout: 20_000 });
 test("gps status uses selected speed unit in settings panel", async ({
   page,
 }) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "/api/settings/language": { language: "en" },
-      "/api/settings/speed-unit": { speed_unit: "mps" },
-      "/api/settings/speed-source/status": gpsStatus({
-        last_update_age_s: 0.333,
-        raw_speed_kmh: 36,
-      }),
+  await installSettingsRoutes(page, {
+    "/api/settings/speed-unit": { speed_unit: "mps" },
+    "/api/settings/speed-source/status": gpsStatus({
+      last_update_age_s: 0.333,
+      raw_speed_kmh: 36,
     }),
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openSpeedSourceTab(page);
+  await expect(page.locator("#speedUnitSelect")).toHaveValue("mps");
+  await expect(page.locator("#gpsStatusState")).toHaveText("Connected");
   await expect(page.locator("#gpsStatusRawSpeed")).toHaveText("10.0 m/s");
   await expect(page.locator("#gpsStatusEffectiveSpeed")).toHaveText("5.0 m/s");
 });
@@ -38,15 +38,11 @@ test("gps status polling does not override websocket speed readout", async ({
   page,
 }) => {
   let gpsStatusCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "/api/settings/language": { language: "en" },
-      "/api/settings/speed-unit": { speed_unit: "kmh" },
-      "GET /api/settings/speed-source/status": async () => {
-        gpsStatusCalls += 1;
-        return gpsStatus({});
-      },
-    }),
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source/status": async () => {
+      gpsStatusCalls += 1;
+      return gpsStatus({});
+    },
   });
   await bootLiveDashboard(page, {
     installRoutes: false,
@@ -56,19 +52,27 @@ test("gps status polling does not override websocket speed readout", async ({
   await expect
     .poll(() => gpsStatusCalls, { timeout: 5_000 })
     .toBeGreaterThanOrEqual(2);
+  await openSpeedSourceTab(page);
+  await expect(page.locator("#gpsStatusRawSpeed")).toHaveText("18.0 km/h");
   await expect(page.locator("#speed")).toContainText("72.0 km/h");
 });
 
 test("spectrum title updates when switching language", async ({ page }) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "PUT /api/settings/language": { language: "nl" },
-      "/api/settings/speed-unit": { speed_unit: "kmh" },
-      "/api/settings/speed-source/status": gpsStatus({
-        raw_speed_kmh: 72,
-        effective_speed_kmh: 72,
-      }),
+  let languagePutCalls = 0;
+  let lastLanguagePayload: Record<string, unknown> | null = null;
+  await installSettingsRoutes(page, {
+    "GET /api/settings/language": { language: "en" },
+    "PUT /api/settings/language": async (route: Route) => {
+      languagePutCalls += 1;
+      lastLanguagePayload = route.request().postDataJSON() as Record<
+        string,
+        unknown
+      >;
+      return { language: "nl" };
+    },
+    "/api/settings/speed-source/status": gpsStatus({
+      raw_speed_kmh: 72,
+      effective_speed_kmh: 72,
     }),
   });
   await bootLiveDashboard(page, {
@@ -98,6 +102,8 @@ test("spectrum title updates when switching language", async ({ page }) => {
   await expect(spectrumTitle).toHaveText(
     "Gecombineerd spectrum van meerdere sensoren",
   );
+  await expect.poll(() => languagePutCalls).toBe(1);
+  expect(lastLanguagePayload).toEqual({ language: "nl" });
   await expect(page.locator("#languageSelect")).toHaveValue("nl");
 });
 
@@ -106,18 +112,17 @@ test("manual speed save uses settings endpoint only (no speed-override call)", a
 }) => {
   let speedSourcePutCalls = 0;
   let speedOverrideCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/speed-source": {
-        speed_source: "gps",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-      },
-      "PUT /api/settings/speed-source": async (route: Route) => {
-        speedSourcePutCalls += 1;
-        return route.request().postDataJSON();
-      },
-    }),
+  let lastSpeedSourcePayload: Record<string, unknown> | null = null;
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source": speedSourceSettings(),
+    "PUT /api/settings/speed-source": async (route: Route) => {
+      speedSourcePutCalls += 1;
+      lastSpeedSourcePayload = route.request().postDataJSON() as Record<
+        string,
+        unknown
+      >;
+      return lastSpeedSourcePayload;
+    },
   });
   await page.route("**/api/speed-override", async (route) => {
     speedOverrideCalls += 1;
@@ -139,26 +144,29 @@ test("manual speed save uses settings endpoint only (no speed-override call)", a
   await page.locator("#saveSpeedSourceBtn").click();
   await expect.poll(() => speedSourcePutCalls).toBe(1);
   await expect.poll(() => speedOverrideCalls).toBe(0);
+  expect(lastSpeedSourcePayload).toEqual({
+    manual_speed_kph: 45,
+    speed_source: "manual",
+    stale_timeout_s: 5,
+  });
+  await expect(page.locator("#speedSourceSaveFeedback")).toBeHidden();
 });
 
 test("resolved fallback manual state stays coherent across header status, form, and GPS status", async ({
   page,
 }) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/speed-source": {
-        speed_source: "gps",
-        manual_speed_kph: 80,
-        stale_timeout_s: 5,
-      },
-      "GET /api/settings/speed-source/status": gpsStatus({
-        gps_enabled: false,
-        connection_state: "disabled",
-        raw_speed_kmh: null,
-        effective_speed_kmh: 80,
-        fallback_active: true,
-        speed_source: "fallback_manual",
-      }),
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source": speedSourceSettings({
+      speed_source: "gps",
+      manual_speed_kph: 80,
+    }),
+    "GET /api/settings/speed-source/status": gpsStatus({
+      gps_enabled: false,
+      connection_state: "disabled",
+      raw_speed_kmh: null,
+      effective_speed_kmh: 80,
+      fallback_active: true,
+      speed_source: "fallback_manual",
     }),
   });
   await bootLiveDashboard(page, {
@@ -181,6 +189,9 @@ test("resolved fallback manual state stays coherent across header status, form, 
     "80.0 km/h",
   );
   await expect(page.locator("#speedSourceFallbackActive")).toHaveText("Yes");
+  await expect(page.locator("#speedSourceCurrentSource")).toHaveClass(
+    /speed-source-summary__value/,
+  );
   await expect(page.locator("#manualSpeedConfig")).toBeVisible();
   await expect(page.locator("#gpsFallbackPanel")).toBeHidden();
   const diagnostics = page.locator("#speedSourceDiagnostics");
@@ -199,48 +210,44 @@ test("resolved fallback manual state stays coherent across header status, form, 
     page.locator('input[name="speedSourceRadio"][value="gps"]'),
   ).not.toBeChecked();
   await expect(page.locator("#manualSpeedInput")).toHaveValue("80");
+  await expect(page.locator("#manualSpeedInput")).toHaveAttribute("min", "0");
 });
 
 test("resolved OBD2 state stays coherent across header status, form, and device summary", async ({
   page,
 }) => {
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/speed-source": {
-        speed_source: "obd2",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-        obd_device_mac: "0022d9001bb1",
-        obd_device_name: "OBDLink CX",
-      },
-      "GET /api/settings/speed-source/status": gpsStatus({
-        gps_enabled: false,
-        connection_state: "connected",
-        device: null,
-        raw_speed_kmh: null,
-        effective_speed_kmh: 81,
-        fallback_active: false,
-        speed_source: "obd2",
-      }),
-      "GET /api/settings/obd/status": {
-        configured_device_mac: "0022d9001bb1",
-        configured_device_name: "OBDLink CX",
-        paired: true,
-        trusted: true,
-        connected: true,
-        rfcomm_channel: 1,
-        last_rpm: 2200,
-        rpm_sample_age_s: 0.1,
-        rpm_target_interval_ms: 75,
-        rpm_effective_hz: 13.3,
-        request_rtt_ms: 61.4,
-        timeout_count: 1,
-        error_count: 2,
-        poll_mode: "rpm_only_backoff",
-        backoff_active: true,
-        last_raw_response: "41 0C 1B 58",
-        debug_hint: null,
-      },
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source": speedSourceSettings({
+      speed_source: "obd2",
+      obd_device_mac: "0022d9001bb1",
+      obd_device_name: "OBDLink CX",
+    }),
+    "GET /api/settings/speed-source/status": gpsStatus({
+      gps_enabled: false,
+      connection_state: "connected",
+      device: null,
+      raw_speed_kmh: null,
+      effective_speed_kmh: 81,
+      fallback_active: false,
+      speed_source: "obd2",
+    }),
+    "GET /api/settings/obd/status": obdStatus({
+      configured_device_mac: "0022d9001bb1",
+      configured_device_name: "OBDLink CX",
+      paired: true,
+      trusted: true,
+      connected: true,
+      rfcomm_channel: 1,
+      last_rpm: 2200,
+      rpm_sample_age_s: 0.1,
+      rpm_target_interval_ms: 75,
+      rpm_effective_hz: 13.3,
+      request_rtt_ms: 61.4,
+      timeout_count: 1,
+      error_count: 2,
+      poll_mode: "rpm_only_backoff",
+      backoff_active: true,
+      last_raw_response: "41 0C 1B 58",
     }),
   });
   await bootLiveDashboard(page, {
@@ -277,6 +284,8 @@ test("resolved OBD2 state stays coherent across header status, form, and device 
     "RPM priority only (backed off)",
   );
   await expect(page.locator("#obdStatusBackoff")).toHaveText("Yes");
+  await expect(page.locator("#obdSpeedConfig")).toBeVisible();
+  await expect(page.locator("#gpsFallbackPanel")).toBeHidden();
 });
 
 test("assigning a sensor location preserves the original sensor name", async ({
@@ -284,9 +293,11 @@ test("assigning a sensor location preserves the original sensor name", async ({
 }) => {
   let locationUpdateCalls = 0;
 
-  await installCommonRoutes(page, {
-    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
-  });
+  await installSettingsRoutes(
+    page,
+    {},
+    { locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }] },
+  );
   await page.route("**/api/clients/**/location", async (route) => {
     locationUpdateCalls += 1;
     await fulfillJson(route, {});
@@ -327,7 +338,11 @@ test("assigning a sensor location preserves the original sensor name", async ({
   await locationSelect.selectOption("front_left_wheel");
   await expect.poll(() => locationUpdateCalls).toBe(1);
   await expect(locationSelect).toHaveValue("front_left_wheel");
+  await expect(locationSelect).toHaveAttribute("data-client-id", "sensor-1");
   await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
+  await expect(row.locator(".settings-sensor-row__meta code")).toHaveText(
+    "sensor-1",
+  );
 });
 
 test("sensor identify and remove actions stay wired through the Sensors panel", async ({
@@ -335,12 +350,17 @@ test("sensor identify and remove actions stay wired through the Sensors panel", 
 }) => {
   let identifyCalls = 0;
   let removeCalls = 0;
+  let identifyPath: string | null = null;
+  let removePath: string | null = null;
 
-  await installCommonRoutes(page, {
-    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
-  });
+  await installSettingsRoutes(
+    page,
+    {},
+    { locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }] },
+  );
   await page.route("**/api/clients/**/identify", async (route) => {
     identifyCalls += 1;
+    identifyPath = new URL(route.request().url()).pathname;
     await fulfillJson(route, {});
   });
   await page.route("**/api/clients/sensor-1", async (route) => {
@@ -349,6 +369,7 @@ test("sensor identify and remove actions stay wired through the Sensors panel", 
       return;
     }
     removeCalls += 1;
+    removePath = new URL(route.request().url()).pathname;
     await fulfillJson(route, {});
   });
   await bootLiveDashboard(page, {
@@ -378,10 +399,12 @@ test("sensor identify and remove actions stay wired through the Sensors panel", 
 
   await row.locator(".row-identify").click();
   await expect.poll(() => identifyCalls).toBe(1);
+  expect(identifyPath).toBe("/api/clients/sensor-1/identify");
 
   await row.locator(".row-remove").click();
   await confirmPrompt(page);
   await expect.poll(() => removeCalls).toBe(1);
+  expect(removePath).toBe("/api/clients/sensor-1");
   await expect(
     page.locator('#sensorsSettingsBody tr[data-client-id="sensor-1"]'),
   ).toHaveCount(0);
@@ -390,9 +413,11 @@ test("sensor identify and remove actions stay wired through the Sensors panel", 
 test("settings keep inferred sensor names unassigned until an explicit location is saved", async ({
   page,
 }) => {
-  await installCommonRoutes(page, {
-    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
-  });
+  await installSettingsRoutes(
+    page,
+    {},
+    { locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }] },
+  );
   await bootLiveDashboard(page, {
     installRoutes: false,
     liveSensorPayload: {
@@ -420,6 +445,10 @@ test("settings keep inferred sensor names unassigned until an explicit location 
   const locationSelect = row.locator("select.row-location-select");
 
   await expect(locationSelect).toHaveValue("");
+  await expect(row.locator("strong")).toHaveText("Front Left Wheel");
+  await expect(row.locator(".settings-sensor-row__meta code")).toHaveText(
+    "sensor-1",
+  );
 });
 
 test("manual OBD scan sorts named devices first and background rescans progressively improve the list", async ({
@@ -439,67 +468,43 @@ test("manual OBD scan sorts named devices first and background rescans progressi
     ],
   };
   const refreshedScan = createDeferred<typeof refreshedScanPayload>();
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
-      "GET /api/settings/speed-source": {
-        speed_source: "obd2",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-        obd_device_mac: null,
-        obd_device_name: null,
-      },
-      "GET /api/settings/speed-source/status": gpsStatus({
-        speed_source: "obd2",
-        connection_state: "disconnected",
-      }),
-      "GET /api/settings/obd/status": {
-        configured_device_mac: null,
-        configured_device_name: null,
-        paired: false,
-        trusted: false,
-        connected: false,
-        rfcomm_channel: null,
-        last_rpm: null,
-        rpm_sample_age_s: null,
-        rpm_target_interval_ms: 50,
-        rpm_effective_hz: null,
-        request_rtt_ms: null,
-        timeout_count: 0,
-        error_count: 0,
-        poll_mode: null,
-        backoff_active: false,
-        last_raw_response: null,
-        debug_hint: null,
-      },
-      "POST /api/settings/obd/scan": async () => {
-        scanCalls += 1;
-        if (scanCalls === 1) {
-          return {
-            devices: [
-              {
-                mac_address: "5340ac571177",
-                name: "53-40-AC-57-11-77",
-                paired: false,
-                trusted: false,
-                connected: false,
-                rfcomm_channel: null,
-              },
-              {
-                mac_address: "0022d9001bb1",
-                name: "Audioengine HD6",
-                paired: false,
-                trusted: false,
-                connected: false,
-                rfcomm_channel: null,
-              },
-            ],
-          };
-        }
-        return await refreshedScan.promise;
-      },
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source": speedSourceSettings({
+      speed_source: "obd2",
+      obd_device_mac: null,
+      obd_device_name: null,
     }),
+    "GET /api/settings/speed-source/status": gpsStatus({
+      speed_source: "obd2",
+      connection_state: "disconnected",
+    }),
+    "GET /api/settings/obd/status": obdStatus(),
+    "POST /api/settings/obd/scan": async () => {
+      scanCalls += 1;
+      if (scanCalls === 1) {
+        return {
+          devices: [
+            {
+              mac_address: "5340ac571177",
+              name: "53-40-AC-57-11-77",
+              paired: false,
+              trusted: false,
+              connected: false,
+              rfcomm_channel: null,
+            },
+            {
+              mac_address: "0022d9001bb1",
+              name: "Audioengine HD6",
+              paired: false,
+              trusted: false,
+              connected: false,
+              rfcomm_channel: null,
+            },
+          ],
+        };
+      }
+      return await refreshedScan.promise;
+    },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openSpeedSourceTab(page);
@@ -514,6 +519,7 @@ test("manual OBD scan sorts named devices first and background rescans progressi
   await expect(
     page.locator(".speed-source-device__actions .btn").nth(0),
   ).toHaveText("Pair and use");
+  await expect(page.locator(".speed-source-device__badge")).toHaveCount(0);
 
   await expect
     .poll(() => scanCalls, { timeout: 5_000 })
@@ -522,62 +528,41 @@ test("manual OBD scan sorts named devices first and background rescans progressi
 
   refreshedScan.resolve(refreshedScanPayload);
   await expect(deviceNames.nth(1)).toHaveText("Pim's iPhone");
+  await expect(page.locator(".speed-source-device__mac").nth(1)).toHaveText(
+    "5340ac571177",
+  );
 });
 
 test("background OBD rescans stop when the Speed Source OBD panel is no longer visible", async ({
   page,
 }) => {
   let scanCalls = 0;
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "GET /api/settings/language": { language: "en" },
-      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
-      "GET /api/settings/speed-source": {
-        speed_source: "obd2",
-        manual_speed_kph: null,
-        stale_timeout_s: 5,
-        obd_device_mac: null,
-        obd_device_name: null,
-      },
-      "GET /api/settings/speed-source/status": gpsStatus({
-        speed_source: "obd2",
-        connection_state: "disconnected",
-      }),
-      "GET /api/settings/obd/status": {
-        configured_device_mac: null,
-        configured_device_name: null,
-        paired: false,
-        trusted: false,
-        connected: false,
-        rfcomm_channel: null,
-        last_rpm: null,
-        rpm_sample_age_s: null,
-        rpm_target_interval_ms: 50,
-        rpm_effective_hz: null,
-        request_rtt_ms: null,
-        timeout_count: 0,
-        error_count: 0,
-        poll_mode: null,
-        backoff_active: false,
-        last_raw_response: null,
-        debug_hint: null,
-      },
-      "POST /api/settings/obd/scan": async () => {
-        scanCalls += 1;
-        return {
-          devices: [
-            {
-              mac_address: "0022d9001bb1",
-              name: "OBDLink CX",
-              paired: false,
-              trusted: false,
-              connected: false,
-              rfcomm_channel: null,
-            },
-          ],
-        };
-      },
+  await installSettingsRoutes(page, {
+    "GET /api/settings/speed-source": speedSourceSettings({
+      speed_source: "obd2",
+      obd_device_mac: null,
+      obd_device_name: null,
     }),
+    "GET /api/settings/speed-source/status": gpsStatus({
+      speed_source: "obd2",
+      connection_state: "disconnected",
+    }),
+    "GET /api/settings/obd/status": obdStatus(),
+    "POST /api/settings/obd/scan": async () => {
+      scanCalls += 1;
+      return {
+        devices: [
+          {
+            mac_address: "0022d9001bb1",
+            name: "OBDLink CX",
+            paired: false,
+            trusted: false,
+            connected: false,
+            rfcomm_channel: null,
+          },
+        ],
+      };
+    },
   });
   await bootLiveDashboard(page, { installRoutes: false });
   await openSpeedSourceTab(page);
@@ -593,5 +578,6 @@ test("background OBD rescans stop when the Speed Source OBD panel is no longer v
     page.locator('input[name="speedSourceRadio"][value="gps"]'),
   ).toBeChecked();
   await expect(page.locator("#obdSpeedConfig")).toBeHidden();
+  await expect(page.locator("#gpsFallbackPanel")).toBeVisible();
   expect(scanCalls).toBe(stoppedAt);
 });

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -516,3 +516,61 @@ export function gpsStatus(overrides: Partial<Record<string, unknown>>) {
     ...overrides,
   };
 }
+
+function baseSettingsRouteMap(
+  overrides: Record<string, SettingsRouteValue> = {},
+): Record<string, SettingsRouteValue> {
+  return {
+    "/api/settings/language": { language: "en" },
+    "/api/settings/speed-unit": { speed_unit: "kmh" },
+    "/api/settings/speed-source/status": gpsStatus({}),
+    ...overrides,
+  };
+}
+
+export async function installSettingsRoutes(
+  page: Page,
+  settingsMap: Record<string, SettingsRouteValue> = {},
+  options: Omit<CommonRouteOptions, "settingsHandler"> = {},
+): Promise<void> {
+  await installCommonRoutes(page, {
+    ...options,
+    settingsHandler: createSettingsHandlerFromMap(
+      baseSettingsRouteMap(settingsMap),
+    ),
+  });
+}
+
+export function obdStatus(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    configured_device_mac: null,
+    configured_device_name: null,
+    paired: false,
+    trusted: false,
+    connected: false,
+    rfcomm_channel: null,
+    last_rpm: null,
+    rpm_sample_age_s: null,
+    rpm_target_interval_ms: 50,
+    rpm_effective_hz: null,
+    request_rtt_ms: null,
+    timeout_count: 0,
+    error_count: 0,
+    poll_mode: null,
+    backoff_active: false,
+    last_raw_response: null,
+    debug_hint: null,
+    ...overrides,
+  };
+}
+
+export function speedSourceSettings(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  return {
+    speed_source: "gps",
+    manual_speed_kph: null,
+    stale_timeout_s: 5,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Closes #3961

## What changed
- Added shared UI settings regression route helpers for default language, speed unit, speed-source, and OBD fixtures.
- Tightened 22 settings regression tests across settings alignment, analysis, car feedback, language, OBD scan, shell, and settings flows.
- Added assertions for request payloads, route endpoints, ARIA/tab state, feedback tone, sensor identity preservation, OBD device details, and active panel visibility.

## Why
The listed tests were mostly smoke-level. They now prove specific settings behavior and share repeated setup.

## Validation
- make plan-validation
- make ui-typecheck
- cd apps/ui && npm run typecheck:tests
- cd apps/ui && npm run test:unit
- cd apps/ui && npm run build
- cd apps/ui && npx playwright test --config=playwright.regression.config.ts --project=laptop-light --list tests/regression.settings-alignment.spec.ts tests/regression.settings-analysis.spec.ts tests/regression.settings-car-feedback-reset.spec.ts tests/regression.settings-language.spec.ts tests/regression.settings-obd-scan-timeout.spec.ts tests/regression.settings-shell.spec.ts tests/regression.settings.spec.ts

Targeted Playwright execution was attempted, but local Chromium cannot start in this container because libglib-2.0.so.0 is missing and sudo dependency install is unavailable. CI should run the browser suite.

## Risks / tradeoffs
- Test-only change.
- Assertions are tighter, so future UI contract drift should fail closer to the changed behavior.
- No production code changed.