### PR TITLE
Improve CI runner hygiene tests

### DIFF
--- a/apps/server/tests/hygiene/test_build_ui_static.py
+++ b/apps/server/tests/hygiene/test_build_ui_static.py
@@ -103,6 +103,8 @@ def test_build_ui_static_builds_and_syncs_static_assets(
 
     module.main([])
 
+    assert commands[0][0] == "node"
+    assert Path(commands[0][1]).name == "ensure_ui_bootstrap.mjs"
     assert _npm_run_labels(commands) == ["sync:generated-contracts", "typecheck", "build"]
     assert any(
         command[0] == "node" and Path(command[1]).name == "ensure_ui_bootstrap.mjs"
@@ -112,6 +114,7 @@ def test_build_ui_static_builds_and_syncs_static_assets(
         encoding="utf-8"
     ) == "<!doctype html>\n<!-- build -->\n"
     metadata = json.loads((static_dir / module.UI_BUILD_METADATA_FILE).read_text(encoding="utf-8"))
+    assert set(metadata) == {"git_commit", "static_assets_hash", "ui_source_hash"}
     assert metadata["git_commit"] == "deadbeef"
     assert metadata["ui_source_hash"]
     assert metadata["static_assets_hash"]
@@ -147,6 +150,7 @@ def test_build_ui_static_passes_skip_npm_ci_to_shared_bootstrap(
 
     bootstrap_command = next(command for command in commands if command[0] == "node")
     assert "--skip-npm-ci" in bootstrap_command
+    assert _npm_run_labels(commands) == ["sync:generated-contracts", "build"]
 
 
 def test_build_ui_static_can_use_prevalidated_contract_build_path(
@@ -166,6 +170,7 @@ def test_build_ui_static_can_use_prevalidated_contract_build_path(
 
 def test_build_ui_static_rejects_prevalidated_contracts_without_skip_typecheck(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     module, _repo, _ui_dir, _static_dir = _load_temp_build_ui_static(tmp_path)
 
@@ -173,6 +178,7 @@ def test_build_ui_static_rejects_prevalidated_contracts_without_skip_typecheck(
         module.main(["--assume-prevalidated-contracts"])
 
     assert exc_info.value.code == 2
+    assert "--assume-prevalidated-contracts requires --skip-typecheck" in capsys.readouterr().err
 
 
 def test_build_ui_static_stays_importable_without_msgspec(

--- a/apps/server/tests/hygiene/test_ci_changed_scope.py
+++ b/apps/server/tests/hygiene/test_ci_changed_scope.py
@@ -62,12 +62,14 @@ def test_pull_request_event_outputs_match_path_rules(
         ci_changed_scope._selection_for_github_event()
         == ci_changed_scope.workflow_job_selection(changed_files).github_outputs()
     )
+    assert ci_changed_scope._selection_for_github_event()["run_frontend_typecheck"] == "true"
 
 
 def test_force_full_stack_env_bypasses_changed_file_scope(
     ci_changed_scope: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     payload_path = tmp_path / "pull_request_event.json"
     payload_path.write_text("{}", encoding="utf-8")
@@ -87,3 +89,4 @@ def test_force_full_stack_env_bypasses_changed_file_scope(
         ci_changed_scope._selection_for_github_event()
         == ci_changed_scope.workflow_job_selection(()).github_outputs()
     )
+    assert "forcing full-stack scope" in capsys.readouterr().err

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -115,6 +115,7 @@ def test_main_uses_shared_ui_bootstrap_helper_when_npm_ci_is_needed(
         ["node", "../../tools/ui/ensure_ui_bootstrap.mjs"],
         cwd=ui_dir,
     )
+    assert captured["bootstrap_steps"][-1].cmd[0] == "node"
 
 
 def test_main_refuses_skip_bootstrap_when_release_smoke_would_race_ui_jobs(
@@ -346,6 +347,7 @@ def test_main_skips_selected_downstream_job_when_github_need_fails(
     assert run_order == ["frontend-typecheck"]
     assert "[ui-unit] skip (needed job failed: frontend-typecheck)" in output
     assert "- ui-unit: SKIP (needed job failed: frontend-typecheck)" in output
+    assert "frontend-typecheck.log" in output
 
 
 def test_main_reports_missing_shellcheck_before_running_shell_lint(
@@ -461,4 +463,6 @@ def test_main_serializes_jobs_with_overlapping_workspace_write_sets(
     output = "\n".join(outputs)
     assert "shared workspace write-set serialization" in output
     assert "ui-generated-contracts: frontend-typecheck, backend-contract-drift" in output
+    assert "- frontend-typecheck: PASS" in output
+    assert "- backend-contract-drift: PASS" in output
     assert max_active_jobs == 1

--- a/apps/server/tests/hygiene/test_ci_path_rules.py
+++ b/apps/server/tests/hygiene/test_ci_path_rules.py
@@ -357,7 +357,11 @@ def test_workflow_job_selection_matrix(ci_path_rules: ModuleType, case: Selectio
         _all_jobs(ci_path_rules) if case.expected_jobs is _FULL_STACK else case.expected_jobs
     )
     assert expected_jobs is not None
+    selection = ci_path_rules.workflow_job_selection(case.changed_files)
     assert _selected_jobs(ci_path_rules, case.changed_files) == expected_jobs
+    assert set(selection.github_outputs()) == {
+        f"run_{field.name}" for field in fields(ci_path_rules.WorkflowJobSelection)
+    }
 
 
 def test_meaningful_tracked_files_do_not_select_empty_ci_jobs(

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -140,3 +140,16 @@ def test_shell_lint_declares_host_shellcheck_prerequisite() -> None:
     module = _load_ci_manifest_module()
 
     assert module.ci_workflow_jobs()["shell-lint"].host_tools == ("shellcheck",)
+
+
+def test_local_needs_reference_manifest_jobs_only() -> None:
+    module = _load_ci_manifest_module()
+
+    jobs = module.ci_workflow_jobs()
+    unknown_needs = {
+        job_name: tuple(need for need in job.needs if need not in jobs)
+        for job_name, job in jobs.items()
+        if any(need not in jobs for need in job.needs)
+    }
+
+    assert unknown_needs == {}

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -128,6 +128,7 @@ def test_main_builds_pytest_command_for_selected_backend_shard(
     assert captured["collect_args"] == ["-m", excluded_markers, "apps/server/tests"]
     assert command[command.index("-m", 2) + 1] == excluded_markers
     assert "apps/server/tests/app/test_app_main.py" in command
+    assert Path(captured["log_path"]).name == "backend-tests-1.log"
     assert any("running shard 1/1" in line for line in emitted)
 
 
@@ -161,6 +162,7 @@ def test_main_can_include_diagnostic_matrix(monkeypatch, tmp_path: Path) -> None
     command = captured["cmd"]
     assert captured["collect_args"] == ["-m", "not dev_tooling", "apps/server/tests"]
     assert "not diagnostic_matrix" not in command
+    assert command[command.index("-m", 2) + 1] == "not dev_tooling"
 
 
 def test_main_reads_diagnostic_matrix_env(monkeypatch, tmp_path: Path) -> None:
@@ -183,6 +185,7 @@ def test_main_can_include_dev_tooling(monkeypatch, tmp_path: Path) -> None:
     command = captured["cmd"]
     assert captured["collect_args"] == ["-m", "not diagnostic_matrix", "apps/server/tests"]
     assert "not dev_tooling" not in command
+    assert command[command.index("-m", 2) + 1] == "not diagnostic_matrix"
 
 
 def test_main_reads_dev_tooling_env(monkeypatch, tmp_path: Path) -> None:

--- a/apps/server/tests/hygiene/test_run_changed.py
+++ b/apps/server/tests/hygiene/test_run_changed.py
@@ -86,8 +86,33 @@ def test_main_dry_run_smoke_maps_representative_changed_paths(
     assert "[test-changed] ui-test:" in output
     assert "[test-changed] ui-typecheck:" in output
     assert "[test-changed] pytest:" in output
+    assert "Changed files vs origin/main:" in output
+    assert "apps/ui/src/ws_payload_validator.ts" in output
     assert "apps/server/tests/hygiene" in output
     assert "apps/server/tests/shared" in output
+
+
+def test_changed_files_combines_committed_staged_unstaged_and_untracked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_run_changed_module()
+    _install_git_state(
+        monkeypatch,
+        module,
+        outputs=_git_outputs(
+            committed=("README.md",),
+            staged=("apps/ui/src/main.ts",),
+            unstaged=("apps/server/tests/hygiene/test_run_changed.py",),
+            untracked=("tools/dev/new_helper.py",),
+        ),
+    )
+
+    assert module._changed_files("origin/main") == (
+        "README.md",
+        "apps/server/tests/hygiene/test_run_changed.py",
+        "apps/ui/src/main.ts",
+        "tools/dev/new_helper.py",
+    )
 
 
 def test_main_exits_cleanly_when_merge_base_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/server/tests/hygiene/test_run_e2e_parallel.py
+++ b/apps/server/tests/hygiene/test_run_e2e_parallel.py
@@ -238,4 +238,6 @@ def test_main_reports_default_min_shards_and_base_config(monkeypatch, tmp_path: 
     assert module.main([]) == 0
 
     assert recorded["config_call"]["source_config"] == module._DEFAULT_BASE_CONFIG.resolve()
+    assert recorded["config_call"]["config_name"] == "shard-1.yaml"
+    assert recorded["config_call"]["data_seed_dir"] == module._DEFAULT_DATA_SEED_DIR
     assert any("min requested: 6" in line for line in emitted)

--- a/apps/server/tests/hygiene/test_shared_contracts_smoke.py
+++ b/apps/server/tests/hygiene/test_shared_contracts_smoke.py
@@ -18,3 +18,4 @@ def test_core_processing_produces_canonical_metric_fields() -> None:
     assert isinstance(db_val, float)
     assert math.isfinite(db_val), f"vibration_strength_db must be finite, got {db_val}"
     assert db_val >= 0, f"vibration_strength_db must be non-negative, got {db_val}"
+    assert result["strength_bucket"] in {"l0", "l1", "l2", "l3", "l4", "l5"}

--- a/apps/server/tests/hygiene/test_shellcheck_targets.py
+++ b/apps/server/tests/hygiene/test_shellcheck_targets.py
@@ -80,6 +80,7 @@ def test_shell_lint_discovers_current_targets_and_make_uses_tool() -> None:
     makefile = _MAKEFILE.read_text(encoding="utf-8")
 
     assert all(reason.strip() for reason in module.SHELLCHECK_ALLOWLIST.values())
+    assert set(module.SHELLCHECK_ALLOWLIST) <= set(_git_lines("ls-files"))
     assert tuple(module.shellcheck_targets()) == _expected_shellcheck_targets(allowlist)
     assert "SHELLCHECK_TARGETS :=" not in makefile
     assert '"$$PYTHON" tools/dev/shellcheck_targets.py' in makefile

--- a/apps/server/tests/hygiene/test_ui_bootstrap_helper.py
+++ b/apps/server/tests/hygiene/test_ui_bootstrap_helper.py
@@ -86,6 +86,7 @@ def test_ui_bootstrap_helper_runs_npm_ci_and_marks_lock_hash(tmp_path: Path) -> 
     )
 
     assert result.returncode == 0
+    assert result.stderr == ""
     assert log_path.read_text(encoding="utf-8").splitlines() == ["ci"]
     assert (ui_dir / ".npm-ci-lock.sha256").read_text(encoding="utf-8").strip() == hashlib.sha256(
         (ui_dir / "package-lock.json").read_bytes()
@@ -168,6 +169,7 @@ def test_ui_bootstrap_helper_materializes_missing_generated_contracts_when_reque
 
     assert result.returncode == 0
     assert log_path.read_text(encoding="utf-8").splitlines() == ["run sync:generated-contracts"]
+    assert "generated UI contract derivatives are missing" in result.stdout
 
 
 def test_ui_bootstrap_helper_skips_generated_contract_sync_when_derivatives_exist(
@@ -196,3 +198,4 @@ def test_ui_bootstrap_helper_skips_generated_contract_sync_when_derivatives_exis
 
     assert result.returncode == 0
     assert not log_path.exists()
+    assert result.stdout.count("sync:generated-contracts") == 0

--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -116,6 +116,7 @@ def test_ui_tooling_covers_playwright_configs_and_ignores_generated_results() ->
     assert "!tests/test-results" in files_includes
     assert output_dirs
     assert all(output_dir.startswith("test-results/") for output_dir in output_dirs)
+    assert all(not output_dir.endswith("/") for output_dir in output_dirs)
 
 
 def test_ui_smoke_command_and_config_alignment() -> None:
@@ -138,6 +139,7 @@ def test_ui_smoke_command_and_config_alignment() -> None:
     assert workers_env_var == "PLAYWRIGHT_SMOKE_WORKERS"
     assert workers_default == "1"
     assert _smoke_test_dir() == "tests"
+    assert _smoke_test_match_patterns() == ["smoke.critical.spec.ts"]
     assert smoke_specs
     assert all(name.startswith("smoke") for name in smoke_specs)
     assert "visual.spec.ts" not in smoke_specs

--- a/apps/server/tests/hygiene/test_watch_pr_checks.py
+++ b/apps/server/tests/hygiene/test_watch_pr_checks.py
@@ -64,7 +64,9 @@ def test_snapshot_check_treats_skipped_and_commit_status_success_as_ok() -> None
 
     assert skipped.bucket == "ok"
     assert skipped.conclusion == "SKIPPED"
+    assert skipped.label == "CI/Backend lint"
     assert commit_status.bucket == "ok"
+    assert commit_status.label == "external-ci/build"
     assert commit_status.details_url == "https://example.invalid/status"
 
 
@@ -74,6 +76,7 @@ def test_actionable_merge_issue_only_flags_real_merge_conflicts() -> None:
     assert module._actionable_merge_issue("BLOCKED", "UNKNOWN") is None
     assert module._actionable_merge_issue("UNKNOWN", "UNKNOWN") is None
     assert module._actionable_merge_issue("DIRTY", "UNKNOWN") == "merge_state=DIRTY"
+    assert module._actionable_merge_issue("dirty", "unknown") == "merge_state=DIRTY"
     assert module._actionable_merge_issue("CLEAN", "CONFLICTING") == "mergeable=CONFLICTING"
 
 


### PR DESCRIPTION
## What changed
- Tightened CI/path/manifest hygiene tests around GitHub output keys, forced full-stack logging, local needs, and shellcheck target allowlists.
- Strengthened local runner tests for bootstrap ordering, failure summaries, shard commands, changed-file detection, e2e config wiring, and PR watcher status labels.
- Added small UI tooling contract checks for static build metadata, bootstrap logging, smoke config selection, and canonical strength buckets.

## Why
Issue #3966 asked to improve CI and parallel test runner hygiene tests so they prove specific behavior instead of only smoke-testing that tooling runs.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_build_ui_static.py apps/server/tests/hygiene/test_ci_changed_scope.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ci_path_rules.py apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_run_changed.py apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_shared_contracts_smoke.py apps/server/tests/hygiene/test_shellcheck_targets.py apps/server/tests/hygiene/test_ui_bootstrap_helper.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/hygiene/test_watch_pr_checks.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`
- `make test-tooling`

## Risks, tradeoffs, edge cases
- Test-only change.
- Assertions are tighter but stay on stable contracts: commands, outputs, labels, metadata keys, selected jobs, and summary text.
- No production runner behavior changed.

Closes #3966