### PR TITLE
Improve repo governance tooling tests

### DIFF
--- a/apps/server/tests/hygiene/test_check_prerequisites.py
+++ b/apps/server/tests/hygiene/test_check_prerequisites.py
@@ -41,6 +41,7 @@ def test_check_docker_accepts_compose_v2_and_keeps_daemon_check(monkeypatch) -> 
 
     results = module._check_docker()
 
+    assert [item.name for item in results] == ["docker", "docker compose", "docker daemon"]
     assert [(item.name, item.status, item.message) for item in results] == [
         ("docker", "OK", "installed"),
         ("docker compose", "OK", "Docker Compose version v2.39.4"),
@@ -76,6 +77,7 @@ def test_check_docker_requires_compose_v2_even_if_legacy_binary_exists(monkeypat
 
     results = module._check_docker()
 
+    assert all(item.name != "docker-compose" for item in results)
     assert [(item.name, item.status, item.message) for item in results] == [
         ("docker", "OK", "installed"),
         (
@@ -96,6 +98,7 @@ def test_check_shellcheck_reports_missing_local_ci_prerequisite(monkeypatch) -> 
 
     assert result.name == "shellcheck"
     assert result.status == "WARN"
+    assert "missing" in result.message
     assert "local shell-lint CI parity" in result.message
 
 
@@ -116,3 +119,4 @@ def test_check_shellcheck_reports_installed_version(monkeypatch) -> None:
         "OK",
         "version: 0.10.0",
     )
+    assert "ShellCheck -" not in result.message

--- a/apps/server/tests/hygiene/test_dev_workflow.py
+++ b/apps/server/tests/hygiene/test_dev_workflow.py
@@ -93,6 +93,7 @@ def test_dev_docker_runs_npm_ci_and_marks_lock_hash_when_node_modules_missing(
     result, commands = _run_dev_docker_script(ui_dir, tmp_path)
 
     assert result.returncode == 0
+    assert result.stderr == ""
     assert commands == [
         "ci",
         "run sync:generated-contracts",
@@ -113,6 +114,7 @@ def test_dev_docker_reinstalls_when_lock_hash_is_stale(tmp_path: Path) -> None:
     result, commands = _run_dev_docker_script(ui_dir, tmp_path)
 
     assert result.returncode == 0
+    assert result.stderr == ""
     assert commands == [
         "ci",
         "run sync:generated-contracts",
@@ -137,6 +139,7 @@ def test_dev_docker_skips_npm_ci_when_lock_hash_is_current(tmp_path: Path) -> No
     result, commands = _run_dev_docker_script(ui_dir, tmp_path)
 
     assert result.returncode == 0
+    assert result.stderr == ""
     assert commands == [
         "run sync:generated-contracts",
         "run dev -- --host 0.0.0.0 --port 5173",
@@ -157,4 +160,5 @@ def test_dev_docker_fails_fast_when_contract_regeneration_fails(tmp_path: Path) 
 
     assert result.returncode == 17
     assert commands == ["run sync:generated-contracts"]
+    assert "run dev" not in "\n".join(commands)
     assert "make sync-contracts" in result.stderr

--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -25,6 +25,7 @@ def test_docs_lint_main_passes_current_repo() -> None:
     module = _load_docs_lint_module()
 
     assert module.main() == 0
+    assert _DOCS_LINT.is_file()
 
 
 def test_docs_lint_rejects_stale_documented_make_target(tmp_path: Path) -> None:
@@ -43,3 +44,6 @@ def test_docs_lint_rejects_stale_documented_make_target(tmp_path: Path) -> None:
     assert module._check_make_command_targets(["docs/testing.md"], tmp_path) == [
         "docs/testing.md: documented make target does not exist: removed-target"
     ]
+    assert module._check_make_command_targets(["docs/testing.md"], tmp_path)[0].startswith(
+        "docs/testing.md:"
+    )

--- a/apps/server/tests/hygiene/test_fuzz_tooling_layers.py
+++ b/apps/server/tests/hygiene/test_fuzz_tooling_layers.py
@@ -27,6 +27,7 @@ def test_processing_fuzz_assertions_are_testable_without_cli() -> None:
     assert module.is_sorted_desc([3.0, 2.0, 2.0, 1.0])
     assert not module.is_sorted_desc([1.0, 3.0])
     module.json_no_nan({"value": 1.0})
+    module.json_no_nan({"nested": [{"value": 1.0}]})
     with pytest.raises(ValueError):
         module.json_no_nan({"value": float("nan")})
 
@@ -51,6 +52,7 @@ def test_analysis_summary_assertions_are_testable_without_cli() -> None:
     )
 
     assert validated
+    assert validated[0][1]["rows"] == 2
     with pytest.raises(AssertionError, match="summary findings missing"):
         module.validate_summary(
             {"rows": 2, "run_suitability": {}},
@@ -114,6 +116,7 @@ def test_analysis_scenario_materializer_is_testable_without_cli() -> None:
     assert len(samples) == 1
     assert samples[0]["run_id"] == "fuzz-test"
     assert samples[0]["sample_rate_hz"] == 800
+    assert samples[0]["strength_bucket"] == "l1"
     assert json.dumps(samples, allow_nan=False)
 
 
@@ -124,6 +127,7 @@ def test_common_worker_helpers_are_testable_without_cli() -> None:
     assert module.worker_seed(100, 3) == 103
     assert module.worker_prefix(None) == ""
     assert module.worker_prefix(2) == "[worker 2] "
+    assert module.worker_prefix(0) == "[worker 0] "
 
 
 def test_fuzz_artifact_writers_are_testable_without_cli(tmp_path: Path) -> None:
@@ -142,6 +146,7 @@ def test_fuzz_artifact_writers_are_testable_without_cli(tmp_path: Path) -> None:
     assert processing_payload["case"] == {"value": 1.0}
     assert processing_payload["output"] == {"ok": False}
     assert processing_payload["exception_type"] == "RuntimeError"
+    assert processing_payload["exception_message"] == "boom"
 
     analysis_path = module.write_analysis_failure_artifact(
         case={"metadata": {"run_id": "fuzz-run"}, "samples": []},
@@ -154,3 +159,4 @@ def test_fuzz_artifact_writers_are_testable_without_cli(tmp_path: Path) -> None:
     analysis_payload = json.loads(analysis_path.read_text(encoding="utf-8"))
     assert analysis_payload["summary"] == {"rows": 0}
     assert analysis_payload["exception_type"] == "ValueError"
+    assert analysis_payload["exception_message"] == "bad"

--- a/apps/server/tests/hygiene/test_gitattributes_eol_policy.py
+++ b/apps/server/tests/hygiene/test_gitattributes_eol_policy.py
@@ -70,6 +70,8 @@ def test_high_value_text_patterns_have_explicit_lf_policy() -> None:
     ]
 
     assert missing_or_weak == []
+    assert {"text", "eol=lf"}.issubset(attributes["*.py"])
+    assert {"text", "eol=lf"}.issubset(attributes["*.sh"])
 
 
 def test_required_lf_patterns_cover_tracked_files() -> None:
@@ -82,3 +84,4 @@ def test_required_lf_patterns_cover_tracked_files() -> None:
     ]
 
     assert stale_patterns == []
+    assert "Makefile" in _REQUIRED_LF_PATTERNS

--- a/apps/server/tests/hygiene/test_loc_check.py
+++ b/apps/server/tests/hygiene/test_loc_check.py
@@ -52,4 +52,5 @@ def test_loc_check_reports_file_and_function_size_policy_violations(
     stdout = capsys.readouterr().out
     assert "file exceeds threshold" in stdout
     assert "function exceeds threshold" in stdout
+    assert "2 lines" in stdout
     assert "src/main.py::too_large" in stdout

--- a/apps/server/tests/hygiene/test_operational_errors.py
+++ b/apps/server/tests/hygiene/test_operational_errors.py
@@ -19,14 +19,15 @@ _ALL_OPERATIONAL_EXCEPTIONS = (
 
 def test_operational_base_exception_is_exception() -> None:
     assert issubclass(OperationalError, Exception)
+    assert str(OperationalError("test")) == "test"
 
 
 @pytest.mark.parametrize("exc_cls", _ALL_OPERATIONAL_EXCEPTIONS, ids=lambda cls: cls.__name__)
 def test_operational_errors_catchable_by_base(exc_cls: type[OperationalError]) -> None:
     try:
         raise exc_cls("test")
-    except OperationalError:
-        pass
+    except OperationalError as exc:
+        assert str(exc) == "test"
     else:
         raise AssertionError(f"{exc_cls.__name__} not catchable as OperationalError")
 
@@ -46,3 +47,4 @@ def test_external_command_error_uses_service_unavailable_base() -> None:
 @pytest.mark.parametrize("exc_cls", _ALL_OPERATIONAL_EXCEPTIONS, ids=lambda cls: cls.__name__)
 def test_operational_errors_are_not_domain_errors(exc_cls: type[OperationalError]) -> None:
     assert not issubclass(exc_cls, VibeSensorError)
+    assert not isinstance(exc_cls("test"), VibeSensorError)

--- a/apps/server/tests/hygiene/test_plan_validation.py
+++ b/apps/server/tests/hygiene/test_plan_validation.py
@@ -42,6 +42,7 @@ def test_plan_validation_uses_ci_path_rules_for_docs_only_changes(monkeypatch) -
     assert plan.act_jobs == ("docs-lint",)
     assert plan.local_command[-2:] == ("--job", "docs-lint")
     assert plan.act_command[-2:] == ("-j", "docs-lint")
+    assert "--job" in plan.local_command
     assert plan.parity == "approximate"
     assert plan.unsupported == ()
     assert plan.github_outputs["run_docs_lint"] == "true"
@@ -61,6 +62,7 @@ def test_plan_validation_expands_backend_tests_for_local_runner(monkeypatch) -> 
     assert "backend-tests" in plan.ci_jobs
     assert "backend-tests" in plan.act_jobs
     assert all(f"backend-tests-{index}" in plan.local_jobs for index in range(1, 6))
+    assert "backend-tests-6" not in plan.local_jobs
     assert plan.github_outputs["run_backend_tests"] == "true"
 
 
@@ -80,3 +82,4 @@ def test_plan_validation_marks_release_smoke_as_approximate_not_unsupported(
     assert plan.parity == "approximate"
     assert plan.unsupported == ()
     assert any("ui-build-artifact" in note for note in plan.approximations)
+    assert "release-smoke" in plan.act_jobs

--- a/apps/server/tests/hygiene/test_privacy_guard.py
+++ b/apps/server/tests/hygiene/test_privacy_guard.py
@@ -90,4 +90,5 @@ def test_hooks_run_privacy_guard_with_repo_python_fallbacks() -> None:
         assert "tools/privacy/privacy_guard.py" in hook_text
         assert ".venv/bin/python" in hook_text
         assert "python3" in hook_text
+        assert '"${python_bin}" "${guard_script}"' in hook_text
         assert "Skipping privacy guard" not in hook_text

--- a/apps/server/tests/hygiene/test_repo_tooling_support.py
+++ b/apps/server/tests/hygiene/test_repo_tooling_support.py
@@ -50,6 +50,12 @@ def test_normalize_shell_command_preserves_chains_and_normalizes_command_token()
         )
         == "env FOO=bar python -m pytest && echo done"
     )
+    normalized_fallback = module.normalize_shell_command(
+        "python3 -m pytest || python -m pytest",
+        command_token_normalizer=_normalize_python,
+    )
+    assert normalized_fallback.startswith("python -m pytest")
+    assert "python -m pytest" in normalized_fallback
 
 
 def test_tracked_files_prefers_git_listing(monkeypatch) -> None:
@@ -82,6 +88,10 @@ def test_tracked_files_prefers_git_listing(monkeypatch) -> None:
         "tools/dev/check_hygiene.py",
         "tools/tests/ci_workflow_manifest.py",
     ]
+    assert "tools/tests/ci_workflow_manifest.py" in module.tracked_files(
+        repo_root,
+        excluded_dirs=("tools/tests",),
+    )
 
 
 def test_ensure_repo_python_version_accepts_configured_major_minor(tmp_path: Path) -> None:
@@ -95,6 +105,7 @@ def test_ensure_repo_python_version_accepts_configured_major_minor(tmp_path: Pat
         actual_version="3.13.13",
         executable="/repo/.venv/bin/python",
     )
+    assert (tmp_path / ".python-version").read_text(encoding="utf-8") == "3.13.5\n"
 
 
 def test_ensure_repo_python_version_rejects_wrong_major_minor(tmp_path: Path) -> None:
@@ -121,3 +132,4 @@ def test_direct_local_ci_runners_enforce_repo_python_version() -> None:
     for runner_path in _DIRECT_LOCAL_CI_RUNNERS:
         text = runner_path.read_text(encoding="utf-8")
         assert "ensure_repo_python_version" in text, runner_path
+        assert "script_path=Path(__file__).resolve()" in text, runner_path

--- a/apps/server/tests/hygiene/test_test_suite_governance.py
+++ b/apps/server/tests/hygiene/test_test_suite_governance.py
@@ -36,6 +36,7 @@ def test_inventory_reports_unowned_and_multiply_owned_tests(
         "apps/ui/tests/shared.spec.ts" in error and "owned by multiple UI runners" in error
         for error in errors
     )
+    assert len(errors) == 2
 
 
 def test_marker_policy_reports_fast_lane_blind_spots(
@@ -65,3 +66,4 @@ def test_marker_policy_reports_fast_lane_blind_spots(
     assert any("marked e2e outside apps/server/tests_e2e/" in error for error in errors)
     assert any("marked benchmark but does not live" in error for error in errors)
     assert any("missing module-level pytest.mark.e2e" in error for error in errors)
+    assert len(errors) == 4

--- a/apps/server/tests/shared/test_structured_logging.py
+++ b/apps/server/tests/shared/test_structured_logging.py
@@ -103,12 +103,14 @@ def test_configure_logging_writes_structured_json_file(tmp_path: Path) -> None:
             handler.flush()
 
         payload = json.loads(log_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+        assert payload["level"] == "info"
         assert payload["message"] == "settings_change"
         assert payload["event"] == "settings_change"
         assert payload["request_id"] == request_id
         assert payload["logger"] == "vibesensor.test"
         assert payload["before"] == {"language": "en"}
         assert payload["after"] == {"language": "nl"}
+        assert "timestamp" in payload
     finally:
         for handler in list(root_logger.handlers):
             root_logger.removeHandler(handler)


### PR DESCRIPTION
## What changed
- Tightened repo governance and meta-tooling tests around prerequisite checks, dev workflow npm caching, docs lint failures, fuzz helper outputs, EOL policy, LOC reporting, and validation planning.
- Strengthened operational error hierarchy, privacy hook, repo tooling support, test-suite governance, and structured logging assertions.
- Kept changes test-only and focused on stable behavior contracts.

## Why
Issue #3969 asked to improve repo governance and meta-tooling tests so each case proves specific behavior instead of only exercising the path.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_check_prerequisites.py apps/server/tests/hygiene/test_dev_workflow.py apps/server/tests/hygiene/test_docs_lint.py apps/server/tests/hygiene/test_fuzz_tooling_layers.py apps/server/tests/hygiene/test_gitattributes_eol_policy.py apps/server/tests/hygiene/test_loc_check.py apps/server/tests/hygiene/test_operational_errors.py apps/server/tests/hygiene/test_plan_validation.py apps/server/tests/hygiene/test_privacy_guard.py apps/server/tests/hygiene/test_repo_tooling_support.py apps/server/tests/hygiene/test_test_suite_governance.py apps/server/tests/shared/test_structured_logging.py`
- `make plan-validation`
- `make lint`
- `make typecheck-backend`
- `make test-tooling`

## Risks, tradeoffs, edge cases
- Test-only change.
- Assertions target observable contracts: command outputs, error messages, planned jobs, hook fallbacks, JSON fields, and governance error counts.
- No production behavior changed.

Closes #3969