### PR TITLE
Improve domain reporting guardrail tests

### DIFF
--- a/apps/server/tests/hygiene/test_domain_finding_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_finding_guardrails.py
@@ -1,83 +1,98 @@
 """Guardrails for Finding domain behavior and confidence ownership."""
 
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import ConfidenceAssessment, Finding, RunCapture, TestRun
+from vibesensor.use_cases.diagnostics.findings import finalize_findings
+from vibesensor.use_cases.diagnostics.top_cause_selection import select_top_causes
+
 
 def test_finalize_findings_returns_domain_findings() -> None:
     """``finalize_findings`` must return domain ``Finding`` objects."""
-    from vibesensor.domain import Finding
-    from vibesensor.use_cases.diagnostics.findings import finalize_findings
-
     domain_findings = finalize_findings(
         [
+            Finding(finding_id="F_LOW", confidence=0.2, suspected_source="engine"),
             Finding(finding_id="F_ORDER", confidence=0.7, suspected_source="wheel/tire"),
         ]
     )
-    assert len(domain_findings) == 1
-    assert isinstance(domain_findings[0], Finding)
-    assert domain_findings[0].finding_id == "F001"
+    assert all(isinstance(finding, Finding) for finding in domain_findings)
+    assert [finding.finding_id for finding in domain_findings] == ["F001", "F002"]
+    assert [finding.suspected_source for finding in domain_findings] == [
+        "wheel/tire",
+        "engine",
+    ]
 
 
 def test_select_top_causes_returns_domain_findings() -> None:
     """``select_top_causes`` must return domain ``Finding`` objects."""
-    from test_support.findings import make_finding_payload
-
-    from vibesensor.domain import Finding
-    from vibesensor.shared.boundaries.summary_fields.finding import finding_from_payload
-    from vibesensor.use_cases.diagnostics.top_cause_selection import select_top_causes
-
-    findings = tuple(
-        finding_from_payload(f)
-        for f in [make_finding_payload(confidence=0.80, suspected_source="wheel/tire")]
+    strong = Finding(
+        finding_id="F001",
+        confidence=0.80,
+        suspected_source="wheel/tire",
+        vibration_strength_db=12.0,
     )
-    domain_findings = select_top_causes(findings)
-    assert len(domain_findings) == 1
-    assert isinstance(domain_findings[0], Finding)
+    weak = Finding(
+        finding_id="F002",
+        confidence=0.30,
+        suspected_source="engine",
+        vibration_strength_db=4.0,
+    )
+    findings = (weak, strong)
+    domain_findings = select_top_causes(findings, drop_off_points=100.0)
+    assert domain_findings == (strong, weak)
+    assert all(isinstance(finding, Finding) for finding in domain_findings)
 
 
-def test_finding_owns_confidence_label() -> None:
+@pytest.mark.parametrize(
+    ("confidence", "expected_label", "expected_tone", "expected_pct"),
+    [
+        pytest.param(0.80, "CONFIDENCE_HIGH", "success", "80%", id="high"),
+        pytest.param(0.55, "CONFIDENCE_MEDIUM", "warn", "55%", id="medium"),
+        pytest.param(0.20, "CONFIDENCE_LOW", "neutral", "20%", id="low"),
+    ],
+)
+def test_finding_owns_confidence_label(
+    confidence: float,
+    expected_label: str,
+    expected_tone: str,
+    expected_pct: str,
+) -> None:
     """Finding must own confidence-tier classification (label, tone, pct)."""
-    from vibesensor.domain import Finding
+    finding = Finding(finding_id="F001", confidence=confidence, suspected_source="wheel/tire")
 
-    high = Finding(finding_id="F001", confidence=0.80, suspected_source="wheel/tire")
-    label_key, tone, pct_text = high.confidence_label()
-    assert label_key == "CONFIDENCE_HIGH"
-    assert tone == "success"
-    assert pct_text == "80%"
-
-    medium = Finding(finding_id="F002", confidence=0.55, suspected_source="engine")
-    label_key, tone, _ = medium.confidence_label()
-    assert label_key == "CONFIDENCE_MEDIUM"
-    assert tone == "warn"
-
-    low = Finding(finding_id="F003", confidence=0.20, suspected_source="unknown")
-    label_key, tone, _ = low.confidence_label()
-    assert label_key == "CONFIDENCE_LOW"
-    assert tone == "neutral"
+    assert finding.confidence_label() == (expected_label, expected_tone, expected_pct)
 
 
 def test_finding_confidence_negligible_strength_downgrade() -> None:
     """Finding with negligible strength should downgrade HIGH → MEDIUM."""
-    from vibesensor.domain import Finding
-
     high = Finding(finding_id="F001", confidence=0.80, suspected_source="wheel/tire")
     label_key, tone, _ = high.confidence_label(strength_band_key="negligible")
     assert label_key == "CONFIDENCE_MEDIUM"
     assert tone == "warn"
+    assert ConfidenceAssessment.assess(0.80, strength_band_key="negligible").downgraded is True
 
 
-def test_classify_confidence_is_domain_owned() -> None:
+@pytest.mark.parametrize(
+    ("confidence", "expected"),
+    [
+        pytest.param(0.80, ("CONFIDENCE_HIGH", "success", "80%"), id="high"),
+        pytest.param(0.55, ("CONFIDENCE_MEDIUM", "warn", "55%"), id="medium"),
+        pytest.param(0.20, ("CONFIDENCE_LOW", "neutral", "20%"), id="low"),
+        pytest.param(float("nan"), ("CONFIDENCE_LOW", "neutral", "0%"), id="nan"),
+    ],
+)
+def test_classify_confidence_is_domain_owned(
+    confidence: float,
+    expected: tuple[str, str, str],
+) -> None:
     """Finding.classify_confidence is the canonical source of truth for confidence presentation."""
-    from vibesensor.domain import Finding
-
-    for conf in (0.80, 0.55, 0.20, 0.0):
-        result = Finding.classify_confidence(conf)
-        assert len(result) == 3
-        assert all(isinstance(v, str) for v in result)
+    assert Finding.classify_confidence(confidence) == expected
 
 
 def test_confidence_assessment_tier_matches_domain_finding() -> None:
     """ConfidenceAssessment.tier must be consistent with Finding.classify_confidence."""
-    from vibesensor.domain import ConfidenceAssessment, Finding
-
     for conf in [0.1, 0.3, 0.5, 0.7, 0.9]:
         label_key, _tone, _pct = Finding.classify_confidence(conf)
         ca = ConfidenceAssessment.assess(conf)
@@ -85,6 +100,8 @@ def test_confidence_assessment_tier_matches_domain_finding() -> None:
             f"ConfidenceAssessment.assess({conf}).label_key must match "
             f"Finding.classify_confidence({conf})[0]"
         )
