### PR TITLE
Improve non-settings UI regression tests

### DIFF
--- a/apps/ui/tests/regression.analysis-sensors.spec.ts
+++ b/apps/ui/tests/regression.analysis-sensors.spec.ts
@@ -4,7 +4,9 @@ import {
   fulfillJson,
   installCommonRoutes,
   installFakeWebSocket,
+  selectedCarSettings,
   requestPath,
+  waitForFakeWebSocketSettled,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 15_000 });
@@ -17,10 +19,7 @@ test("analysis guidance can reopen and refocus after repeated invalid saves", as
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
       if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings());
         return;
       }
       await fulfillJson(route, {});
@@ -48,6 +47,9 @@ test("analysis guidance can reopen and refocus after repeated invalid saves", as
   await expect(guidanceHelp).toHaveAttribute("open", "");
   await expect(bandwidthInput).toHaveAttribute("aria-invalid", "true");
   await expect(bandwidthInput).toBeFocused();
+  await expect(page.locator("#wheelBandwidthGuidance")).toContainText(
+    "Wheel Bandwidth (%) must stay between 0.1% and 100%",
+  );
 
   await guidanceHelp.evaluate((element) => {
     if (!(element instanceof HTMLDetailsElement)) {
@@ -64,6 +66,7 @@ test("analysis guidance can reopen and refocus after repeated invalid saves", as
   await expect(guidanceHelp).toHaveAttribute("open", "");
   await expect(bandwidthInput).toHaveAttribute("aria-invalid", "true");
   await expect(bandwidthInput).toBeFocused();
+  await expect(bandwidthInput).toHaveValue("130");
 });
 
 test("sensor row actions stay wired while live updates keep arriving", async ({
@@ -71,16 +74,21 @@ test("sensor row actions stay wired while live updates keep arriving", async ({
 }) => {
   let identifyCalls = 0;
   let locationUpdateCalls = 0;
+  let identifyPath: string | null = null;
+  let locationPayload: Record<string, unknown> | null = null;
+  const trackerKey = "__sensorActionsRepeatTracker";
 
   await installCommonRoutes(page, {
     locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
   });
   await page.route("**/api/clients/**/location", async (route) => {
     locationUpdateCalls += 1;
+    locationPayload = route.request().postDataJSON() as Record<string, unknown>;
     await fulfillJson(route, {});
   });
   await page.route("**/api/clients/**/identify", async (route) => {
     identifyCalls += 1;
+    identifyPath = new URL(route.request().url()).pathname;
     await fulfillJson(route, {});
   });
   await installFakeWebSocket(page, {
@@ -104,6 +112,7 @@ test("sensor row actions stay wired while live updates keep arriving", async ({
     },
     repeatPayloadCount: 6,
     repeatPayloadIntervalMs: 40,
+    trackerKey,
   });
 
   await page.goto("/");
@@ -118,9 +127,14 @@ test("sensor row actions stay wired while live updates keep arriving", async ({
   await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
   await locationSelect.selectOption("front_left_wheel");
   await expect.poll(() => locationUpdateCalls).toBe(1);
+  expect(locationPayload).toEqual({ location_code: "front_left_wheel" });
+  await expect(locationSelect).toHaveValue("front_left_wheel");
   await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
 
+  await waitForFakeWebSocketSettled(page, trackerKey, 7);
+  await expect(locationSelect).toHaveValue("front_left_wheel");
   await row.locator(".row-identify").click();
   await expect.poll(() => identifyCalls).toBe(1);
+  expect(identifyPath).toBe("/api/clients/sensor-1/identify");
   await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
 });

--- a/apps/ui/tests/regression.bootstrap.spec.ts
+++ b/apps/ui/tests/regression.bootstrap.spec.ts
@@ -6,6 +6,8 @@ import {
   installCommonRoutes,
   installFakeWebSocket,
   requestPath,
+  selectedCarSettings,
+  speedSourceSettings,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 15_000 });
@@ -40,18 +42,7 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
     locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [
-            {
-              id: "car-1",
-              name: "Test Hatch",
-              type: "Simulated setup",
-              variant: null,
-              aspects: {},
-            },
-          ],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings({ name: "Test Hatch" }));
         return;
       }
       await fulfillJson(route, {});
@@ -107,6 +98,9 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
       .locator('.capture-readiness__item[data-readiness-state="pass"]')
       .first(),
   ).toContainText(/live sensor.*streaming cleanly/i);
+  await expect(
+    page.locator('.capture-readiness__item[data-readiness-state="pass"]'),
+  ).toHaveCount(4);
 
   captureReadiness = buildCaptureReadiness({
     isReady: false,
@@ -136,6 +130,12 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
       .locator('.capture-readiness__item[data-readiness-state="fail"]')
       .first(),
   ).toContainText(/live speed sample/i);
+  await expect(
+    page.locator('.capture-readiness__item[data-readiness-state="warn"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('.capture-readiness__item[data-readiness-state="fail"]'),
+  ).toHaveCount(2);
   const banner = page.locator(".app-error-banner");
   await banner.evaluate((element) => {
     if (!(element instanceof HTMLElement)) {
@@ -147,6 +147,7 @@ test("dark mode theme regression keeps shared readiness and warning surfaces wir
   });
 
   await expect(banner).toBeVisible();
+  await expect(banner).toHaveAttribute("data-variant", "warn");
   await expect(banner).toContainText("Attention needed");
 });
 
@@ -164,25 +165,11 @@ test("dashboard bootstrap defers secondary bundle until a dependent view opens",
     settingsHandler: async (route) => {
       const path = requestPath(route);
       if (path === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [
-            {
-              id: "car-1",
-              name: "Test Hatch",
-              type: "Simulated setup",
-              aspects: {},
-            },
-          ],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings({ name: "Test Hatch" }));
         return;
       }
       if (path === "/api/settings/speed-source") {
-        await fulfillJson(route, {
-          speed_source: "gps",
-          manual_speed_kph: null,
-          stale_timeout_s: 5,
-        });
+        await fulfillJson(route, speedSourceSettings());
         return;
       }
       await fulfillJson(route, {});
@@ -198,6 +185,8 @@ test("dashboard bootstrap defers secondary bundle until a dependent view opens",
 
   await page.locator("#tab-settings").click();
   await expect.poll(() => secondaryBundleRequests.length).toBeGreaterThan(0);
+  expect(new Set(secondaryBundleRequests).size).toBe(1);
+  await expect(page.locator("#settingsView")).toHaveJSProperty("hidden", false);
 });
 
 test("saved run state points directly to History", async ({ page }) => {
@@ -237,18 +226,7 @@ test("saved run state points directly to History", async ({ page }) => {
     ],
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [
-            {
-              id: "car-1",
-              name: "Test Hatch",
-              type: "Simulated setup",
-              variant: null,
-              aspects: {},
-            },
-          ],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings({ name: "Test Hatch" }));
         return;
       }
       await fulfillJson(route, {});
@@ -293,6 +271,12 @@ test("saved run state points directly to History", async ({ page }) => {
   await expect(savedSummary).toContainText(
     "Open History to review the diagnosis",
   );
+  await expect(
+    savedSummary.locator('[data-inline-state-action="open-history"]'),
+  ).toHaveText("Open History");
   await savedSummary.getByRole("button", { name: "Open History" }).click();
   await expect(page.locator("#historyView")).toHaveJSProperty("hidden", false);
+  await expect(
+    page.locator('[data-run-row="1"][data-run="run-002"]'),
+  ).toBeVisible();
 });

--- a/apps/ui/tests/regression.car-wizard.spec.ts
+++ b/apps/ui/tests/regression.car-wizard.spec.ts
@@ -7,6 +7,7 @@ import {
   installCommonRoutes,
   installFakeWebSocket,
   requestPath,
+  selectedCarSettings,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 15_000 });
@@ -27,12 +28,7 @@ test("opens the add car wizard in a focused task container and restores focus wh
   await page.setViewportSize({ width: 390, height: 844 });
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
-      "/api/settings/cars": {
-        cars: [
-          { id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} },
-        ],
-        active_car_id: "car-1",
-      },
+      "/api/settings/cars": selectedCarSettings({ name: "Audit Demo Car" }),
     }),
   });
   await page.route("**/api/car-library/**", async (route) => {
@@ -52,6 +48,14 @@ test("opens the add car wizard in a focused task container and restores focus wh
 
   await expect(page.locator("#wizardBackdrop")).toBeVisible();
   await expect(page.locator("#addCarWizard")).toBeVisible();
+  await expect(page.locator("#addCarWizard")).toHaveAttribute(
+    "aria-modal",
+    "true",
+  );
+  await expect(page.locator("#addCarWizard")).toHaveAttribute(
+    "aria-labelledby",
+    "wizardTitle",
+  );
   await expect(page.locator("#wizardProgressText")).toContainText(
     "Step 1 of 5",
   );
@@ -86,12 +90,7 @@ test("closes the add car wizard from Escape on the focused input and restores fo
   await page.setViewportSize({ width: 390, height: 844 });
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
-      "/api/settings/cars": {
-        cars: [
-          { id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} },
-        ],
-        active_car_id: "car-1",
-      },
+      "/api/settings/cars": selectedCarSettings({ name: "Audit Demo Car" }),
     }),
   });
   await page.route("**/api/car-library/**", async (route) => {
@@ -127,6 +126,8 @@ test("keeps the manual branch deliberate while summarizing selections and activa
   ];
   let activeCarId = "car-1";
   let createdCarName = "";
+  let createdCarAspects: Record<string, number> | null = null;
+  let activatedCarId: string | null = null;
 
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
@@ -143,6 +144,7 @@ test("keeps the manual branch deliberate while summarizing selections and activa
           aspects: Record<string, number>;
         };
         createdCarName = body.name;
+        createdCarAspects = body.aspects;
         cars.push({
           id: "car-2",
           name: body.name,
@@ -155,6 +157,7 @@ test("keeps the manual branch deliberate while summarizing selections and activa
       if (path === "/api/settings/cars/active" && method === "PUT") {
         const body = route.request().postDataJSON() as { car_id: string };
         activeCarId = body.car_id;
+        activatedCarId = body.car_id;
         await fulfillJson(route, { cars, active_car_id: activeCarId });
         return;
       }
@@ -251,6 +254,14 @@ test("keeps the manual branch deliberate while summarizing selections and activa
   await page.locator("#wizardManualAddBtn").click();
 
   await expect.poll(() => createdCarName).toBe("BMW X5 M60i");
+  expect(createdCarAspects).toMatchObject({
+    current_gear_ratio: 0.68,
+    final_drive_ratio: 3.08,
+    rim_in: 18,
+    tire_aspect_pct: 45,
+    tire_width_mm: 245,
+  });
+  await expect.poll(() => activatedCarId).toBe("car-2");
   await expect(page.locator("#addCarWizard")).toBeHidden();
   await expect(page.locator("#wizardBackdrop")).toBeHidden();
   await expect(page.locator("#addCarBtn")).toBeFocused();
@@ -274,6 +285,8 @@ test("completes the library branch on a short mobile screen without losing the f
   ];
   let activeCarId = "car-1";
   let createdCarName = "";
+  let createdCarAspects: Record<string, number> | null = null;
+  let activatedCarId: string | null = null;
 
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
@@ -290,6 +303,7 @@ test("completes the library branch on a short mobile screen without losing the f
           aspects: Record<string, number>;
         };
         createdCarName = body.name;
+        createdCarAspects = body.aspects;
         cars.push({
           id: "car-2",
           name: body.name,
@@ -302,6 +316,7 @@ test("completes the library branch on a short mobile screen without losing the f
       if (path === "/api/settings/cars/active" && method === "PUT") {
         const body = route.request().postDataJSON() as { car_id: string };
         activeCarId = body.car_id;
+        activatedCarId = body.car_id;
         await fulfillJson(route, { cars, active_car_id: activeCarId });
         return;
       }
@@ -384,6 +399,14 @@ test("completes the library branch on a short mobile screen without losing the f
   await page.locator("#wizardManualAddBtn").click();
 
   await expect.poll(() => createdCarName).toBe("BMW X5");
+  expect(createdCarAspects).toMatchObject({
+    current_gear_ratio: 0.67,
+    final_drive_ratio: 3.15,
+    rim_in: 21,
+    tire_aspect_pct: 40,
+    tire_width_mm: 275,
+  });
+  await expect.poll(() => activatedCarId).toBe("car-2");
   await expect(page.locator("#addCarWizard")).toBeHidden();
   await expect(page.locator("#addCarBtn")).toBeFocused();
   const newRow = page.locator('#carListBody tr[data-car-id="car-2"]');

--- a/apps/ui/tests/regression.cars.spec.ts
+++ b/apps/ui/tests/regression.cars.spec.ts
@@ -10,6 +10,8 @@ import {
   openCarsTab,
   openHistoryTab,
   requestPath,
+  selectedCarSettings,
+  settingsCarsResponse,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 20_000 });
@@ -22,7 +24,7 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({
     settingsHandler: async (route) => {
       const path = requestPath(route);
       if (path === "/api/settings/cars") {
-        await fulfillJson(route, { cars: [], active_car_id: null });
+        await fulfillJson(route, settingsCarsResponse([], null));
         return;
       }
       await fulfillJson(route, {});
@@ -69,6 +71,9 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({
   await activateWizardCloseButton(page);
   await openAnalysisTab(page);
   await expect(page.locator("#analysisNoCarMessage")).toBeVisible();
+  await expect(page.locator("#analysisNoCarMessage")).toContainText(
+    "Select or create a car",
+  );
   await expect(page.locator("#saveAnalysisBtn")).toBeDisabled();
   await expect(page.locator("#resetAnalysisBtn")).toBeDisabled();
   expect(analysisPutCalls).toBe(0);
@@ -107,23 +112,19 @@ test("keeps contextual no-car guidance hidden until active car bootstrap resolve
       const path = requestPath(route);
       if (path === "/api/settings/cars") {
         await waitForCars;
-        await fulfillJson(route, {
-          cars: [
-            {
-              id: "car-1",
-              name: "Audit Demo Car",
-              type: "sedan",
-              aspects: {
-                tire_width_mm: 285,
-                tire_aspect_pct: 30,
-                rim_in: 21,
-                final_drive_ratio: 3.08,
-                current_gear_ratio: 0.64,
-              },
+        await fulfillJson(
+          route,
+          selectedCarSettings({
+            aspects: {
+              current_gear_ratio: 0.64,
+              final_drive_ratio: 3.08,
+              rim_in: 21,
+              tire_aspect_pct: 30,
+              tire_width_mm: 285,
             },
-          ],
-          active_car_id: "car-1",
-        });
+            name: "Audit Demo Car",
+          }),
+        );
         return;
       }
       if (path === "/api/settings/analysis") {
@@ -235,6 +236,7 @@ test("keeps contextual no-car guidance hidden until active car bootstrap resolve
     "data-state",
     "active",
   );
+  await expect(activeRow).toHaveAttribute("data-car-complete", "true");
 
   await page.locator("#tab-dashboard").click();
   await expect(page.locator("#liveActiveCar")).not.toHaveAttribute(
@@ -256,6 +258,7 @@ test("shows a live warning state until an active car is selected, then clears it
 }) => {
   let activeCarId: string | null = null;
   let startCalls = 0;
+  let activatedCarPayload: Record<string, unknown> | null = null;
   const completeAspects = {
     tire_width_mm: 245,
     tire_aspect_pct: 40,
@@ -289,6 +292,10 @@ test("shows a live warning state until an active car is selected, then clears it
         return;
       }
       if (path === "/api/settings/cars/active" && method === "PUT") {
+        activatedCarPayload = route.request().postDataJSON() as Record<
+          string,
+          unknown
+        >;
         activeCarId = "car-2";
         await fulfillJson(route, {
           cars: [
@@ -421,6 +428,7 @@ test("shows a live warning state until an active car is selected, then clears it
   await page
     .locator('#carListBody tr[data-car-id="car-2"] .car-activate-btn')
     .click();
+  expect(activatedCarPayload).toEqual({ car_id: "car-2" });
 
   await page.locator("#tab-dashboard").click();
   await expect(page.locator("#liveActiveCar")).not.toHaveAttribute(
@@ -435,4 +443,5 @@ test("shows a live warning state until an active car is selected, then clears it
   await expect(page.locator("#loggingStatus")).toBeHidden();
   await expect(page.locator("#startLoggingBtn")).toBeVisible();
   await expect(page.locator("#startLoggingBtn")).toBeEnabled();
+  await expect.poll(() => startCalls).toBe(0);
 });

--- a/apps/ui/tests/regression.esp-flash.spec.ts
+++ b/apps/ui/tests/regression.esp-flash.spec.ts
@@ -15,6 +15,8 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({
 }) => {
   let statusState: "idle" | "running" | "success" = "idle";
   let logCursor = 0;
+  let startCalls = 0;
+  let statusCalls = 0;
   const logs = Array.from(
     { length: 18 },
     (_, index) => `flash line ${index}: ${"output ".repeat(12)}`,
@@ -38,12 +40,14 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({
         return;
       }
       if (path === "/api/esp-flash/start") {
+        startCalls += 1;
         statusState = "running";
         logCursor = 0;
         await fulfillJson(route, { status: "started", job_id: 1 });
         return;
       }
       if (path === "/api/esp-flash/status") {
+        statusCalls += 1;
         if (statusState === "running" && logCursor >= logs.length)
           statusState = "success";
         await fulfillJson(route, {
@@ -130,6 +134,7 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({
     panel.scrollTop = 0;
   });
   await page.locator("#espFlashStartBtn").click();
+  await expect.poll(() => startCalls).toBe(1);
   statusState = "running";
   logCursor = 2;
   const pairedLayout = await page.evaluate(() => {
@@ -167,6 +172,7 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({
   expect(pairedLayout?.leftDelta ?? 0).toBeGreaterThan(40);
   expect(pairedLayout?.readinessGrouped).toBe(true);
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Running");
+  await expect.poll(() => statusCalls).toBeGreaterThan(0);
   await expect(page.locator("#espFlashStartBtn")).toBeHidden();
   await expect(page.locator("#espFlashCancelBtn")).toBeVisible();
   await expect(page.locator("#espFlashReadinessPanel")).toContainText(
@@ -208,6 +214,7 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({
     )
     .toBe(true);
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Success");
+  await expect(page.locator("#espFlashCancelBtn")).toBeHidden();
   await expect(
     page.locator(
       '#espFlashJourneyPanel .maintenance-stage[data-stage-state="done"]',
@@ -244,6 +251,10 @@ test("settings esp flash status falls back to idle when API omits state", async 
   await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="espFlashTab"]').click();
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Idle");
+  await expect(page.locator("#espFlashStatusBanner")).toHaveAttribute(
+    "data-variant",
+    "muted",
+  );
   await expect(page.locator("#espFlashStartBtn")).toBeDisabled();
   await expect(page.locator("#espFlashCancelBtn")).toBeHidden();
   await expect(page.locator("#espFlashStartSummary")).toContainText(
@@ -321,6 +332,10 @@ test("settings esp flash failure shows retry guidance, retained failed stage, an
   await page.locator('[data-settings-tab="espFlashTab"]').click();
   await expect(page.locator("#espFlashStartBtn")).toHaveText("Retry flash");
   await expect(page.locator("#espFlashStartBtn")).toBeEnabled();
+  await expect(page.locator("#espFlashStatusBanner")).toHaveAttribute(
+    "data-variant",
+    "bad",
+  );
   await expect(page.locator("#espFlashStartSummary")).toContainText(
     "Recovery guidance",
   );

--- a/apps/ui/tests/regression.history-layout.spec.ts
+++ b/apps/ui/tests/regression.history-layout.spec.ts
@@ -5,6 +5,7 @@ import {
   installCommonRoutes,
   installFakeWebSocket,
   requestPath,
+  selectedCarSettings,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 12_000 });
@@ -27,10 +28,7 @@ test("history uses mobile run cards and keeps the primary action readable on nar
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings());
         return;
       }
       await fulfillJson(route, {});
@@ -67,6 +65,8 @@ test("history uses mobile run cards and keeps the primary action readable on nar
     '[data-run-toggle="details"][data-run="run-001"]',
   );
   await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(toggle).toHaveAttribute("data-run", "run-001");
   await expect(row).toContainText("Track Car");
   await expect(row).toContainText("Started");
   await expect(row).toContainText("Samples");
@@ -77,6 +77,7 @@ test("history uses mobile run cards and keeps the primary action readable on nar
   await expect(toggle).toContainText("Open diagnosis");
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator(".history-details-row")).toBeVisible();
 });
 
 test("history empty state stays action-oriented on narrow screens", async ({
@@ -99,4 +100,9 @@ test("history empty state stays action-oriented on narrow screens", async ({
   const emptyState = page.locator("#historyTableBody .empty-state");
   await expect(emptyState).toContainText("Capture the first run from Live.");
   await expect(emptyState).toContainText("Go to Live");
+  await emptyState.getByRole("button", { name: "Go to Live" }).click();
+  await expect(page.locator("#dashboardView")).toHaveJSProperty(
+    "hidden",
+    false,
+  );
 });

--- a/apps/ui/tests/regression.history.spec.ts
+++ b/apps/ui/tests/regression.history.spec.ts
@@ -6,6 +6,7 @@ import {
   openHistoryTab,
   requestPath,
   installCommonRoutes,
+  selectedCarSettings,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 15_000 });
@@ -27,10 +28,7 @@ test("history rows show diagnostic context before expansion", async ({
   await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings());
         return;
       }
       await fulfillJson(route, {});
@@ -123,10 +121,7 @@ test("history preview uses dB intensity fields from insights payload", async ({
   await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings());
         return;
       }
       await fulfillJson(route, {});
@@ -251,6 +246,8 @@ test("history PDF download revokes object URL with safe delay", async ({
   page,
 }) => {
   let reportPdfCalls = 0;
+  let requestedPdfPath: string | null = null;
+  let revokedUrl: string | null = null;
   const revokeCallCount = () =>
     page.evaluate(
       () =>
@@ -271,6 +268,7 @@ test("history PDF download revokes object URL with safe delay", async ({
   });
   await page.route("**/api/history/**/report.pdf**", async (route) => {
     reportPdfCalls += 1;
+    requestedPdfPath = new URL(route.request().url()).pathname;
     await route.fulfill({
       status: 200,
       headers: {
@@ -283,11 +281,13 @@ test("history PDF download revokes object URL with safe delay", async ({
   await page.addInitScript(() => {
     const globalState = window as typeof window & {
       __revokeCallCount?: number;
+      __revokedUrl?: string;
     };
     globalState.__revokeCallCount = 0;
     URL.createObjectURL = (() =>
       "blob:history-download-test") as typeof URL.createObjectURL;
     URL.revokeObjectURL = ((_: string) => {
+      globalState.__revokedUrl = _;
       globalState.__revokeCallCount = (globalState.__revokeCallCount ?? 0) + 1;
     }) as typeof URL.revokeObjectURL;
   });
@@ -299,8 +299,15 @@ test("history PDF download revokes object URL with safe delay", async ({
   await expect(pdfButton).toBeVisible();
   await pdfButton.click();
   await expect.poll(() => reportPdfCalls).toBe(1);
+  expect(requestedPdfPath).toBe("/api/history/run-001/report.pdf");
   expect(await revokeCallCount()).toBe(0);
   await expect.poll(revokeCallCount, { timeout: 2_000 }).toBe(1);
+  revokedUrl = await page.evaluate(
+    () =>
+      (window as typeof window & { __revokedUrl?: string }).__revokedUrl ??
+      null,
+  );
+  expect(revokedUrl).toBe("blob:history-download-test");
 });
 
 test("history loaded insights promote the result summary above supporting evidence", async ({
@@ -309,10 +316,7 @@ test("history loaded insights promote the result summary above supporting eviden
   await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
-        await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
-          active_car_id: "car-1",
-        });
+        await fulfillJson(route, selectedCarSettings());
         return;
       }
       await fulfillJson(route, {});

--- a/apps/ui/tests/regression.realtime-logging-summary.spec.ts
+++ b/apps/ui/tests/regression.realtime-logging-summary.spec.ts
@@ -50,6 +50,10 @@ test("keeps the no-car Live CTA stable while repeated websocket payloads arrive"
   const liveSummary = page.locator("#loggingSummary");
   const addCarButton = liveSummary.getByRole("button", { name: "Add a car" });
   await expect(addCarButton).toBeVisible();
+  await expect(addCarButton).toHaveAttribute(
+    "data-inline-state-action",
+    "open-add-car",
+  );
   await expect(page.locator("#spectrumPanelRoot")).toBeHidden();
 
   await page.evaluate(() => {
@@ -106,5 +110,6 @@ test("keeps the no-car Live CTA stable while repeated websocket payloads arrive"
 
   await addCarButton.click();
   await expect(page.locator("#settingsView")).toHaveJSProperty("hidden", false);
+  await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
   await expect(page.locator("#wizardBackdrop")).toBeVisible();
 });

--- a/apps/ui/tests/regression.spectrum.spec.ts
+++ b/apps/ui/tests/regression.spectrum.spec.ts
@@ -41,6 +41,7 @@ test("spectrum controls simplify the chart and update the inspector", async ({
   await expect(bandToggle).toHaveAttribute("aria-expanded", "false");
   await expect(bandLegend).toBeHidden();
   await expect(inspector).toContainText("Strongest:");
+  await expect(page.locator("#specChart canvas")).toBeVisible();
   await expect(sensorChip).not.toHaveAttribute("data-legend-state", "active");
   await expect(sensorChip).not.toHaveAttribute("data-legend-state", "muted");
   await sensorChip.click();
@@ -62,6 +63,7 @@ test("spectrum controls simplify the chart and update the inspector", async ({
   );
   await expect(bandLegend).toBeVisible();
   await expect(bandLegend).toContainText("Wheel 1x");
+  await expect(bandLegend.locator(".legend-item")).toHaveCount(4);
   const headerBottom = await page
     .locator(".site-header")
     .evaluate((el) => el.getBoundingClientRect().bottom);
@@ -219,12 +221,14 @@ test("spectrum controls stay interactive while repeated websocket updates arrive
   await sensorChip.click();
   await expect(sensorChip).toHaveAttribute("aria-pressed", "true");
   await expect(sensorChip).toHaveAttribute("data-legend-state", "active");
+  await expect(sensorChip).toContainText("12.0 dB");
   await expect(allTracesChip).toHaveAttribute("aria-pressed", "false");
   await expect(inspector).toContainText("Focused:");
   await expect(inspector).toContainText("Front Right Wheel");
 
   await bandToggle.click();
   await expect(bandToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(bandToggle).toHaveAttribute("aria-expanded", "true");
   await expect(bandLegend).toBeVisible();
 
   await waitForFakeWebSocketSettled(page, trackerKey, 7);
@@ -306,6 +310,9 @@ test("spectrum band toggle stays hidden when no spectrum data is available", asy
   await page.goto("/");
 
   await expect(page.locator("#spectrumOverlay")).toBeVisible();
+  await expect(page.locator("#spectrumOverlay")).toContainText(
+    "Waiting for spectrum data",
+  );
   await expect(page.locator("#spectrumBandToggle")).toBeHidden();
   await expect(page.locator("#bandLegend")).toBeHidden();
 });

--- a/apps/ui/tests/regression.update.spec.ts
+++ b/apps/ui/tests/regression.update.spec.ts
@@ -109,6 +109,7 @@ test("settings update tab renders readiness guidance when idle", async ({
     "Starting a Wi-Fi update temporarily pauses hotspot access",
   );
   await page.locator("#updateSsidInput").fill("Workshop Wi-Fi");
+  await expect(page.locator("#updateSsidInput")).toHaveValue("Workshop Wi-Fi");
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "All visible prerequisites are ready to start the update.",
   );
@@ -182,6 +183,7 @@ test("settings internet tab and updater show USB internet when usable", async ({
     "Existing USB internet",
   );
   await page.locator("#updateTransportChoiceUsb").click();
+  await expect(page.locator("#updateTransportUsbRadio")).toBeChecked();
   await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
     "data-selected",
     "true",
@@ -255,6 +257,7 @@ test("settings internet tab restores persisted Wi-Fi SSID after reboot", async (
   await bootLiveDashboard(page, { installRoutes: false });
   await openInternetTab(page);
   await expect(page.locator("#updateSsidInput")).toHaveValue("Workshop Wi-Fi");
+  await expect(page.locator("#updateTransportWifiRadio")).toBeChecked();
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "All visible prerequisites are ready to start the update.",
   );
@@ -318,6 +321,7 @@ test("settings internet tab toggles the Wi-Fi password field without losing the 
     "password",
   );
   await expect(page.locator("#updatePasswordInput")).toHaveValue("secret");
+  await expect(page.locator("#updateTogglePasswordBtn")).toContainText("Show");
 });
 
 test("settings update failure shows retry guidance, failed-stage retention, and latest attempt context", async ({
@@ -483,4 +487,7 @@ test("settings update recovery keeps Retry Update enabled even when readiness st
   await openUpdateTab(page);
   await expect(page.locator("#updateStartBtn")).toHaveText("Retry Update");
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "GitHub release download timed out",
+  );
 });

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -574,3 +574,38 @@ export function speedSourceSettings(
     ...overrides,
   };
 }
+
+const completeCarAspects = {
+  current_gear_ratio: 0.82,
+  final_drive_ratio: 3.91,
+  rim_in: 18,
+  tire_aspect_pct: 40,
+  tire_width_mm: 245,
+} as const;
+
+export function settingsCarsResponse(
+  cars: readonly Record<string, unknown>[],
+  activeCarId: string | null,
+): Record<string, unknown> {
+  return {
+    active_car_id: activeCarId,
+    cars,
+  };
+}
+
+export function selectedCarSettings(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return settingsCarsResponse(
+    [
+      {
+        aspects: completeCarAspects,
+        id: "car-1",
+        name: "Selected",
+        type: "sedan",
+        ...overrides,
+      },
+    ],
+    "car-1",
+  );
+}

--- a/apps/ui/tests/visual.spec.ts
+++ b/apps/ui/tests/visual.spec.ts
@@ -1,9 +1,7 @@
-import { test, expect } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 /** Assert the spectrum canvas has visible coloured (non-background) pixels (i.e. plotted graph data). */
-async function assertSpectrumHasData(
-  page: import("@playwright/test").Page,
-): Promise<void> {
+async function assertSpectrumHasData(page: Page): Promise<void> {
   await expect
     .poll(
       async () =>
@@ -49,7 +47,11 @@ test.describe("Live view", () => {
   test("renders the live overview dashboard", async ({ page }) => {
     await page.goto("/?demo=1");
 
-    // Verify the spectrum chart has visible graph data (not just an empty canvas)
+    await expect(page.locator("#dashboardView")).toHaveJSProperty(
+      "hidden",
+      false,
+    );
+    await expect(page.locator("#liveSensorRoster article")).toHaveCount(3);
     await assertSpectrumHasData(page);
 
     await expect(page).toHaveScreenshot("live-view.png", { fullPage: true });
@@ -59,15 +61,16 @@ test.describe("Live view", () => {
 test.describe("Settings view", () => {
   test("renders analysis tab", async ({ page }) => {
     await page.goto("/?demo=1");
-    // Navigate to Settings
     await page.click('[data-view="settingsView"]');
-    // Click the Analysis tab
     await page.click('[data-settings-tab="analysisTab"]');
-    // Wait for the analysis panel to become the active visible tabpanel.
     await expect(page.locator("#analysisTab")).toHaveJSProperty(
       "hidden",
       false,
     );
+    await expect(page.locator("#analysisGuidanceHelp")).toContainText(
+      "Safe starting point",
+    );
+    await expect(page.locator("#saveAnalysisBtn")).toBeVisible();
     await expect(page).toHaveScreenshot("settings-analysis.png", {
       fullPage: true,
     });


### PR DESCRIPTION
Closes #3962

## What changed
- Added shared car settings fixtures for UI regression tests.
- Tightened 34 non-settings UI regression and visual tests across analysis/sensors, bootstrap, car wizard, cars, ESP flash, history, realtime logging, spectrum, update, and visual specs.
- Added stronger assertions for request payloads, route endpoints, ARIA/dialog state, live-update stability, readiness states, activation flows, history downloads, update/flash status variants, and visual preconditions.

## Why
The listed tests were too smoke-level. They now prove the specific UI behavior under review and reuse common setup instead of repeating fixture payloads.

## Validation
- make plan-validation
- make ui-typecheck
- cd apps/ui && npm run typecheck:tests
- cd apps/ui && npm run test:unit
- cd apps/ui && npm run build
- cd apps/ui && npx playwright test --config=playwright.regression.config.ts --project=laptop-light --list tests/regression.analysis-sensors.spec.ts tests/regression.bootstrap.spec.ts tests/regression.car-wizard.spec.ts tests/regression.cars.spec.ts tests/regression.esp-flash.spec.ts tests/regression.history-layout.spec.ts tests/regression.history.spec.ts tests/regression.realtime-logging-summary.spec.ts tests/regression.spectrum.spec.ts tests/regression.update.spec.ts
- cd apps/ui && npx playwright test --list tests/visual.spec.ts

Targeted Playwright execution cannot run in this container because local Chromium is missing libglib-2.0.so.0 and sudo dependency install is unavailable. CI should run the browser suite.

## Risks / tradeoffs
- Test-only change.
- Tighter assertions may fail on intentional UI copy/contract changes, which is the goal.
- No production code changed.