### PR TITLE
Improve release and Pi tooling tests

### DIFF
--- a/apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py
+++ b/apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py
@@ -61,6 +61,8 @@ def test_server_pyproject_includes_esp_flash_and_firmware_cache_entrypoints() ->
     assert "vibesensor.use_cases.updates.releases.cli:fetch_latest_wheel_cli" in pyproject_text, (
         "Server release fetch CLI entry point must target the releases package module"
     )
+    assert pyproject_text.count("vibesensor-fw-refresh") == 1
+    assert pyproject_text.count("vibesensor-fw-info") == 1
 
 
 @pytest.mark.smoke
@@ -77,6 +79,7 @@ def test_firmware_uses_pinned_registry_neopixel_library() -> None:
     assert "adafruit/Adafruit NeoPixel@1.15.4" in platformio_text, (
         "firmware platformio.ini must pin the NeoPixel PlatformIO registry dependency"
     )
+    assert "lib_deps =" in platformio_text
     vendored_library = REPO_ROOT / "firmware" / "esp" / "lib" / "Adafruit_NeoPixel"
     assert not vendored_library.exists(), (
         "firmware must not vendor Adafruit NeoPixel now that platformio.ini pins it"

--- a/apps/server/tests/hygiene/test_install_pi_runtime_policy.py
+++ b/apps/server/tests/hygiene/test_install_pi_runtime_policy.py
@@ -152,6 +152,7 @@ def test_install_pi_fails_fast_when_python3_is_below_supported_floor(tmp_path: P
     assert result.returncode == 1
     assert "requires python3 >= 3.13" in result.stderr
     assert "docs/runtime_support_matrix.md" in result.stderr
+    assert "pip install" not in result.stderr
     assert not any(call.startswith("-m venv ") for call in python_calls)
     assert pip_calls == []
     assert not (server_root / ".venv").exists()
@@ -167,3 +168,4 @@ def test_install_pi_reaches_venv_creation_with_supported_python(tmp_path: Path) 
     assert result.returncode == 41
     assert f"-m venv {server_root / '.venv'}" in python_calls
     assert pip_calls == ["install --upgrade pip"]
+    assert (server_root / ".venv" / "bin" / "pip").is_file()

--- a/apps/server/tests/hygiene/test_main_release_scripts.py
+++ b/apps/server/tests/hygiene/test_main_release_scripts.py
@@ -59,6 +59,8 @@ def test_compute_release_version_increments_latest_numeric_suffix() -> None:
     )
 
     assert version_info.version == "2026.4.6.10"
+    assert version_info.tag == "server-v2026.4.6.10"
+    assert version_info.bundle == "vibesensor-fw-v2026.4.6.10.zip"
 
 
 def test_build_wheel_subcommand_stamps_version_and_reports_artifact(
@@ -113,6 +115,17 @@ def test_build_wheel_subcommand_stamps_version_and_reports_artifact(
         command[:3] == ["/fake/python", "-m", "build"] and "--wheel" in command
         for command in commands
     )
+    pip_index = next(
+        index
+        for index, command in enumerate(commands)
+        if command[:4] == ["/fake/python", "-m", "pip", "install"]
+    )
+    build_index = next(
+        index
+        for index, command in enumerate(commands)
+        if command[:3] == ["/fake/python", "-m", "build"]
+    )
+    assert pip_index < build_index
 
 
 def test_generate_firmware_manifest_subcommand_writes_manifest_and_reports_path(
@@ -189,6 +202,7 @@ def test_generate_firmware_manifest_subcommand_writes_manifest_and_reports_path(
         ],
     }
     assert any(command[:3] == ["pio", "run", "-e"] and "envdump" in command for command in commands)
+    assert manifest_path.parent == firmware_dir / "dist"
 
 
 def test_cleanup_releases_dry_run_prints_selected_wheel_esp_releases(
@@ -271,6 +285,7 @@ def test_cleanup_releases_reports_missing_tag_and_continues(
     output = capsys.readouterr().out
     assert "Deleting superseded Wheel / ESP release server-v2026.4.5" in output
     assert "Tag server-v2026.4.5 was already absent" in output
+    assert "server-v2026.4.6" not in deleted_paths
     assert set(deleted_paths) == {"releases/2", "git/refs/tags/server-v2026.4.5"}
 
 
@@ -305,6 +320,7 @@ def test_github_request_uses_timeout_and_returns_json(
         "url": "https://api.github.com/repos/Skamba/VibeSensor/releases",
         "timeout": module.GITHUB_API_TIMEOUT_S,
     }
+    assert captured["url"].endswith("/releases")
 
 
 def test_github_request_reports_url_errors_with_method_and_path(

--- a/apps/server/tests/hygiene/test_main_release_workflow.py
+++ b/apps/server/tests/hygiene/test_main_release_workflow.py
@@ -60,6 +60,9 @@ def test_main_release_workflow_uses_ci_source_and_release_artifact_contracts() -
     assert '--generated-from "${{ steps.release_source.outputs.sha }}"' in run_script
     assert "tools/publish_github_release.py" in run_script
     assert '--target "${{ steps.release_source.outputs.sha }}"' in run_script
+    publish_index = run_script.index("tools/publish_github_release.py")
+    assert run_script.index("validate-wheel-metadata") < publish_index
+    assert run_script.index("validate-firmware-manifest") < publish_index
     assert "tools/release/main_release.py cleanup-releases" in run_script
     assert "WHEEL_ESP_RELEASE_TITLE_PREFIX: Wheel / ESP release" in yaml.safe_dump(release_job)
     assert "GITHUB_SHA" not in run_script

--- a/apps/server/tests/hygiene/test_packaged_runtime_data_sync.py
+++ b/apps/server/tests/hygiene/test_packaged_runtime_data_sync.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from _paths import SERVER_ROOT
 
 
@@ -9,6 +11,8 @@ def test_packaged_runtime_data_matches_canonical_source() -> None:
     packaged_dir = SERVER_ROOT / "vibesensor" / "data"
 
     assert (packaged_dir / "report_i18n.json").is_file()
+    report_i18n = json.loads((packaged_dir / "report_i18n.json").read_text(encoding="utf-8"))
+    assert isinstance(report_i18n, dict)
     vehicle_config_dir = packaged_dir / "vehicle_configurations"
     assert vehicle_config_dir.is_dir()
     assert any(vehicle_config_dir.rglob("*.json"))

--- a/apps/server/tests/hygiene/test_pi_app_artifacts_contract_sync.py
+++ b/apps/server/tests/hygiene/test_pi_app_artifacts_contract_sync.py
@@ -79,4 +79,5 @@ esac
         "run sync:generated-contracts",
         "run build",
     ]
+    assert (ui_dir / "src/generated/http_api_contracts.ts").is_file()
     assert (server_static_dir / "index.html").read_text(encoding="utf-8") == "<!doctype html>\n"

--- a/apps/server/tests/hygiene/test_pi_app_artifacts_versioning.py
+++ b/apps/server/tests/hygiene/test_pi_app_artifacts_versioning.py
@@ -78,6 +78,7 @@ def test_compute_app_build_version_prefers_release_tag_at_head(tmp_path: Path) -
     version = _run_app_artifacts_function(repo, "compute_app_build_version")
 
     assert version == "2026.3.29"
+    assert not version.startswith("server-v")
 
 
 def test_compute_app_build_version_falls_back_to_git_sha(tmp_path: Path) -> None:
@@ -88,6 +89,7 @@ def test_compute_app_build_version_falls_back_to_git_sha(tmp_path: Path) -> None
     version = _run_app_artifacts_function(repo, "compute_app_build_version")
 
     assert version == f"0.0.0.dev0+g{git_sha}"
+    assert len(git_sha) == 12
 
 
 def test_build_app_artifacts_stamps_version_before_building_wheel() -> None:
@@ -101,3 +103,7 @@ def test_build_app_artifacts_stamps_version_before_building_wheel() -> None:
     assert stamp_call in script_text
     assert script_text.index(stamp_call) < script_text.index(build_call)
     assert 'echo "version=${app_version}"' in script_text
+    assert (
+        'git_sha="$(git -C "${REPO_ROOT}" rev-parse --short=12 HEAD 2>/dev/null || true)"'
+        in script_text
+    )

--- a/apps/server/tests/hygiene/test_pi_gen_artifact_selection.py
+++ b/apps/server/tests/hygiene/test_pi_gen_artifact_selection.py
@@ -38,6 +38,7 @@ def test_choose_final_artifact_prefers_current_image_priority(tmp_path: Path) ->
 
     assert result.returncode == 0, result.stderr
     assert Path(result.stdout.strip()).name == f"image_2026-03-21{_IMG_SUFFIX}.img"
+    assert result.stderr == ""
 
 
 def test_choose_final_artifact_prefers_image_prefixed_zip_over_legacy_name(tmp_path: Path) -> None:
@@ -57,3 +58,4 @@ def test_choose_final_artifact_rejects_legacy_non_image_zip_names(tmp_path: Path
 
     assert result.returncode != 0
     assert result.stdout == ""
+    assert result.stderr == ""

--- a/apps/server/tests/hygiene/test_pi_image_build_action.py
+++ b/apps/server/tests/hygiene/test_pi_image_build_action.py
@@ -56,6 +56,7 @@ def test_build_pi_image_action_reuses_shared_runtime_and_publishes_image_contrac
     assert "sha256sum" in collect_run
     assert "version_info_source" in collect_run
     assert "published_artifact=${artifact_name}" in collect_run
+    assert "release-artifact-name=${artifact_name}" in collect_run
 
     upload_step = _step_by_name(steps, "Upload Pi image workflow artifact")
     assert upload_step["uses"] == "actions/upload-artifact@v7"

--- a/apps/server/tests/hygiene/test_pi_image_python_runtime_policy.py
+++ b/apps/server/tests/hygiene/test_pi_image_python_runtime_policy.py
@@ -61,6 +61,7 @@ def test_image_validation_reads_supported_python_floor_from_pyproject(tmp_path: 
     )
 
     assert result.stdout.strip() == "3.13"
+    assert result.stderr == ""
 
 
 def test_image_validation_python_version_meets_floor() -> None:
@@ -73,6 +74,7 @@ def test_image_validation_python_version_meets_floor() -> None:
     )
 
     assert result.returncode == 1
+    assert result.stdout == ""
 
 
 def test_pi_image_stage_records_runtime_python_metadata_before_cleanup() -> None:
@@ -140,6 +142,8 @@ def test_write_version_info_includes_validated_image_python_metadata(tmp_path: P
     text = version_info.read_text(encoding="utf-8")
     assert "image_runtime_python_version=3.13.4" in text
     assert "image_runtime_python_floor=3.13" in text
+    assert "git_sha=abcdef123456" in text
+    assert "source_artifact=vibesensor-lite.img.zip" in text
 
 
 def test_pi_build_threads_validated_runtime_python_into_version_info() -> None:
@@ -147,3 +151,4 @@ def test_pi_build_threads_validated_runtime_python_into_version_info() -> None:
 
     assert '"${VALIDATED_IMAGE_PYTHON_VERSION:-}"' in text
     assert '"${VALIDATED_IMAGE_PYTHON_FLOOR:-}"' in text
+    assert "write_version_info" in text

--- a/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
+++ b/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
@@ -73,6 +73,7 @@ def test_server_systemd_runs_packaged_server_with_narrow_steady_state_privileges
     }
     assert shlex.split(_only_value(service, "AmbientCapabilities")) == ["CAP_NET_BIND_SERVICE"]
     assert shlex.split(_only_value(service, "CapabilityBoundingSet")) == ["CAP_NET_BIND_SERVICE"]
+    assert "CAP_SYS_ADMIN" not in _only_value(service, "CapabilityBoundingSet")
 
     prestart_commands = [shlex.split(value) for value in service["ExecStartPre"]]
     assert ["/usr/bin/test", "-r", "/etc/vibesensor/config.yaml"] in prestart_commands
@@ -112,3 +113,4 @@ def test_image_validation_accepts_wheel_static_data_and_rejects_source_tree(
 
     assert result.returncode == 1
     assert "source tree still present" in result.stdout
+    assert "apps/server/vibesensor" in result.stdout

--- a/apps/server/tests/hygiene/test_pi_image_wrapper_commands.py
+++ b/apps/server/tests/hygiene/test_pi_image_wrapper_commands.py
@@ -193,6 +193,7 @@ def test_build_wrapper_app_mode_finishes_after_app_artifacts(tmp_path: Path) -> 
     assert result.returncode == 0, result.stderr
     assert "Build mode 'app' complete." in result.stdout
     assert (paths["out"] / "app-built.txt").is_file()
+    assert not (paths["out"] / "validated-artifact.txt").exists()
     assert "Final artifact:" not in result.stdout
 
 
@@ -219,6 +220,7 @@ def test_build_wrapper_reports_final_artifact_and_copies_release_files(tmp_path:
     )
     assert (release_dir / artifact.name).is_file()
     assert (release_dir / version_info.name).is_file()
+    assert (release_dir / artifact.name).read_text(encoding="utf-8") == "image\n"
     assert "Using Raspbian mirror: https://mirror.invalid/raspbian" in result.stdout
     assert f"Final artifact: {artifact}" in result.stdout
     assert f"Version info: {version_info}" in result.stdout
@@ -235,6 +237,7 @@ def test_validate_image_wrapper_uses_selected_artifact_and_reports_completion(
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == f"Validation complete for: {artifact}"
+    assert "Final artifact:" not in result.stdout
     assert (paths["out"] / "validated-artifact.txt").read_text(encoding="utf-8").strip() == str(
         artifact
     )

--- a/apps/server/tests/hygiene/test_publish_github_release.py
+++ b/apps/server/tests/hygiene/test_publish_github_release.py
@@ -86,6 +86,7 @@ def test_main_creates_or_updates_release_with_repo_endpoint_and_uploads_assets(
 
     for existing_release_id, method, endpoint in cases:
         commands: list[list[str]] = []
+        release_payloads: list[dict[str, object]] = []
         monkeypatch.setattr(
             module,
             "_existing_release_id",
@@ -100,8 +101,13 @@ def test_main_creates_or_updates_release_with_repo_endpoint_and_uploads_assets(
             context: str,
             timeout_s: float,
             recorded_commands: list[list[str]] = commands,
+            recorded_payloads: list[dict[str, object]] = release_payloads,
         ):
             recorded_commands.append(list(command))
+            if "--input" in command:
+                recorded_payloads.append(
+                    json.loads(Path(_option_value(command, "--input")).read_text())
+                )
             return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
         monkeypatch.setattr(module, "_run", _fake_run)
@@ -129,6 +135,10 @@ def test_main_creates_or_updates_release_with_repo_endpoint_and_uploads_assets(
         assert endpoint in release_command
         assert _option_value(release_command, "--method") == method
         assert "--input" in release_command
+        release_payload = release_payloads[0]
+        assert release_payload["tag_name"] == "server-v2026.3.28"
+        assert release_payload["target_commitish"] == "abc123"
+        assert release_payload["name"] == "Release 2026.3.28"
 
         assert upload_command[:3] == ["gh", "release", "upload"]
         assert "server-v2026.3.28" in upload_command

--- a/apps/server/tests/hygiene/test_update_sudo_wrapper.py
+++ b/apps/server/tests/hygiene/test_update_sudo_wrapper.py
@@ -53,6 +53,8 @@ def test_update_sudo_wrapper_allows_expected_update_commands(tmp_path: Path) -> 
     for command in allowed_commands:
         result = _run_wrapper(tmp_path, command)
         assert result.returncode == 0, result.stderr
+        assert result.stderr == ""
+        assert result.stdout.strip().endswith(" ".join(command[1:]))
 
 
 def test_update_sudo_wrapper_rejects_basename_spoofing(tmp_path: Path) -> None:
@@ -64,6 +66,7 @@ def test_update_sudo_wrapper_rejects_basename_spoofing(tmp_path: Path) -> None:
 
     assert result.returncode == 126
     assert "is not allowed" in result.stderr
+    assert result.stdout == ""
 
 
 def test_update_sudo_wrapper_rejects_unexpected_subcommands(tmp_path: Path) -> None:
@@ -71,6 +74,7 @@ def test_update_sudo_wrapper_rejects_unexpected_subcommands(tmp_path: Path) -> N
 
     assert result.returncode == 126
     assert "is not allowed" in result.stderr
+    assert result.stdout == ""
 
 
 def test_update_sudo_wrapper_rejects_malformed_nmcli_options(tmp_path: Path) -> None:
@@ -78,6 +82,7 @@ def test_update_sudo_wrapper_rejects_malformed_nmcli_options(tmp_path: Path) -> 
 
     assert result.returncode == 126
     assert "is not allowed" in result.stderr
+    assert result.stdout == ""
 
 
 def test_manual_pi_install_installs_update_sudoers_entry() -> None:

--- a/apps/server/tests/scripts/test_vibesensor_obd_admin.py
+++ b/apps/server/tests/scripts/test_vibesensor_obd_admin.py
@@ -41,6 +41,7 @@ def test_ensure_repo_venv_python_reexecs_when_sys_prefix_is_not_the_repo_venv(
     with pytest.raises(SystemExit, match="0"):
         module._ensure_repo_venv_python()
 
+    assert module.sys.argv == ["vibesensor_obd_admin.py", "scan"]
     assert execv_calls == [
         (
             str(target_python),
@@ -68,6 +69,7 @@ def test_ensure_repo_venv_python_accepts_symlinked_venv_when_sys_prefix_matches(
     monkeypatch.setattr(module.os, "execv", _unexpected_execv)
 
     module._ensure_repo_venv_python()
+    assert module.sys.prefix == str(venv_root)
 
 
 def test_find_repo_venv_python_falls_back_to_python3(
@@ -83,3 +85,4 @@ def test_find_repo_venv_python_falls_back_to_python3(
     monkeypatch.setattr(module, "VENV_PYTHON_BASENAMES", ("python", "python3"))
 
     assert module._find_repo_venv_python() == target_python
+    assert target_python.name == "python3"

--- a/apps/server/tests/use_cases/updates/firmware/test_firmware_cache_refresh.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_firmware_cache_refresh.py
@@ -65,6 +65,7 @@ def test_refresh_download_failure_preserves_current_bundle(tmp_path: Path) -> No
     assert (cache.current_dir / "marker.txt").read_text(encoding="utf-8") == "old-tag"
     assert read_meta(cache.current_dir).tag == "old-tag"
     assert not (cache.current_dir.parent / "current.old").exists()
+    assert fetcher.download_asset.call_count == 1
 
 
 def test_refresh_restores_previous_bundle_after_activation_failure(
@@ -110,3 +111,4 @@ def test_refresh_restores_previous_bundle_after_activation_failure(
     assert (cache.current_dir / "marker.txt").read_text(encoding="utf-8") == "old-tag"
     assert read_meta(cache.current_dir).tag == "old-tag"
     assert not (cache.current_dir.parent / "current.old").exists()
+    assert extracted_dirs and not extracted_dirs[0].exists()

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -82,6 +82,8 @@ def test_build_release_smoke_config_rewrites_runtime_paths(tmp_path: Path) -> No
     assert data["logging"]["history_db_path"].endswith("history.db")
     assert data["logging"]["app_log_path"].endswith("app.log")
     assert data["update"]["rollback_dir"].endswith("rollback")
+    assert str(tmp_path) in data["logging"]["history_db_path"]
+    assert str(tmp_path) in data["update"]["rollback_dir"]
 
 
 def test_validate_firmware_dist_accepts_generated_manifest(tmp_path: Path) -> None:
@@ -410,6 +412,7 @@ def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) 
     assert popen_kwargs["env"]["VIBESENSOR_SERVE_STATIC"] == "0"
     assert popen_kwargs["env"]["VIBESENSOR_UPDATE_STATE_PATH"].endswith("update_status.json")
     assert popen_kwargs["stdout"] == subprocess.PIPE
+    assert recorded["config"][2:] == ("127.0.0.1", 18081)
     assert recorded["terminated"] is True
 
 

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -153,6 +153,7 @@ async def test_snapshot_for_rollback_writes_checksum_metadata(tmp_path: Path) ->
     assert metadata["repo_path"] == str(installer._config.repo)
     assert "assets_verified" in metadata
     assert "has_packaged_static" in metadata
+    assert metadata["sha256"] == sha256_file(rollback_dir / "rollback_snapshot.whl")
     assert (rollback_dir / "rollback_snapshot.whl").is_file()
 
 
@@ -222,6 +223,7 @@ async def test_snapshot_for_rollback_preserves_previous_snapshot_when_metadata_w
     assert read_wheel_metadata(previous_wheel).version == "2025.6.13"
     metadata = json.loads((rollback_dir / "rollback_snapshot.json").read_text(encoding="utf-8"))
     assert metadata["version"] == "2025.6.13"
+    assert metadata["sha256"] == sha256_file(previous_wheel)
     assert any(
         issue.message == "Rollback metadata could not be written" for issue in tracker.status.issues
     )

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -310,6 +310,7 @@ class TestNoSecretsInPersistedFile:
 
         assert state_path.is_file(), "State file should have been created"
         contents = state_path.read_text(encoding="utf-8")
+        assert "TestNet" in contents
         assert secret_password not in contents, "Password leaked into persisted state file!"
 
 


### PR DESCRIPTION
## What changed
- Tightened release helper/workflow tests around version derivation, command ordering, manifest output, GitHub API behavior, and publish payloads.
- Strengthened Pi image/app artifact tests for runtime metadata, artifact selection, wrapper outputs, workflow action contracts, static-data policy, and offline install guardrails.
- Added focused update tooling checks for sudo wrapper output, OBD admin venv selection, firmware cache rollback cleanup, release smoke config paths, rollback checksums, and persisted status secrecy.

## Why
Issue #3968 asked to improve release, Pi image, update tooling, and firmware cache tests so each case proves concrete behavior instead of just running through the path.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py apps/server/tests/hygiene/test_install_pi_runtime_policy.py apps/server/tests/hygiene/test_main_release_scripts.py apps/server/tests/hygiene/test_main_release_workflow.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py apps/server/tests/hygiene/test_pi_app_artifacts_contract_sync.py apps/server/tests/hygiene/test_pi_app_artifacts_versioning.py apps/server/tests/hygiene/test_pi_gen_artifact_selection.py apps/server/tests/hygiene/test_pi_image_build_action.py apps/server/tests/hygiene/test_pi_image_python_runtime_policy.py apps/server/tests/hygiene/test_pi_image_static_guardrails.py apps/server/tests/hygiene/test_pi_image_wrapper_commands.py apps/server/tests/hygiene/test_publish_github_release.py apps/server/tests/hygiene/test_update_sudo_wrapper.py apps/server/tests/scripts/test_vibesensor_obd_admin.py apps/server/tests/use_cases/updates/firmware/test_firmware_cache_refresh.py apps/server/tests/use_cases/updates/releases/test_release_validation.py apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/test_update_state_persistence.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`
- `make test-tooling`

## Risks, tradeoffs, edge cases
- Test-only change.
- Assertions target stable contracts: emitted artifacts, command payloads, metadata fields, runtime paths, and safety failures.
- No release, update, or Pi image production behavior changed.

Closes #3968