### PR TITLE
Improve domain boundary contract tests

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -103,14 +103,41 @@ def test_v2_structured_roundtrip(tmp_path: Path) -> None:
 def test_v2_nan_inf_sanitized(tmp_path: Path) -> None:
     db = create_history_persistence_adapters(tmp_path / "history.db")
     db.run_repository.create_run("run-nan", "2026-01-01T00:00:00Z", _metadata("run-nan"))
-    sample = {"speed_kmh": float("nan"), "accel_x_g": float("inf"), "t_s": 1.0}
+    sample = {
+        "speed_kmh": float("nan"),
+        "gps_speed_kmh": float("-inf"),
+        "engine_rpm": float("inf"),
+        "accel_x_g": float("inf"),
+        "vibration_strength_db": float("nan"),
+        "strength_peak_amp_g": float("inf"),
+        "t_s": 1.0,
+        "client_id": "nan-client",
+        "strength_bucket": "l2",
+    }
     db.run_repository.append_samples("run-nan", [sensor_frame_from_mapping(sample)])
+
+    stored = fetch_one(
+        db.lifecycle,
+        """
+        SELECT speed_kmh, gps_speed_kmh, engine_rpm, accel_x_g,
+               vibration_strength_db, strength_peak_amp_g, t_s, client_id, strength_bucket
+        FROM samples_v2 WHERE run_id = ?
+        """,
+        ("run-nan",),
+    )
+    assert stored == (None, None, None, None, None, None, 1.0, "nan-client", "l2")
 
     rows = db.run_repository.get_run_samples("run-nan")
     assert len(rows) == 1
     assert rows[0].speed_kmh is None
+    assert rows[0].gps_speed_kmh is None
+    assert rows[0].engine_rpm is None
     assert rows[0].accel_x_g is None
+    assert rows[0].vibration_strength_db is None
+    assert rows[0].strength_peak_amp_g is None
     assert rows[0].t_s == 1.0
+    assert rows[0].client_id == "nan-client"
+    assert rows[0].strength_bucket == "l2"
 
 
 def test_v2_no_json_blobs_in_storage(tmp_path: Path) -> None:

--- a/apps/server/tests/domain/test_car_domain.py
+++ b/apps/server/tests/domain/test_car_domain.py
@@ -323,9 +323,11 @@ class TestCarOrderReferenceSpec:
 
 
 def test_car_snapshot_aspects_mapping_is_immutable() -> None:
-    snap = CarSnapshot(aspects={"a": 1.0})
-    try:
+    source_aspects = {"a": 1.0}
+    snap = CarSnapshot(aspects=source_aspects)
+
+    source_aspects["a"] = 9.0
+    assert dict(snap.aspects) == {"a": 1.0}
+
+    with pytest.raises(TypeError):
         snap.aspects["b"] = 2.0
-        raise AssertionError("Should not allow mutation")  # noqa: TRY301
-    except TypeError:
-        pass  # MappingProxyType raises TypeError on mutation

--- a/apps/server/tests/hygiene/test_analysis_settings_sync.py
+++ b/apps/server/tests/hygiene/test_analysis_settings_sync.py
@@ -65,15 +65,18 @@ def _parse_ui_setting_keys() -> list[str]:
 
 
 def test_ui_defaults_match_backend() -> None:
-    """Every backend DEFAULTS key must appear in UI vehicle defaults with the same value."""
+    """Generated UI vehicle defaults must be a value-for-value backend projection."""
     backend = AnalysisSettingsSnapshot.DEFAULTS
     frontend = _parse_ui_vehicle_defaults()
 
-    missing = set(backend) - set(frontend)
-    assert not missing, f"UI vehicle defaults are missing keys: {sorted(missing)}"
+    assert set(frontend) == set(backend), (
+        "UI vehicle defaults key set drifted from backend DEFAULTS: "
+        f"missing={sorted(set(backend) - set(frontend))}, "
+        f"extra={sorted(set(frontend) - set(backend))}"
+    )
 
     mismatched: list[str] = []
-    for key, be_val in backend.items():
+    for key, be_val in sorted(backend.items()):
         fe_val = frontend[key]
         if abs(fe_val - be_val) > 1e-9:
             mismatched.append(f"  {key}: UI={fe_val}, backend={be_val}")
