### PR TITLE
Improve test coverage batch 1

### DIFF
--- a/apps/server/tests/adapters/analysis_summary/test_analysis_summary_edge_cases.py
+++ b/apps/server/tests/adapters/analysis_summary/test_analysis_summary_edge_cases.py
@@ -20,8 +20,12 @@ class TestSummarizeRunDataEdgeCases:
 
     def test_empty_samples_no_crash(self) -> None:
         summary = summarize_run_data(self._MINIMAL_META, [], lang="en")
+        assert summary["run_id"] == "test-edge"
+        assert summary["lang"] == "en"
         assert summary["rows"] == 0
-        assert summary.get("run_suitability") is not None
+        assert summary["duration_s"] == 60.0
+        assert summary["samples"] == []
+        assert summary["run_suitability"]
 
     def test_samples_with_all_none_axes(self) -> None:
         samples: list[dict[str, Any]] = [
@@ -37,6 +41,9 @@ class TestSummarizeRunDataEdgeCases:
         summary = summarize_run_data(self._MINIMAL_META, samples, lang="en")
         assert summary["rows"] == 10
         accel_sanity = summary.get("data_quality", {}).get("accel_sanity", {})
+        assert accel_sanity.get("x_mean") is None
+        assert accel_sanity.get("y_mean") is None
+        assert accel_sanity.get("z_mean") is None
         assert accel_sanity.get("saturation_count") == 0
 
     def test_single_sample_no_crash(self) -> None:
@@ -54,7 +61,10 @@ class TestSummarizeRunDataEdgeCases:
         ]
         summary = summarize_run_data(self._MINIMAL_META, samples, lang="en")
         assert summary["rows"] == 1
-        assert summary.get("findings") is not None
+        assert summary["samples"][0]["client_id"] == "c1"
+        assert summary["samples"][0]["location"] == "front"
+        assert summary["samples"][0]["vibration_strength_db"] == 5.0
+        assert summary["findings"]
 
     def test_nl_lang_no_crash(self) -> None:
         summary = summarize_run_data(self._MINIMAL_META, [], lang="nl")
@@ -63,3 +73,5 @@ class TestSummarizeRunDataEdgeCases:
     def test_missing_metadata_fields(self) -> None:
         summary = summarize_run_data({"run_id": "minimal"}, [], lang="en")
         assert summary["run_id"] == "minimal"
+        assert summary["duration_s"] == 0.0
+        assert summary["sensor_model"] == "unknown"