+        assert ca.pct_text == f"{round(conf * 100):.0f}%"
+        assert ca.tier in {"A", "B", "C"}
 
 
 def test_speed_profile_used_by_confidence_assessment() -> None:
@@ -94,10 +111,23 @@ def test_speed_profile_used_by_confidence_assessment() -> None:
     is the single source of truth for confidence assessment. Report mapping
     uses ``ConfidenceAssessment.tier`` for layout gating.
     """
-    from tests._paths import SERVER_ROOT
-
-    report_presentation_path = SERVER_ROOT / "vibesensor" / "shared" / "report_presentation.py"
-    source = report_presentation_path.read_text()
-    assert "certainty_label" not in source, (
-        "certainty_label was deleted; ConfidenceAssessment.assess() is the replacement"
+    finding = Finding(finding_id="F001", confidence=0.85, suspected_source="wheel/tire")
+    run_with_gap = TestRun(
+        capture=RunCapture(run_id="guard"),
+        findings=(Finding(finding_id="REF_SPEED"), finding),
+        top_causes=(finding,),
     )
+    assessment = ConfidenceAssessment.assess(
+        finding.confidence or 0.0,
+        steady_speed=False,
+        has_reference_gaps=run_with_gap.has_relevant_reference_gap(finding.suspected_source),
+        weak_spatial=True,
+        sensor_count=1,
+    )
+
+    assert assessment.label_key == "CONFIDENCE_HIGH"
+    assert assessment.tier == "B"
+    assert assessment.is_conclusive is False
+    assert "Missing reference data" in assessment.reason
+    assert "Speed was not steady" in assessment.reason
+    assert "Single sensor" in assessment.reason

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 
-def test_prepared_report_input_has_domain_aggregate() -> None:
-    """Prepared report inputs must carry the reconstructed domain aggregate."""
-    from test_support.findings import make_finding_payload
+from test_support.findings import make_finding_payload
 
-    from vibesensor.domain import TestRun
-    from vibesensor.shared.boundaries.reporting import prepare_report_input
 
-    summary = {
-        "run_id": "test-context",
-        "findings": [make_finding_payload(finding_id="F001")],
-        "top_causes": [make_finding_payload(finding_id="F001")],
+def _report_summary(
+    *,
+    run_id: str = "guard-run",
+    finding: Mapping[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    finding_payload = dict(finding or make_finding_payload(finding_id="F001", confidence=0.80))
+    summary: dict[str, object] = {
+        "run_id": run_id,
+        "findings": [finding_payload],
+        "top_causes": [finding_payload],
         "lang": "en",
         "metadata": {},
         "report_date": "",
@@ -24,10 +28,26 @@ def test_prepared_report_input_has_domain_aggregate() -> None:
         "sensor_locations_connected_throughout": [],
         "most_likely_origin": {},
         "run_suitability": [],
+        "warnings": [],
+        "plots": {},
+        "test_plan": [],
+        "sensor_count_used": 2,
     }
+    summary.update(overrides)
+    return summary
+
+
+def test_prepared_report_input_has_domain_aggregate() -> None:
+    """Prepared report inputs must carry the reconstructed domain aggregate."""
+    from vibesensor.domain import TestRun
+    from vibesensor.shared.boundaries.reporting import prepare_report_input
+
+    summary = _report_summary(run_id="test-context")
     prepared = prepare_report_input(summary)
     assert isinstance(prepared.domain_test_run, TestRun)
     assert len(prepared.domain_test_run.findings) == 1
+    assert prepared.domain_test_run.run_id == "test-context"
+    assert prepared.report_facts.run.run_id == "test-context"
 
 
 def test_build_system_cards_uses_domain_findings() -> None:
@@ -78,42 +98,25 @@ def test_build_system_cards_uses_domain_findings() -> None:
 
 def test_build_report_document_produces_report_with_domain_findings() -> None:
     """build_report_document must produce report data using domain-first pipeline."""
-    from test_support.findings import make_finding_payload
-
     from vibesensor.shared.boundaries.reporting import prepare_report_input
     from vibesensor.use_cases.history.report_document import build_report_document
 
-    summary = {
-        "run_id": "test-map",
-        "file_name": "test.csv",
-        "rows": 100,
-        "duration_s": 60.0,
-        "lang": "en",
-        "metadata": {},
-        "report_date": "",
-        "record_length": "",
-        "start_time_utc": "",
-        "end_time_utc": "",
-        "warnings": [],
-        "sensor_locations": [],
-        "sensor_locations_connected_throughout": [],
-        "sensor_intensity_by_location": [],
-        "most_likely_origin": {},
-        "run_suitability": [],
-        "plots": {},
-        "test_plan": [],
-        "findings": [make_finding_payload(finding_id="F001", confidence=0.80)],
-        "top_causes": [make_finding_payload(finding_id="F001", confidence=0.80)],
-        "sensor_count_used": 2,
-    }
+    summary = _report_summary(
+        run_id="test-map",
+        file_name="test.csv",
+        rows=100,
+        duration_s=60.0,
+        sensor_locations=["front_left", "front_right"],
+        sensor_intensity_by_location=[],
+    )
     template = build_report_document(prepare_report_input(summary))
     assert template.run_id == "test-map"
+    assert template.sensor_count == 2
+    assert template.lang == "en"
 
 
 def test_report_mapping_business_functions_use_domain_objects() -> None:
     """Primary-candidate resolution must derive values from the domain aggregate."""
-    from test_support.findings import make_finding_payload
-
     from vibesensor.domain import VibrationSource
     from vibesensor.report_i18n import tr
     from vibesensor.shared.boundaries.reporting import prepare_report_input
@@ -125,23 +128,10 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
     finding = make_finding_payload(
         finding_id="F001",
         confidence=0.80,
-        suspected_source="wheel_tire",
+        suspected_source="wheel/tire",
+        strongest_location="front_left",
     )
-    summary = {
-        "run_id": "guard-biz",
-        "findings": [finding],
-        "top_causes": [finding],
-        "lang": lang,
-        "metadata": {},
-        "report_date": "",
-        "record_length": "",
-        "start_time_utc": "",
-        "end_time_utc": "",
-        "sensor_locations": [],
-        "sensor_locations_connected_throughout": [],
-        "most_likely_origin": {},
-        "run_suitability": [],
-    }
+    summary = _report_summary(run_id="guard-biz", finding=finding, lang=lang)
 
     prepared = prepare_report_input(summary)
     primary = resolve_primary_report_candidate(
@@ -154,34 +144,20 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
     assert isinstance(primary.primary_source, VibrationSource), (
         "primary_source must be a VibrationSource enum when domain aggregate is present"
     )
+    assert primary.primary_source is VibrationSource.WHEEL_TIRE
+    assert primary.primary_location == "front_left"
 
 
 def test_prepared_report_input_exposes_canonical_summary_boundary() -> None:
     """Prepared report inputs must expose explicit typed fields instead of raw dict state."""
-    from test_support.findings import make_finding_payload
-
     from vibesensor.shared.boundaries.reporting import prepare_report_input
 
-    prepared = prepare_report_input(
-        {
-            "run_id": "guardrails",
-            "findings": [make_finding_payload(finding_id="F001")],
-            "top_causes": [make_finding_payload(finding_id="F001")],
-            "lang": "en",
-            "metadata": {},
-            "report_date": "",
-            "record_length": "",
-            "start_time_utc": "",
-            "end_time_utc": "",
-            "sensor_locations": [],
-            "sensor_locations_connected_throughout": [],
-            "most_likely_origin": {},
-            "run_suitability": [],
-            "plots": {},
-        }
-    )
+    prepared = prepare_report_input(_report_summary(run_id="guardrails"), filename="guard.pdf")
 
+    assert prepared.filename == "guard.pdf"
+    assert prepared.language == "en"
     assert prepared.report_facts.run.run_id == "guardrails"
+    assert prepared.domain_test_run.run_id == "guardrails"
 
 
 def test_next_steps_consume_prepared_actions() -> None:

--- a/apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py
@@ -32,3 +32,10 @@ def test_boundary_decoder_builds_diagnostic_case_from_summary() -> None:
     assert diagnostic_case.case_id == "summary-case-guard-id"
     assert diagnostic_case.test_runs
     assert diagnostic_case.primary_run is not None
+    assert diagnostic_case.primary_run.run_id == "summary-case-guard"
+    assert diagnostic_case.car is not None
+    assert diagnostic_case.car.name == "Guard Car"
+    assert [finding.finding_id for finding in diagnostic_case.primary_run.findings] == ["F001"]
+    assert [
+        action.action_id for action in diagnostic_case.primary_run.test_plan.prioritized_actions
+    ] == ["check-wheel"]

--- a/apps/server/tests/hygiene/test_domain_test_run_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_test_run_guardrails.py
@@ -1,17 +1,39 @@
 """Guardrails for TestRun as the canonical post-analysis domain aggregate."""
 
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import Finding, RunCapture, TestRun, VibrationSource
 from vibesensor.shared.boundaries.analysis_payloads.reconstruction import (
     test_run_from_summary as reconstruct_test_run_from_summary,
 )
 
 
+def _finding(
+    finding_id: str,
+    *,
+    confidence: float = 0.75,
+    source: str = "wheel/tire",
+    strength_db: float | None = None,
+    severity: str = "diagnostic",
+    location: str = "",
+) -> Finding:
+    return Finding(
+        finding_id=finding_id,
+        confidence=confidence,
+        severity=severity,
+        suspected_source=source,
+        vibration_strength_db=strength_db,
+        strongest_location=location,
+    )
+
+
 def test_test_run_provides_finding_queries() -> None:
     """``TestRun`` must own finding classification queries."""
-    from vibesensor.domain import Finding, RunCapture, TestRun
-
-    diag = Finding(finding_id="F001", confidence=0.75, suspected_source="wheel/tire")
-    ref = Finding(finding_id="REF_SPEED", confidence=1.0, suspected_source="unknown")
-    info = Finding(finding_id="F002", confidence=0.10, severity="info", suspected_source="unknown")
+    diag = _finding("F001")
+    ref = _finding("REF_SPEED", confidence=1.0, source="unknown")
+    info = _finding("F002", confidence=0.10, severity="info", source="unknown")
 
     result = TestRun(
         capture=RunCapture(run_id="test-123"),
@@ -22,20 +44,28 @@ def test_test_run_provides_finding_queries() -> None:
     assert result.primary_finding == diag
     assert result.diagnostic_findings == (diag,)
     assert result.non_reference_findings == (diag, info)
+    assert result.sensor_count == 0
+    assert result.total_usable_samples == 0
 
 
 def test_test_run_effective_top_causes() -> None:
     """``effective_top_causes()`` mirrors diagnosis_candidates logic."""
-    from vibesensor.domain import Finding, RunCapture, TestRun
-
-    actionable = Finding(finding_id="F001", confidence=0.75, suspected_source="wheel/tire")
+    actionable = _finding("F001")
     result = TestRun(
         capture=RunCapture(run_id="test"),
         findings=(actionable,),
         top_causes=(actionable,),
     )
     effective = result.effective_top_causes()
-    assert actionable in effective
+    assert effective == (actionable,)
+
+    reference_only = _finding("REF_SPEED", source="unknown")
+    fallback = TestRun(
+        capture=RunCapture(run_id="test"),
+        findings=(reference_only,),
+        top_causes=(reference_only,),
+    )
+    assert fallback.effective_top_causes() == (reference_only,)
 
 
 def test_run_analysis_produces_test_run() -> None:
@@ -75,12 +105,10 @@ def test_run_analysis_produces_test_run() -> None:
 
 def test_test_run_reference_gap_detection() -> None:
     """``has_relevant_reference_gap()`` detects source-relevant gaps."""
-    from vibesensor.domain import Finding, RunCapture, TestRun, VibrationSource
-
-    ref_speed = Finding(finding_id="REF_SPEED", suspected_source="unknown")
-    ref_wheel = Finding(finding_id="REF_WHEEL", suspected_source="unknown")
-    ref_engine = Finding(finding_id="REF_ENGINE", suspected_source="unknown")
-    diag = Finding(finding_id="F001", confidence=0.80, suspected_source="wheel/tire")
+    ref_speed = _finding("REF_SPEED", source="unknown")
+    ref_wheel = _finding("REF_WHEEL", source="unknown")
+    ref_engine = _finding("REF_ENGINE", source="unknown")
+    diag = _finding("F001", confidence=0.80)
 
     assert ref_speed.is_reference
     assert ref_wheel.is_reference
@@ -110,20 +138,8 @@ def test_test_run_reference_gap_detection() -> None:
 
 def test_test_run_top_strength_db() -> None:
     """``top_strength_db()`` finds the best strength from findings."""
-    from vibesensor.domain import Finding, RunCapture, TestRun
-
-    f1 = Finding(
-        finding_id="F001",
-        confidence=0.80,
-        suspected_source="wheel/tire",
-        vibration_strength_db=12.5,
-    )
-    f2 = Finding(
-        finding_id="F002",
-        confidence=0.60,
-        suspected_source="engine",
-        vibration_strength_db=8.0,
-    )
+    f1 = _finding("F001", confidence=0.80, strength_db=12.5)
+    f2 = _finding("F002", confidence=0.60, source="engine", strength_db=8.0)
     result = TestRun(
         capture=RunCapture(run_id="test"),
         findings=(f1, f2),
@@ -132,7 +148,7 @@ def test_test_run_top_strength_db() -> None:
     assert result.top_strength_db() == 12.5
 
     # No strength → None
-    f3 = Finding(finding_id="F003", confidence=0.50, suspected_source="engine")
+    f3 = _finding("F003", confidence=0.50, source="engine")
     result2 = TestRun(
         capture=RunCapture(run_id="test"),
         findings=(f3,),
@@ -143,14 +159,7 @@ def test_test_run_top_strength_db() -> None:
 
 def test_test_run_primary_source_and_location() -> None:
     """``primary_source`` and ``primary_location`` are domain queries."""
-    from vibesensor.domain import Finding, RunCapture, TestRun, VibrationSource
-
-    f = Finding(
-        finding_id="F001",
-        confidence=0.80,
-        suspected_source="wheel/tire",
-        strongest_location="Left Front",
-    )
+    f = _finding("F001", confidence=0.80, location="Left Front")
     result = TestRun(
         capture=RunCapture(run_id="test"),
         findings=(f,),
@@ -184,6 +193,8 @@ def test_test_run_from_summary_populates_speed_profile() -> None:
     result = reconstruct_test_run_from_summary(summary)
     assert result.speed_profile is not None, "test_run_from_summary must populate speed_profile"
     assert result.speed_profile.steady_speed
+    assert result.speed_profile.min_kmh == 30.0
+    assert result.speed_profile.max_kmh == 90.0
 
 
 def test_test_run_from_summary_populates_suitability() -> None:
@@ -199,6 +210,7 @@ def test_test_run_from_summary_populates_suitability() -> None:
     result = reconstruct_test_run_from_summary(summary)
     assert result.suitability is not None, "test_run_from_summary must populate suitability"
     assert result.suitability.is_usable
+    assert result.suitability.checks[0].check_key == "speed"
 
 
 def test_run_analysis_builds_test_run_and_diagnostic_case() -> None:
@@ -241,3 +253,25 @@ def test_run_analysis_builds_test_run_and_diagnostic_case() -> None:
     assert isinstance(result.diagnostic_case, DiagnosticCase)
     assert result.diagnostic_case.primary_run is not None
     assert result.diagnostic_case.primary_run.run_id == analysis.test_run.run_id
+    assert result.diagnostic_case.car is not None
+    assert result.diagnostic_case.car.name == "Guard Car"
+
+
+@pytest.mark.parametrize(
+    ("top_causes", "message"),
+    [
+        pytest.param((), None, id="empty-top-causes"),
+        pytest.param((_finding("F999"),), "unmatched top causes", id="unmatched-top-cause"),
+    ],
+)
+def test_test_run_rejects_unmatched_top_causes(
+    top_causes: tuple[Finding, ...],
+    message: str | None,
+) -> None:
+    findings = (_finding("F001"),)
+    if message is None:
+        TestRun(capture=RunCapture(run_id="test"), findings=findings, top_causes=top_causes)
+        return
+
+    with pytest.raises(ValueError, match=message):
+        TestRun(capture=RunCapture(run_id="test"), findings=findings, top_causes=top_causes)

--- a/apps/server/tests/hygiene/test_history_db_mixins.py
+++ b/apps/server/tests/hygiene/test_history_db_mixins.py
@@ -38,11 +38,20 @@ def test_run_history_repository_mixins_expose_disjoint_public_methods() -> None:
 
     overlaps = {name: owners for name, owners in owners_by_name.items() if len(owners) > 1}
     assert overlaps == {}, f"run-history mixins must keep disjoint public APIs: {overlaps}"
+    assert {
+        "create_run",
+        "append_samples",
+        "get_run",
+        "get_run_samples",
+    } <= set().union(*(_public_method_names(mixin) for mixin in mixins))
 
 
 def test_history_persistence_factory_returns_split_adapters(tmp_path: Path) -> None:
     adapters = create_history_persistence_adapters(tmp_path / "history.db")
     try:
+        assert adapters.lifecycle is adapters.run_repository._engine
+        assert adapters.lifecycle is adapters.settings_snapshot_repository._engine
+        assert adapters.lifecycle is adapters.client_name_repository._engine
         assert isinstance(adapters.lifecycle, SQLiteHistoryEngine)
         assert isinstance(adapters.run_repository, RunHistoryRepository)
         assert isinstance(adapters.settings_snapshot_repository, SettingsSnapshotRepository)

--- a/apps/server/tests/hygiene/test_location_codes_sync.py
+++ b/apps/server/tests/hygiene/test_location_codes_sync.py
@@ -7,6 +7,8 @@ import re
 import subprocess
 import sys
 
+import pytest
+
 from tests._paths import REPO_ROOT
 from vibesensor.app.config_defaults import documented_default_config
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
@@ -44,39 +46,36 @@ def _extract_export_json(module_text: str, export_name: str) -> object:
     return json.loads(match.group("value"))
 
 
-def test_generated_ui_constants_encode_backend_locations() -> None:
-    """The shared constants generator must reflect backend location literals only."""
-    generated = _generated_constants_ts()
-    assert _extract_export_json(generated, "defaultLocationCodes") == list(LOCATION_CODES.keys())
+@pytest.fixture(scope="module")
+def generated_constants() -> str:
+    return _generated_constants_ts()
 
 
-def test_generated_ui_constants_encode_backend_analysis_defaults() -> None:
-    """Generated UI defaults must come from backend analysis-settings defaults."""
-    generated = _generated_constants_ts()
-    assert _extract_export_json(generated, "defaultAnalysisSettings") == (
-        AnalysisSettingsSnapshot.DEFAULTS
-    )
-
-
-def test_generated_ui_constants_encode_backend_live_analysis_config() -> None:
-    """Generated live-analysis constants must stay aligned with backend owners."""
-    generated = _generated_constants_ts()
+def test_generated_ui_constants_encode_backend_sources(generated_constants: str) -> None:
+    """Generated UI constants must be direct projections of backend owners."""
     config = documented_default_config()
     processing = config.get("processing")
     assert isinstance(processing, dict)
     sample_rate_hz = processing.get("sample_rate_hz")
     assert isinstance(sample_rate_hz, (int, float))
-    assert _extract_export_json(generated, "defaultLiveAnalysisConfig") == {
-        "sampleRateHz": sample_rate_hz,
-        "fftWindowSizeSamples": FFT_N,
-        "spectrumMinHz": SPECTRUM_MIN_HZ,
-        "spectrumMaxHz": SPECTRUM_MAX_HZ,
-        "peakBandwidthHz": PEAK_BANDWIDTH_HZ,
-        "peakSeparationHz": PEAK_SEPARATION_HZ,
-        "strengthAlgorithmVersion": STRENGTH_ALGORITHM_VERSION,
-        "peakDetectorVersion": PEAK_DETECTOR_VERSION,
-        "calibrationProfileId": CALIBRATION_PROFILE_ID,
+
+    expected_exports = {
+        "defaultLocationCodes": list(LOCATION_CODES.keys()),
+        "defaultAnalysisSettings": AnalysisSettingsSnapshot.DEFAULTS,
+        "defaultLiveAnalysisConfig": {
+            "sampleRateHz": sample_rate_hz,
+            "fftWindowSizeSamples": FFT_N,
+            "spectrumMinHz": SPECTRUM_MIN_HZ,
+            "spectrumMaxHz": SPECTRUM_MAX_HZ,
+            "peakBandwidthHz": PEAK_BANDWIDTH_HZ,
+            "peakSeparationHz": PEAK_SEPARATION_HZ,
+            "strengthAlgorithmVersion": STRENGTH_ALGORITHM_VERSION,
+            "peakDetectorVersion": PEAK_DETECTOR_VERSION,
+            "calibrationProfileId": CALIBRATION_PROFILE_ID,
+        },
     }
+    for export_name, expected in expected_exports.items():
+        assert _extract_export_json(generated_constants, export_name) == expected
 
 
 def test_domain_location_codes_match_shared() -> None:
@@ -84,3 +83,5 @@ def test_domain_location_codes_match_shared() -> None:
     assert DOMAIN_LOCATION_CODES == LOCATION_CODES, (
         "domain/sensor.py _LOCATION_CODES drifted from shared/locations.py LOCATION_CODES"
     )
+    assert list(DOMAIN_LOCATION_CODES) == list(LOCATION_CODES)
+    assert len(set(LOCATION_CODES)) == len(LOCATION_CODES)

--- a/apps/server/tests/hygiene/test_sample_column_alignment.py
+++ b/apps/server/tests/hygiene/test_sample_column_alignment.py
@@ -70,11 +70,20 @@ def _core_export_columns() -> set[str]:
     return set(_export_columns()) - _EXPORT_ONLY
 
 
+def _assert_same_columns(left_name: str, left: set[str], right_name: str, right: set[str]) -> None:
+    assert left == right, (
+        f"{left_name} and {right_name} sample columns drifted:\n"
+        f"  {left_name}-only: {sorted(left - right)}\n"
+        f"  {right_name}-only: {sorted(right - left)}"
+    )
+
+
 class TestSampleColumnAlignment:
     def test_insert_columns_match_ddl(self) -> None:
         ddl = _core_ddl_columns()
         insert = set(_insert_columns())
-        assert ddl == insert, f"DDL↔insert mismatch: {ddl.symmetric_difference(insert)}"
+        _assert_same_columns("DDL", ddl, "insert", insert)
+        assert _insert_columns() == [column for column in _ddl_columns() if column not in _DDL_ONLY]
 
     def test_domain_fields_cover_ddl(self) -> None:
         ddl = _core_ddl_columns()
@@ -91,6 +100,7 @@ class TestSampleColumnAlignment:
         assert not missing_from_export, (
             f"DDL columns missing from EXPORT_CSV_COLUMNS: {missing_from_export}"
         )
+        assert len(_export_columns()) == len(set(_export_columns()))
 
     def test_no_unexpected_extras_in_domain(self) -> None:
         ddl = _core_ddl_columns()
@@ -99,6 +109,7 @@ class TestSampleColumnAlignment:
         assert not unexpected, (
             f"SensorFrame has fields not in DDL (add to _DDL_ONLY or fix): {unexpected}"
         )
+        assert len(_domain_fields()) == len(set(_domain_fields()))
 
     def test_no_unexpected_extras_in_export(self) -> None:
         ddl = _core_ddl_columns()

--- a/apps/server/tests/hygiene/test_strength_peak_parity.py
+++ b/apps/server/tests/hygiene/test_strength_peak_parity.py
@@ -34,27 +34,27 @@ def _typeddict_field_names(cls: type) -> set[str]:
     return set(cls.__required_keys__ | cls.__optional_keys__)
 
 
+def _assert_parity(name: str, dataclass_type: type, typeddict_type: type) -> None:
+    dc_fields = _dataclass_field_names(dataclass_type)
+    td_fields = _typeddict_field_names(typeddict_type)
+    assert dc_fields == td_fields, (
+        f"{name} field drift!\n"
+        f"  dataclass-only: {dc_fields - td_fields}\n"
+        f"  TypedDict-only: {td_fields - dc_fields}"
+    )
+    assert typeddict_type.__required_keys__ <= dc_fields
+    assert typeddict_type.__optional_keys__ <= dc_fields
+
+
 class TestStrengthPeakFieldParity:
     """StrengthPeak TypedDict must have the same fields as the dataclass."""
 
     def test_field_names_match(self) -> None:
-        dc_fields = _dataclass_field_names(StrengthPeakDC)
-        td_fields = _typeddict_field_names(StrengthPeakTD)
-        assert dc_fields == td_fields, (
-            f"StrengthPeak field drift!\n"
-            f"  dataclass-only: {dc_fields - td_fields}\n"
-            f"  TypedDict-only: {td_fields - dc_fields}"
-        )
+        _assert_parity("StrengthPeak", StrengthPeakDC, StrengthPeakTD)
 
 
 class TestStrengthMetricsFieldParity:
     """VibrationStrengthMetrics TypedDict must have the same fields as StrengthMetrics dataclass."""
 
     def test_field_names_match(self) -> None:
-        dc_fields = _dataclass_field_names(StrengthMetricsDC)
-        td_fields = _typeddict_field_names(VibrationStrengthMetricsTD)
-        assert dc_fields == td_fields, (
-            f"StrengthMetrics field drift!\n"
-            f"  dataclass-only: {dc_fields - td_fields}\n"
-            f"  TypedDict-only: {td_fields - dc_fields}"
-        )
+        _assert_parity("StrengthMetrics", StrengthMetricsDC, VibrationStrengthMetricsTD)

--- a/apps/server/tests/hygiene/test_type_safety_consolidation.py
+++ b/apps/server/tests/hygiene/test_type_safety_consolidation.py
@@ -26,7 +26,10 @@ class TestNormalizeLangConsolidation:
             ("nl-BE", "nl"),
             ("NL-NL", "nl"),
             ("  NL ", "nl"),
+            ("nl_BE.UTF-8", "nl"),
+            ("nld", "nl"),
             ("fr", "en"),
+            ("en-US", "en"),
             (None, "en"),
             (42, "en"),
             ("", "en"),
@@ -52,9 +55,10 @@ class TestMypyEnforcement:
     def test_mypy_uses_package_level_discovery(self, mypy_config: dict[str, object]) -> None:
         assert mypy_config.get("packages") == ["vibesensor"]
         assert "files" not in mypy_config
+        assert "namespace_packages" not in mypy_config
 
     def test_mypy_discovery_has_no_internal_exclude(self, mypy_config: dict[str, object]) -> None:
-        assert mypy_config.get("exclude") in (None, [])
+        assert mypy_config.get("exclude") in (None, [], "")
 
     def test_mypy_has_no_internal_ignore_errors_override(
         self,
@@ -62,12 +66,15 @@ class TestMypyEnforcement:
     ) -> None:
         overrides = mypy_config.get("overrides")
         assert isinstance(overrides, list)
-        assert not any(
-            isinstance(override, dict)
-            and override.get("ignore_errors") is True
-            and any(
-                isinstance(module_name, str) and module_name.startswith("vibesensor.")
-                for module_name in override.get("module", [])
+        offending_modules: list[str] = []
+        for override in overrides:
+            if not isinstance(override, dict) or override.get("ignore_errors") is not True:
+                continue
+            modules = override.get("module", [])
+            module_names = [modules] if isinstance(modules, str) else modules
+            offending_modules.extend(
+                module_name
+                for module_name in module_names
+                if isinstance(module_name, str) and module_name.startswith("vibesensor.")
             )
-            for override in overrides
-        )
+        assert offending_modules == []


### PR DESCRIPTION
Closes #3965

## What changed
- Tightened domain finding/confidence, report mapping, summary reconstruction, and TestRun guardrail tests.
- Improved history persistence composition, generated constants, sample column alignment, strength metric parity, and type-safety config hygiene tests.
- Replaced duplicated smoke checks with shared fixtures and parameterized contract assertions where useful.

## Why
The listed hygiene tests were too shallow. They now prove concrete contracts: domain-owned confidence reasoning, prepared report/domain aggregate alignment, diagnostic-case reconstruction, TestRun query behavior, split repository ownership, generated backend constant projection, DDL/insert/export/sample parity, and mypy package discovery rules.

## Validation
- ./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_domain_finding_guardrails.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py apps/server/tests/hygiene/test_domain_test_run_guardrails.py apps/server/tests/hygiene/test_history_db_mixins.py apps/server/tests/hygiene/test_location_codes_sync.py apps/server/tests/hygiene/test_sample_column_alignment.py apps/server/tests/hygiene/test_strength_peak_parity.py apps/server/tests/hygiene/test_type_safety_consolidation.py
- make plan-validation
- make lint
- make typecheck-backend

## Risks / tradeoffs
- Test-only change.
- Tighter guardrails may catch future report/domain drift earlier.
- No production code changed.