@@ -83,12 +86,14 @@ def test_ui_defaults_match_backend() -> None:
 
 
 def test_ui_setting_keys_match_backend() -> None:
-    """UI vehicle-setting key unions must list every backend DEFAULTS key."""
-    backend_keys = set(AnalysisSettingsSnapshot.DEFAULTS)
-    frontend_keys = set(_parse_ui_setting_keys())
+    """UI vehicle-setting key unions must list each backend DEFAULTS key exactly once."""
+    backend_keys = tuple(AnalysisSettingsSnapshot.DEFAULTS)
+    frontend_keys = _parse_ui_setting_keys()
 
-    missing = backend_keys - frontend_keys
-    assert not missing, f"UI vehicle-setting keys missing: {sorted(missing)}"
-
-    extra = frontend_keys - backend_keys
-    assert not extra, f"UI vehicle-setting keys have extra entries: {sorted(extra)}"
+    duplicates = sorted({key for key in frontend_keys if frontend_keys.count(key) > 1})
+    assert not duplicates, f"UI vehicle-setting keys are duplicated: {duplicates}"
+    assert set(frontend_keys) == set(backend_keys), (
+        "UI vehicle-setting keys drifted from backend DEFAULTS: "
+        f"missing={sorted(set(backend_keys) - set(frontend_keys))}, "
+        f"extra={sorted(set(frontend_keys) - set(backend_keys))}"
+    )

--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -26,16 +26,23 @@ def test_http_history_reexports_shared_typed_dict_contracts() -> None:
     """HTTP history aliases must point at shared owners, not duplicate them."""
 
     assert history_models.__all__
+    assert len(history_models.__all__) == len(set(history_models.__all__))
     for name in history_models.__all__:
         api_contract = getattr(history_models, name)
-        shared_contracts = {
-            contract
+        shared_contracts = [
+            (module.__name__, contract)
             for module in _SHARED_CONTRACT_MODULES
             if (contract := _exported_contract(module, name)) is not None
-        }
+        ]
 
         assert is_typeddict(api_contract), f"{name} should be a TypedDict contract"
-        assert shared_contracts == {api_contract}, (
-            f"{name} should be re-exported from a shared contract owner instead of "
-            "duplicated in adapters.http.models.history"
+        shared_contract_objects = {contract for _, contract in shared_contracts}
+        assert shared_contract_objects == {api_contract}, (
+            f"{name} should resolve to the same shared contract object, found owners "
+            f"{[module_name for module_name, _ in shared_contracts]}"
+        )
+        assert shared_contracts, f"{name} should have at least one shared owner"
+        assert all(shared_contract is api_contract for _, shared_contract in shared_contracts), (
+            f"{name} should be re-exported from shared owners instead of duplicated in "
+            "adapters.http.models.history"
         )

--- a/apps/server/tests/hygiene/test_domain_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_domain_boundary_parity.py
@@ -122,10 +122,17 @@ def test_finding_payload_round_trips_domain_summary_boundary() -> None:
     decoded = finding_from_payload(payload)
 
     assert payload["finding_id"] == finding.finding_id
+    assert payload["suspected_source"] == "wheel/tire"
+    assert "source" not in payload
     assert payload["evidence_metrics"]["vibration_strength_db"] == 16.4
+    assert payload["evidence_metrics"]["matched_samples"] == 22
     assert payload["location_hotspot"]["ambiguous_locations"] == ["front_right_wheel"]
+    assert payload["location_hotspot"]["location_count"] == 4
     assert payload["matched_points"][0]["matched_hz"] == 43.5
+    assert payload["matched_points"][0]["phase"] == "cruise"
     assert payload["phase_evidence"]["phases_detected"] == ["acceleration", "cruise"]
+    assert payload["confidence_label_key"] == "CONFIDENCE_HIGH"
+    assert payload["signatures_observed"] == ["wheel order"]
     assert decoded == finding
 
 
@@ -158,3 +165,4 @@ def test_run_suitability_payload_round_trips_domain_boundary() -> None:
         }
     ]
     assert decoded == suitability
+    assert decoded.checks[0].details == (("sat_count", 3),)

--- a/apps/server/tests/hygiene/test_domain_exceptions.py
+++ b/apps/server/tests/hygiene/test_domain_exceptions.py
@@ -16,7 +16,7 @@ from vibesensor.shared.exceptions import (
     VibeSensorError,
 )
 