--- a/apps/server/tests/adapters/gps/test_gps_reconnect_backoff.py
+++ b/apps/server/tests/adapters/gps/test_gps_reconnect_backoff.py
@@ -20,14 +20,13 @@ class TestGPSReconnectBackoff:
     @pytest.mark.asyncio
     async def test_reconnect_delay_doubles_and_caps(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monitor = GPSSpeedMonitor(gps_enabled=True)
-        delays_seen: list[float] = []
+        retry_delays: list[float] = []
 
         connect_count = 0
 
         async def _mock_open_connection(host, port):
             nonlocal connect_count
             connect_count += 1
-            delays_seen.append(monitor.current_reconnect_delay)
             if connect_count >= 5:
                 raise asyncio.CancelledError()
             raise ConnectionRefusedError("test")
@@ -35,6 +34,7 @@ class TestGPSReconnectBackoff:
         original_sleep = asyncio.sleep
 
         async def _fast_sleep(delay):
+            retry_delays.append(delay)
             await original_sleep(0)
 
         monkeypatch.setattr(asyncio, "open_connection", _mock_open_connection)
@@ -43,11 +43,13 @@ class TestGPSReconnectBackoff:
         with pytest.raises(asyncio.CancelledError):
             await monitor.run(host="127.0.0.1", port=29470)
 
-        assert delays_seen[0] == GPS_RECONNECT_DELAY_S
-        for i in range(1, min(3, len(delays_seen))):
-            assert delays_seen[i] >= delays_seen[i - 1]
-        for delay in delays_seen:
-            assert delay <= GPS_RECONNECT_MAX_DELAY_S
+        assert connect_count == 5
+        assert retry_delays == [
+            GPS_RECONNECT_DELAY_S,
+            GPS_RECONNECT_DELAY_S * 2,
+            GPS_RECONNECT_DELAY_S * 4,
+            GPS_RECONNECT_MAX_DELAY_S,
+        ]
 
     @pytest.mark.asyncio
     async def test_version_message_sets_device_info(self) -> None:

--- a/apps/server/tests/adapters/gps/test_gps_speed_extended.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_extended.py
@@ -23,13 +23,18 @@ async def test_run_can_be_cancelled_while_gps_stream_hangs() -> None:
     server = await asyncio.start_server(_handler, host="127.0.0.1", port=0)
     host, port = server.sockets[0].getsockname()[:2]
     task = asyncio.create_task(monitor.run(host=host, port=port))
-    await asyncio.wait_for(client_connected.wait(), timeout=1.0)
-    task.cancel()
-    results = await asyncio.gather(task, return_exceptions=True)
-    assert isinstance(results[0], asyncio.CancelledError)
-    assert monitor.speed_mps is None
-    server.close()
-    await server.wait_closed()
+    try:
+        await asyncio.wait_for(client_connected.wait(), timeout=1.0)
+        task.cancel()
+        results = await asyncio.gather(task, return_exceptions=True)
+        assert isinstance(results[0], asyncio.CancelledError)
+        assert monitor.speed_mps is None
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        server.close()
+        await server.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -69,8 +74,14 @@ async def test_run_cancellation_waits_writer_close_once(
 
     monkeypatch.setattr(asyncio, "open_connection", _open_connection)
     task = asyncio.create_task(monitor.run(host="127.0.0.1", port=2947))
-    await asyncio.wait_for(read_started.wait(), timeout=1.0)
-    task.cancel()
-    await asyncio.gather(task, return_exceptions=True)
-    assert fake_writer.wait_closed_calls == 1
-    assert monitor.speed_mps is None
+    try:
+        await asyncio.wait_for(read_started.wait(), timeout=1.0)
+        task.cancel()
+        results = await asyncio.gather(task, return_exceptions=True)
+        assert isinstance(results[0], asyncio.CancelledError)
+        assert fake_writer.wait_closed_calls == 1
+        assert monitor.speed_mps is None
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)

--- a/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
@@ -188,31 +188,36 @@ async def test_run_reconnects_on_connection_failure(
     caplog.set_level("WARNING")
 
     task = asyncio.create_task(monitor.run(host="127.0.0.1", port=9999))
-    await asyncio.wait_for(enough_attempts.wait(), timeout=5.0)
-    await _await_condition(
-        "GPS reconnect error state after refused connections",
-        lambda: (
-            attempt_count >= 2
-            and monitor.last_error == "mock refused"
-            and 0.02 <= monitor.current_reconnect_delay <= 0.04
-        ),
-        timeout_s=5.0,
-    )
+    try:
+        await asyncio.wait_for(enough_attempts.wait(), timeout=5.0)
+        await _await_condition(
+            "GPS reconnect error state after refused connections",
+            lambda: (
+                attempt_count >= 2
+                and monitor.last_error == "mock refused"
+                and 0.02 <= monitor.current_reconnect_delay <= 0.04
+            ),
+            timeout_s=5.0,
+        )
 
-    assert attempt_count >= 2, f"Expected at least 2 attempts, got {attempt_count}"
-    assert monitor.speed_mps is None
-    assert monitor.last_error == "mock refused"
-    assert 0.02 <= monitor.current_reconnect_delay <= 0.04
+        assert attempt_count >= 2, f"Expected at least 2 attempts, got {attempt_count}"
+        assert monitor.speed_mps is None
+        assert monitor.last_error == "mock refused"
+        assert 0.02 <= monitor.current_reconnect_delay <= 0.04
 
-    task.cancel()
-    await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=5.0)
+        task.cancel()
+        await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=5.0)
 