-_ALL_DOMAIN_EXCEPTIONS = (
+_DIRECT_DOMAIN_EXCEPTIONS = (
     ConfigurationError,
     DataCorruptError,
     PersistenceError,
@@ -28,45 +28,63 @@ _ALL_DOMAIN_EXCEPTIONS = (
 )
 
 
+def _all_domain_exception_classes() -> tuple[type[VibeSensorError], ...]:
+    classes: list[type[VibeSensorError]] = []
+
+    def collect(cls: type[VibeSensorError]) -> None:
+        for subclass in sorted(cls.__subclasses__(), key=lambda item: item.__name__):
+            classes.append(subclass)
+            collect(subclass)
+
+    collect(VibeSensorError)
+    return tuple(classes)
+
+
+_ALL_DOMAIN_EXCEPTIONS = _all_domain_exception_classes()
+
+
 def test_base_exception_is_exception() -> None:
     assert issubclass(VibeSensorError, Exception)
-
-
-@pytest.mark.parametrize("exc_cls", _ALL_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
-def test_domain_errors_catchable_by_base(exc_cls: type[VibeSensorError]) -> None:
-    """All domain exceptions should be catchable with VibeSensorError."""
-    try:
-        raise exc_cls("test")
-    except VibeSensorError:
-        pass  # expected
-    else:
-        raise AssertionError(f"{exc_cls.__name__} not catchable as VibeSensorError")
-
-
-@pytest.mark.parametrize("exc_cls", _ALL_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
-def test_all_domain_exceptions_single_base(exc_cls: type[VibeSensorError]) -> None:
-    """Every domain exception inherits exclusively from VibeSensorError."""
     assert VibeSensorError.__bases__ == (Exception,)
+
+
+@pytest.mark.parametrize("exc_cls", _DIRECT_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_domain_errors_catchable_by_base_preserve_message(
+    exc_cls: type[VibeSensorError],
+) -> None:
+    """Every top-level domain exception is catchable through VibeSensorError."""
+    with pytest.raises(VibeSensorError, match=f"{exc_cls.__name__} message"):
+        raise exc_cls(f"{exc_cls.__name__} message")
+
+
+@pytest.mark.parametrize("exc_cls", _DIRECT_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_all_domain_exceptions_single_base(exc_cls: type[VibeSensorError]) -> None:
+    """Top-level domain exceptions inherit directly from VibeSensorError."""
     assert exc_cls.__bases__ == (VibeSensorError,), (
         f"{exc_cls.__name__}.__bases__ = {exc_cls.__bases__}, expected (VibeSensorError,)"
     )
 
 
 @pytest.mark.parametrize("exc_cls", _ALL_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
-def test_no_stdlib_exception_inheritance(exc_cls: type[VibeSensorError]) -> None:
-    """No domain exception is a subclass of ValueError, RuntimeError, or LookupError."""
-    stdlib_bases = (ValueError, RuntimeError, LookupError)
-    for stdlib in stdlib_bases:
-        assert not issubclass(exc_cls, stdlib), (
-            f"{exc_cls.__name__} should not be a subclass of {stdlib.__name__}"
-        )
+def test_domain_exception_hierarchy_has_no_stdlib_compat_bases(
+    exc_cls: type[VibeSensorError],
+) -> None:
+    """Concrete exceptions may specialize another domain error, but no stdlib class."""
+    assert len(exc_cls.__bases__) == 1
+    assert issubclass(exc_cls.__bases__[0], VibeSensorError)
+
+    stdlib_mro_entries = [
+        cls.__name__
+        for cls in exc_cls.__mro__[1:]
+        if cls not in (VibeSensorError, Exception, BaseException, object)
+        and cls.__module__ == "builtins"
+    ]
+    assert not stdlib_mro_entries, (
+        f"{exc_cls.__name__} should not inherit from stdlib exception bases: {stdlib_mro_entries}"
+    )
 
 
-def test_configuration_error_caught_by_vibesensor_error() -> None:
-    """ConfigurationError is catchable via except VibeSensorError."""
-    with_catch = False
-    try:
-        raise ConfigurationError("bad")
-    except VibeSensorError:
-        with_catch = True
-    assert with_catch
+def test_configuration_error_is_in_recursive_exception_inventory() -> None:
+    assert ConfigurationError in _ALL_DOMAIN_EXCEPTIONS
+    with pytest.raises(VibeSensorError, match="bad config"):
+        raise ConfigurationError("bad config")

--- a/apps/server/tests/hygiene/test_domain_migration_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_migration_guardrails.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
 
-def test_f_order_finding_id_normalization() -> None:
+from vibesensor.domain import Finding
+from vibesensor.use_cases.diagnostics.findings import finalize_findings
+
+
+def test_f_order_finding_id_normalization_preserves_order_and_reference_ids() -> None:
     """``finalize_findings`` normalises arbitrary IDs to sequential ``F###``.
 
     ``F_ORDER`` is an internal working ID from order analysis.
@@ -12,29 +17,34 @@ def test_f_order_finding_id_normalization() -> None:
     consumers see deterministic identifiers.  The normalization to
     ``F001`` is correct behavior, not a test bug.
     """
-    from vibesensor.domain import Finding
-    from vibesensor.use_cases.diagnostics.findings import finalize_findings
 
     domain_findings = finalize_findings(
         [
-            Finding(finding_id="F_ORDER", confidence=0.7, suspected_source="wheel/tire"),
-            Finding(finding_id="F_PERSISTENT", confidence=0.4, suspected_source="engine"),
+            Finding(
+                finding_id="F_ORDER",
+                confidence=0.7,
+                ranking_score=0.3,
+                suspected_source="wheel/tire",
+            ),
+            Finding(
+                finding_id="F_PERSISTENT",
+                confidence=0.4,
+                ranking_score=0.9,
+                suspected_source="engine",
+            ),
         ]
     )
-    # Both get sequential F### IDs regardless of their input names
-    assert domain_findings[0].finding_id == "F001"
-    assert domain_findings[1].finding_id == "F002"
-    assert all(isinstance(f, Finding) for f in domain_findings)
+    assert [finding.finding_id for finding in domain_findings] == ["F001", "F002"]
+    assert [finding.suspected_source for finding in domain_findings] == ["wheel/tire", "engine"]
 
     # Reference findings keep their original IDs
     domain_ref = finalize_findings(
         [
-            Finding(finding_id="REF_SPEED", confidence=None, suspected_source="unknown"),
-            Finding(finding_id="F_ORDER", confidence=0.7, suspected_source="wheel/tire"),
+            Finding(finding_id="REF_SPEED", confidence=None, ranking_score=0.1),
+            Finding(finding_id="F_ORDER", confidence=0.7, ranking_score=0.2),
         ]
     )
-    assert domain_ref[0].finding_id == "REF_SPEED"
-    assert domain_ref[1].finding_id == "F001"
+    assert [finding.finding_id for finding in domain_ref] == ["REF_SPEED", "F001"]
 
 
 def test_no_compat_dual_base_exceptions() -> None:
@@ -88,3 +98,17 @@ def test_no_compat_dual_base_exceptions() -> None:
         "Custom exceptions must inherit exclusively from VibeSensorError, "
         f"not from stdlib exception types: {violations}"
     )
+
+
+@pytest.mark.parametrize(
+    "legacy_id",
+    [
+        pytest.param("F_ORDER", id="order"),
+        pytest.param("F_PERSISTENT", id="persistent"),
+        pytest.param("CUSTOM_FINDING", id="custom"),
+    ],
+)
+def test_non_reference_finding_ids_get_stable_sequential_ids(legacy_id: str) -> None:
+    domain_findings = finalize_findings([Finding(finding_id=legacy_id, confidence=0.7)])
+
+    assert [finding.finding_id for finding in domain_findings] == ["F001"]

--- a/apps/server/tests/hygiene/test_domain_new_types.py
+++ b/apps/server/tests/hygiene/test_domain_new_types.py
@@ -25,32 +25,76 @@ from vibesensor.shared.boundaries.summary_fields.order_match import (
 
 
 class TestOrderMatchObservation:
-    def test_is_close_match(self) -> None:
-        close = OrderMatchObservation(
-            predicted_hz=100.0, matched_hz=104.0, rel_error=0.04, amp=1.0, location="x"
-        )
-        assert close.is_close_match
-        far = OrderMatchObservation(
-            predicted_hz=100.0, matched_hz=110.0, rel_error=0.10, amp=1.0, location="x"
-        )
-        assert not far.is_close_match
-
-    def test_frequency_error_hz(self) -> None:
+    @pytest.mark.parametrize(
+        ("rel_error", "expected"),
+        [
+            pytest.param(0.0, True, id="exact"),
+            pytest.param(0.05, True, id="threshold-inclusive"),
+            pytest.param(0.0501, False, id="above-threshold"),
+        ],
+    )
+    def test_is_close_match_uses_inclusive_five_percent_threshold(
+        self,
+        rel_error: float,
+        expected: bool,
+    ) -> None:
         obs = OrderMatchObservation(
-            predicted_hz=100.0, matched_hz=105.0, rel_error=0.05, amp=1.0, location="x"
+            predicted_hz=100.0,
+            matched_hz=100.0 * (1.0 + rel_error),
+            rel_error=rel_error,
+            amp=1.0,
+            location="front_left",
         )
-        assert obs.frequency_error_hz == 5.0
 
-    def test_invalid_predicted_hz_rejected(self) -> None:
-        with pytest.raises(ValueError, match="predicted_hz"):
-            OrderMatchObservation(
-                predicted_hz=0.0, matched_hz=100.0, rel_error=0.0, amp=1.0, location="x"
-            )
+        assert obs.is_close_match is expected
 
-    def test_negative_rel_error_rejected(self) -> None:
-        with pytest.raises(ValueError, match="rel_error"):
+    @pytest.mark.parametrize(
+        ("matched_hz", "expected_error"),
+        [
+            pytest.param(105.0, 5.0, id="above-predicted"),
+            pytest.param(95.0, 5.0, id="below-predicted"),
+        ],
+    )
+    def test_frequency_error_hz_is_absolute(
+        self,
+        matched_hz: float,
+        expected_error: float,
+    ) -> None:
+        obs = OrderMatchObservation(
+            predicted_hz=100.0,
+            matched_hz=matched_hz,
+            rel_error=0.05,
+            amp=1.0,
+            location="front_left",
+        )
+        assert obs.frequency_error_hz == expected_error
+
+    @pytest.mark.parametrize(
+        ("overrides", "message"),
+        [
+            pytest.param({"predicted_hz": 0.0}, "predicted_hz", id="zero-predicted"),
+            pytest.param({"rel_error": -0.1}, "rel_error", id="negative-rel-error"),
+        ],
+    )
+    def test_invalid_frequency_contract_rejected(
+        self,
+        overrides: dict[str, float],
+        message: str,
+    ) -> None:
+        payload = {
+            "predicted_hz": 100.0,
+            "matched_hz": 100.0,
+            "rel_error": 0.0,
+            "amp": 1.0,
+        }
+        payload.update(overrides)
+        with pytest.raises(ValueError, match=message):
             OrderMatchObservation(
-                predicted_hz=100.0, matched_hz=100.0, rel_error=-0.1, amp=1.0, location="x"
+                predicted_hz=payload["predicted_hz"],
+                matched_hz=payload["matched_hz"],
+                rel_error=payload["rel_error"],
+                amp=payload["amp"],
+                location="front_left",
             )
 
     def test_boundary_codec_from_mapping(self) -> None:
@@ -65,9 +109,16 @@ class TestOrderMatchObservation:
             "phase": "cruise",
         }
         obs = order_match_observation_from_mapping(raw)
-        assert obs.predicted_hz == 100.0
-        assert obs.phase == "cruise"
-        assert obs.t_s == 1.5
+        assert obs == OrderMatchObservation(
+            predicted_hz=100.0,
+            matched_hz=102.0,
+            rel_error=0.02,
+            amp=0.5,
+            location="front_left",
+            t_s=1.5,
+            speed_kmh=60.0,
+            phase="cruise",
+        )
 
     def test_boundary_codec_missing_optional_keys(self) -> None:
         raw = {
@@ -89,13 +140,35 @@ class TestOrderMatchObservation:
 
 
 class TestDrivingPhaseInterval:
-    def test_duration_s(self) -> None:
-        interval = DrivingPhaseInterval(phase=DrivingPhase.CRUISE, start_t_s=10.0, end_t_s=20.0)
-        assert interval.duration_s == 10.0
+    @pytest.mark.parametrize(
+        ("start_t_s", "end_t_s", "expected_duration"),
+        [
+            pytest.param(10.0, 20.0, 10.0, id="bounded"),
+            pytest.param(10.0, 10.0, 0.0, id="zero-length"),
+            pytest.param(None, 20.0, None, id="missing-start"),
+            pytest.param(10.0, None, None, id="missing-end"),
+        ],
+    )
+    def test_duration_s(
+        self,
+        start_t_s: float | None,
+        end_t_s: float | None,
+        expected_duration: float | None,
+    ) -> None:
+        interval = DrivingPhaseInterval(
+            phase=DrivingPhase.CRUISE,
+            start_t_s=start_t_s,
+            end_t_s=end_t_s,
+            speed_min_kmh=70.0,
+            speed_max_kmh=75.0,
+            has_fault_evidence=True,
+        )
 
-    def test_duration_s_none(self) -> None:
-        interval = DrivingPhaseInterval(phase=DrivingPhase.CRUISE)
-        assert interval.duration_s is None
+        assert interval.duration_s == expected_duration
+        assert interval.phase is DrivingPhase.CRUISE
+        assert interval.speed_min_kmh == 70.0
+        assert interval.speed_max_kmh == 75.0
+        assert interval.has_fault_evidence is True
 
     def test_temporal_ordering_invariant(self) -> None:
         with pytest.raises(ValueError, match="start_t_s"):
@@ -108,25 +181,56 @@ class TestDrivingPhaseInterval:
 
 
 class TestLocationIntensitySummary:
-    def test_diagnostic_sample_count_uses_usable_count(self) -> None:
+    def test_diagnostic_fields_prefer_usable_sample_metrics(self) -> None:
         summary = LocationIntensitySummary(
             location="front_left",
             sample_count=100,
+            sample_coverage_ratio=0.9,
+            sample_coverage_warning=False,
             usable_sample_count=80,
+            usable_sample_coverage_ratio=0.75,
+            usable_sample_coverage_warning=True,
         )
         assert summary.diagnostic_sample_count == 80
+        assert summary.diagnostic_sample_coverage_ratio == 0.75
+        assert summary.diagnostic_sample_coverage_warning is True
 
-    def test_negative_sample_count_rejected(self) -> None:
-        with pytest.raises(ValueError, match="sample_count"):
-            LocationIntensitySummary(location="x", sample_count=-1)
+    def test_diagnostic_fields_fall_back_to_raw_sample_metrics(self) -> None:
+        summary = LocationIntensitySummary(
+            location="front_left",
+            sample_count=100,
+            sample_coverage_ratio=0.9,
+            sample_coverage_warning=True,
+        )
 
-    def test_invalid_coverage_ratio_rejected(self) -> None:
-        with pytest.raises(ValueError, match="sample_coverage_ratio"):
-            LocationIntensitySummary(location="x", sample_coverage_ratio=1.5)
+        assert summary.diagnostic_sample_count == 100
+        assert summary.diagnostic_sample_coverage_ratio == 0.9
+        assert summary.diagnostic_sample_coverage_warning is True
 
-    def test_invalid_usable_coverage_ratio_rejected(self) -> None:
-        with pytest.raises(ValueError, match="usable_sample_coverage_ratio"):
-            LocationIntensitySummary(location="x", usable_sample_coverage_ratio=1.5)
+    @pytest.mark.parametrize(
+        ("overrides", "message"),
+        [
+            pytest.param({"sample_count": -1}, "sample_count", id="negative-samples"),
+            pytest.param({"usable_sample_count": -1}, "usable_sample_count", id="negative-usable"),
+            pytest.param(
+                {"sample_coverage_ratio": 1.5},
+                "sample_coverage_ratio",
+                id="sample-coverage-high",
+            ),
+            pytest.param(
+                {"usable_sample_coverage_ratio": -0.1},
+                "usable_sample_coverage_ratio",
+                id="usable-coverage-low",
+            ),
+        ],
+    )
+    def test_invalid_sample_contract_rejected(
+        self,
+        overrides: dict[str, int | float],
+        message: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            LocationIntensitySummary(location="front_left", **overrides)
 
     def test_boundary_codec_from_mapping(self) -> None:
         raw = {
@@ -135,6 +239,9 @@ class TestLocationIntensitySummary:
             "samples": 50,
             "sample_coverage_ratio": 0.8,
             "sample_coverage_warning": False,
+            "usable_sample_count": 42,
+            "usable_sample_coverage_ratio": 0.7,
+            "usable_sample_coverage_warning": True,
             "mean_intensity_db": 10.0,
             "p50_intensity_db": 9.0,
             "p95_intensity_db": 15.0,
@@ -158,8 +265,16 @@ class TestLocationIntensitySummary:
         assert summary.location == "rear_axle"
         assert summary.partial_coverage is True
         assert summary.sample_count == 50  # from "samples" key
+        assert summary.usable_sample_count == 42
+        assert summary.diagnostic_sample_count == 42
+        assert summary.diagnostic_sample_coverage_ratio == 0.7
+        assert summary.diagnostic_sample_coverage_warning is True
         assert summary.p95_intensity_db == 15.0
-        assert summary.strength_bucket_distribution.total == 5
+        assert summary.strength_bucket_distribution == StrengthBucketDistribution(
+            total=5,
+            counts={"l0": 5},
+            percent_time_l0=100.0,
+        )
         assert summary.phase_intensity == {
             "cruise": PhaseIntensitySummary(
                 count=2,
@@ -176,3 +291,4 @@ class TestLocationIntensitySummary:
     def test_default_strength_bucket_distribution(self) -> None:
         summary = LocationIntensitySummary(location="x")
         assert summary.strength_bucket_distribution == StrengthBucketDistribution()
+        assert summary.phase_intensity is None

--- a/apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py
+++ b/apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py
@@ -83,14 +83,17 @@ class TestRemovedSignalFallbacks:
 class TestRemovedHotspotAliases:
     """Canonical hotspot decoding ignores removed alias keys."""
 
-    def test_location_hotspot_ignores_second_location_and_old_location_aliases(self) -> None:
+    def test_location_hotspot_uses_only_canonical_location_keys(self) -> None:
         payload: dict[str, object] = {
             "finding_id": "F-hotspot",
             "severity": "diagnostic",
             "suspected_source": "wheel/tire",
             "location_hotspot": {
-                "location": "front-left",
+                "top_location": "front-left",
+                "ambiguous_locations": ["rear-left"],
+                "location_count": 4,
                 "second_location": "front-right",
+                "location": "wrong-location",
                 "ambiguous_location": True,
             },
         }
@@ -98,5 +101,7 @@ class TestRemovedHotspotAliases:
         finding = finding_from_payload(payload)
 
         assert finding.location is not None
-        assert finding.location.strongest_location == ""
-        assert finding.location.alternative_locations == ()
+        assert finding.location.strongest_location == "front-left"
+        assert finding.location.alternative_locations == ("rear-left",)
+        assert finding.location.location_count == 4
+        assert finding.location.ambiguous is True


### PR DESCRIPTION
Closes #3964

## What changed
- Tightened structured history storage sanitization coverage for non-finite sample values.
- Improved CarSnapshot immutability, UI/backend settings parity, HTTP history contract re-export, domain boundary codec, exception hierarchy, finding ID normalization, domain value object, and legacy alias tests.
- Merged duplicate one-off checks into parameterized contract tests where useful.

## Why
The listed tests were too narrow or smoke-level. They now prove the actual contracts: copied immutable mappings, exact backend/UI key parity, shared TypedDict ownership, canonical payload fields, recursive exception hierarchy rules, stable finding IDs, typed value object invariants, and canonical hotspot alias behavior.

## Validation
- ./.venv/bin/python -m pytest -q apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py apps/server/tests/domain/test_car_domain.py apps/server/tests/hygiene/test_analysis_settings_sync.py apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/hygiene/test_domain_boundary_parity.py apps/server/tests/hygiene/test_domain_exceptions.py apps/server/tests/hygiene/test_domain_migration_guardrails.py apps/server/tests/hygiene/test_domain_new_types.py apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py
- make plan-validation
- make lint
- make typecheck-backend

## Risks / tradeoffs
- Test-only change.
- Tighter hygiene assertions may flag future contract drift earlier.
- No production code changed.