-    assert "GPS connection lost, retrying" in caplog.text
-    reconnect_records = [
-        record for record in caplog.records if "GPS connection lost, retrying" in record.message
-    ]
-    assert reconnect_records
-    assert all(record.exc_info is None for record in reconnect_records)
+        assert "GPS connection lost, retrying" in caplog.text
+        reconnect_records = [
+            record for record in caplog.records if "GPS connection lost, retrying" in record.message
+        ]
+        assert reconnect_records
+        assert all(record.exc_info is None for record in reconnect_records)
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -235,11 +240,15 @@ async def test_run_does_not_swallow_processing_programming_errors() -> None:
     host, port = server.sockets[0].getsockname()[:2]
     task = asyncio.create_task(monitor.run(host=host, port=port))
 
-    with pytest.raises(RuntimeError, match="bug"):
-        await asyncio.wait_for(task, timeout=1.0)
-
-    server.close()
-    await server.wait_closed()
+    try:
+        with pytest.raises(RuntimeError, match="bug"):
+            await asyncio.wait_for(task, timeout=1.0)
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        server.close()
+        await server.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -270,29 +279,35 @@ async def test_run_resets_speed_on_disconnect(monkeypatch: pytest.MonkeyPatch) -
     )
 
     task = asyncio.create_task(monitor.run(host=host, port=port))
+    server_closed = False
+    try:
+        await _await_condition(
+            "GPS speed to update before server disconnect",
+            lambda: monitor.speed_mps == 42.0,
+            timeout_s=2.0,
+        )
+        assert monitor.speed_mps == 42.0
 
-    await _await_condition(
-        "GPS speed to update before server disconnect",
-        lambda: monitor.speed_mps == 42.0,
-        timeout_s=2.0,
-    )
-    assert monitor.speed_mps == 42.0
+        # After the server closes, the client detects EOF and the except block
+        # resets speed_mps to None on the next failed reconnect attempt.
+        # The server is already closed; the next connect attempt will fail.
+        server.close()
+        await server.wait_closed()
+        server_closed = True
 
-    # After the server closes, the client detects EOF and the except block
-    # resets speed_mps to None on the next failed reconnect attempt.
-    # The server is already closed; the next connect attempt will fail.
-    server.close()
-    await server.wait_closed()
-
-    await _await_condition(
-        "GPS speed to clear after disconnect and failed reconnect",
-        lambda: monitor.speed_mps is None,
-        timeout_s=5.0,
-    )
-    assert monitor.speed_mps is None
-
-    task.cancel()
-    await asyncio.gather(task, return_exceptions=True)
+        await _await_condition(
+            "GPS speed to clear after disconnect and failed reconnect",
+            lambda: monitor.speed_mps is None,
+            timeout_s=5.0,
+        )
+        assert monitor.speed_mps is None
+    finally:
+        if not server_closed:
+            server.close()
+            await server.wait_closed()
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -322,13 +337,15 @@ async def test_run_disabled_polls_without_connecting(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(asyncio, "sleep", _spy_sleep)
 
     task = asyncio.create_task(monitor.run())
-    await asyncio.wait_for(disabled_poll_seen.wait(), timeout=1.0)
+    try:
+        await asyncio.wait_for(disabled_poll_seen.wait(), timeout=1.0)
 
-    assert monitor.speed_mps is None
-    assert not connection_attempted
-
-    task.cancel()
-    await asyncio.gather(task, return_exceptions=True)
+        assert monitor.speed_mps is None
+        assert not connection_attempted
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/adapters/gps/test_parse_manual_speed.py
+++ b/apps/server/tests/adapters/gps/test_parse_manual_speed.py
@@ -19,6 +19,7 @@ from vibesensor.shared.types.speed_source_config import SpeedSourceConfig
         pytest.param(math.inf, None, id="inf-rejected"),
         pytest.param(-math.inf, None, id="neg-inf-rejected"),
         pytest.param(math.nan, None, id="nan-rejected"),
+        pytest.param(True, None, id="bool-rejected"),
         pytest.param(-1, None, id="negative-rejected"),
         pytest.param(0, None, id="zero-rejected"),
         pytest.param(500.1, None, id="above-upper-bound-rejected"),

--- a/apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 from vibesensor.cli.hotspot_config import main
 
 
@@ -20,21 +22,32 @@ def _run_cli(
     return captured.out, captured.err
 
 
-def test_hotspot_config_cli_warns_and_falls_back_on_parse_error(
+@pytest.mark.parametrize(
+    ("config_text", "expected_warning"),
+    [
+        pytest.param("ap: [unterminated\n", "Failed to parse hotspot config", id="parse-error"),
+        pytest.param("- item\n", "must contain a top-level mapping", id="top-level-list"),
+        pytest.param("ap: disabled\n", "has a non-mapping 'ap' section", id="ap-not-mapping"),
+    ],
+)
+def test_hotspot_config_cli_warns_and_falls_back_on_invalid_config(
     tmp_path: Path,
     monkeypatch,
     capsys,
+    config_text: str,
+    expected_warning: str,
 ) -> None:
     missing_path = tmp_path / "missing.yaml"
     defaults_out, defaults_err = _run_cli(missing_path, monkeypatch=monkeypatch, capsys=capsys)
     assert defaults_err == ""
 
     broken_path = tmp_path / "broken.yaml"
-    broken_path.write_text("ap: [unterminated\n", encoding="utf-8")
+    broken_path.write_text(config_text, encoding="utf-8")
 
     broken_out, broken_err = _run_cli(broken_path, monkeypatch=monkeypatch, capsys=capsys)
 
     assert broken_out == defaults_out
     assert "WARNING:" in broken_err
     assert str(broken_path) in broken_err
+    assert expected_warning in broken_err
     assert "using defaults" in broken_err

--- a/apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py
@@ -11,7 +11,17 @@ import pytest
 from vibesensor.cli.hotspot_self_heal import main
 
 
-def test_hotspot_self_heal_cli_loads_config_and_runs_diagnostics() -> None:
+@pytest.mark.parametrize(
+    ("mode", "expected_diagnostics_only"),
+    [
+        pytest.param("diagnostics", True, id="diagnostics-mode"),
+        pytest.param("check-heal", False, id="check-heal-mode"),
+    ],
+)
+def test_hotspot_self_heal_cli_loads_config_and_runs_selected_mode(
+    mode: str,
+    expected_diagnostics_only: bool,
+) -> None:
     config = SimpleNamespace(ap=SimpleNamespace(), self_heal=SimpleNamespace())
     config.ap.self_heal = config.self_heal
 
@@ -20,7 +30,7 @@ def test_hotspot_self_heal_cli_loads_config_and_runs_diagnostics() -> None:
             "argparse.ArgumentParser.parse_args",
             return_value=SimpleNamespace(
                 config=Path("/tmp/test-config.yaml"),
-                mode="diagnostics",
+                mode=mode,
             ),
         ),
         patch("vibesensor.cli.hotspot_self_heal.load_config", return_value=config) as load_config,
@@ -32,5 +42,9 @@ def test_hotspot_self_heal_cli_loads_config_and_runs_diagnostics() -> None:
 
     assert exc_info.value.code == 0
     load_config.assert_called_once_with(Path("/tmp/test-config.yaml"))
-    run_self_heal.assert_called_once_with(config.ap, config.ap.self_heal, diagnostics_only=True)
+    run_self_heal.assert_called_once_with(
+        config.ap,
+        config.ap.self_heal,
+        diagnostics_only=expected_diagnostics_only,
+    )
     basic_config.assert_called_once()

--- a/apps/server/tests/adapters/http/test_api_history_delete_run.py
+++ b/apps/server/tests/adapters/http/test_api_history_delete_run.py
@@ -16,6 +16,16 @@ from fastapi.testclient import TestClient
 from vibesensor.adapters.analysis_summary import summarize_run_data
 
 
+def test_delete_run_returns_deleted_status_for_safe_run() -> None:
+    app, _ = make_app_and_state(language="en")
+
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 200
+    assert response.json() == {"run_id": "run-1", "status": "deleted"}
+
+
 def test_delete_active_run_returns_409() -> None:
     @dataclass
     class ActiveDB(FakeHistoryDB):

--- a/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
@@ -72,6 +72,7 @@ def test_history_export_uses_streaming_response() -> None:
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
+    assert response.headers["content-disposition"] == 'attachment; filename="run-1.zip"'
     content_length = response.headers.get("content-length")
     assert content_length is not None
     assert int(content_length) > 0

--- a/apps/server/tests/adapters/http/test_recording_endpoints.py
+++ b/apps/server/tests/adapters/http/test_recording_endpoints.py
@@ -151,13 +151,24 @@ class TestRecordingStatusEndpoint:
 
 class TestRecordingStartEndpoint:
     def test_start_returns_running_status(self, _recording_client) -> None:
-        client, _state = _recording_client
+        client, state = _recording_client
 
         response = client.post("/api/recording/start")
 
         assert response.status_code == 200
-        assert response.json()["enabled"] is True
-        assert response.json()["run_id"] == "run-abc"
+        assert response.json() == {
+            "enabled": True,
+            "run_id": "run-abc",
+            "write_error": None,
+            "analysis_in_progress": False,
+            "start_time_utc": None,
+            "samples_written": 42,
+            "samples_dropped": 0,
+            "last_completed_run_id": None,
+            "last_completed_run_error": None,
+            "capture_readiness": None,
+        }
+        state.run_recorder.start_recording.assert_called_once_with()
 
     def test_start_when_already_recording_returns_status(self, _recording_client) -> None:
         """start_recording is idempotent — called again it still returns a valid status."""
@@ -180,12 +191,24 @@ class TestRecordingStartEndpoint:
 
 class TestRecordingStopEndpoint:
     def test_stop_returns_idle_status(self, _recording_client) -> None:
-        client, _state = _recording_client
+        client, state = _recording_client
 
         response = client.post("/api/recording/stop")
 
         assert response.status_code == 200
-        assert response.json()["enabled"] is False
+        assert response.json() == {
+            "enabled": False,
+            "run_id": None,
+            "write_error": None,
+            "analysis_in_progress": False,
+            "start_time_utc": None,
+            "samples_written": 0,
+            "samples_dropped": 0,
+            "last_completed_run_id": None,
+            "last_completed_run_error": None,
+            "capture_readiness": None,
+        }
+        state.run_recorder.stop_recording.assert_called_once_with()
 
     def test_stop_when_not_recording_returns_idle_status(self, _recording_client) -> None:
         """stop_recording when not recording is safe — returns idle status."""

--- a/apps/server/tests/adapters/http/test_safe_filename.py
+++ b/apps/server/tests/adapters/http/test_safe_filename.py
@@ -16,6 +16,8 @@ class TestSafeFilename:
             pytest.param("run-2026-01-01_abc", "run-2026-01-01_abc", id="safe-name-kept"),
             pytest.param("", "download", id="empty-name-uses-download"),
             pytest.param("///", "___", id="path-separators-replaced"),
+            pytest.param(".hidden", "hidden", id="leading-dot-stripped"),
+            pytest.param("...", "download", id="dot-only-name-uses-download"),
             pytest.param(
                 "run/with spaces & $pecial",
                 "run_with_spaces____pecial",
@@ -28,4 +30,4 @@ class TestSafeFilename:
 
     def test_long_name_truncated(self) -> None:
         result = _safe_filename("a" * 500)
-        assert len(result) <= 200
+        assert result == "a" * 200

--- a/apps/server/tests/adapters/http/test_update_endpoints.py
+++ b/apps/server/tests/adapters/http/test_update_endpoints.py
@@ -197,6 +197,7 @@ def test_cancel_update_returns_cancelled_flag(update_client) -> None:
 
     assert response.status_code == 200
     assert response.json() == {"cancelled": True}
+    state.update_manager.cancel.assert_called_once_with()
 
 
 def test_list_esp_flash_ports_returns_detected_ports(update_client) -> None:
@@ -334,6 +335,7 @@ def test_cancel_esp_flash_returns_cancelled_flag(update_client) -> None:
 
     assert response.status_code == 200
     assert response.json() == {"cancelled": True}
+    state.esp_flash_manager.cancel.assert_called_once_with()
 
 
 def test_get_esp_flash_history_returns_attempts(update_client) -> None:

--- a/apps/server/tests/adapters/http/test_ws_message_router.py
+++ b/apps/server/tests/adapters/http/test_ws_message_router.py
@@ -45,3 +45,13 @@ async def test_route_ws_message_applies_valid_selection() -> None:
     await route_ws_message(hub, ws, json.dumps({"client_id": "AA:BB:CC:DD:EE:FF"}))
 
     hub.update_selected_client.assert_awaited_once_with(ws, "aabbccddeeff")
+
+
+@pytest.mark.asyncio
+async def test_route_ws_message_clears_selection_when_client_id_is_null() -> None:
+    hub = AsyncMock()
+    ws = AsyncMock()
+
+    await route_ws_message(hub, ws, json.dumps({"client_id": None}))
+
+    hub.update_selected_client.assert_awaited_once_with(ws, None)

--- a/apps/server/tests/adapters/pdf/test_report_cli.py
+++ b/apps/server/tests/adapters/pdf/test_report_cli.py
@@ -24,3 +24,33 @@ def test_main_returns_error(tmp_path: Path, content: str | None) -> None:
         input_file.write_text(content)
     with patch("sys.argv", ["vibesensor-report", str(input_file)]):
         assert main() == 1
+
+
+def test_main_writes_pdf_and_optional_summary_json(tmp_path: Path) -> None:
+    input_file = tmp_path / "input.jsonl"
+    output_file = tmp_path / "out" / "report.pdf"
+    summary_file = tmp_path / "out" / "summary.json"
+    input_file.write_text('{"record_type":"metadata"}\n', encoding="utf-8")
+    summary = {"run_id": "run-1", "rows": 1}
+
+    with (
+        patch(
+            "sys.argv",
+            [
+                "vibesensor-report",
+                str(input_file),
+                "--output",
+                str(output_file),
+                "--summary-json",
+                str(summary_file),
+            ],
+        ),
+        patch("vibesensor.cli.report.summarize_log", return_value=summary) as summarize_log,
+        patch("vibesensor.cli.report.prepare_report_input", return_value=object()),
+        patch("vibesensor.cli.report.build_prepared_report_pdf", return_value=b"%PDF-test"),
+    ):
+        assert main() == 0
+
+    summarize_log.assert_called_once_with(input_file, include_samples=True)
+    assert output_file.read_bytes() == b"%PDF-test"
+    assert summary_file.read_text(encoding="utf-8").startswith('{\n  "run_id": "run-1"')

--- a/apps/server/vibesensor/shared/types/speed_source_config.py
+++ b/apps/server/vibesensor/shared/types/speed_source_config.py
@@ -45,7 +45,7 @@ class SpeedSourcePayload(TypedDict):
 
 def _parse_manual_speed(value: object) -> float | None:
     """Return a positive, finite float speed (≤500 km/h) or None."""
-    if isinstance(value, NUMERIC_TYPES):
+    if isinstance(value, NUMERIC_TYPES) and not isinstance(value, bool):
         speed = float(value)
         if _isfinite(speed) and 0 < speed <= 500:
             return speed


### PR DESCRIPTION
Batch 1. Medium PR.

Files processed: 100.
Files changed: 15.

What changed:
- Tightened analysis-summary, GPS, hotspot, HTTP, and report CLI tests.
- Added stronger endpoint payload and dispatch assertions.
- Added report CLI success coverage for PDF and optional summary JSON writes.
- Added manual-speed bool rejection because bool is an int subclass and is not a valid speed.

Why:
- These tests had useful gaps: weak assertions, missing dispatch checks, and missing success-path coverage.
- Good tests were kept unchanged after review.

Validation:
- Focused pytest runs for each processed cluster passed.
- `make plan-validation` generated the expected backend-focused plan.
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" ./.venv/bin/python tools/tests/plan_validation.py --run` passed repo-hygiene, backend-lint, backend-static-guards, backend-preflight, backend-contract-drift, backend-typecheck, backend-tests shards 1/2/3/5, backend-tooling-tests, release-smoke, and e2e.
- Same run failed backend-tests-4 on existing raw-capture queue-full tests outside this batch; focused rerun of the first failing raw-capture test passed.

Risks and edge cases:
- Low product risk. Product change is limited to rejecting boolean manual speed inputs.
- Tests now pin exact response shapes in selected HTTP paths, so intentional API response changes will need test updates.

Kept unchanged:
- Most processed helpers/PDF/report scenario tests already had strong behavior, rendering, localization, and pipeline coverage. Kept unchanged with tracker notes.

Follow-ups:
- Continue batch 2 after this PR merges.
