### PR TITLE
Improve backend tests batch 2

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -232,11 +232,8 @@ def test_create_run_does_not_auto_recover_recording(tmp_path: Path) -> None:
     """create_run no longer auto-recovers stale recordings — startup does that."""
     db = create_history_persistence_adapters(tmp_path / "history.db")
     db.run_repository.create_run("run-old", "2026-01-01T00:00:00Z", _metadata("run-old"))
-    # Second create should fail (unique constraint) — old run stays recording
-    try:
+    with pytest.raises(sqlite3.IntegrityError):
         db.run_repository.create_run("run-old", "2026-01-01T00:01:00Z", _metadata("run-old"))
-    except Exception:
-        pass
     old_run = db.run_repository.get_run("run-old")
     assert old_run is not None and old_run.status.value == "recording"
 
@@ -256,13 +253,10 @@ def test_create_run_persists_case_id(tmp_path: Path) -> None:
     assert run.case_id == "case-123"
 
 
-def test_recover_stale_recording_logs_warning(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_recover_stale_recording_marks_run_error(tmp_path: Path) -> None:
     db = create_history_persistence_adapters(tmp_path / "history.db")
     db.run_repository.create_run("run-old", "2026-01-01T00:00:00Z", _metadata("run-old"))
-    with caplog.at_level(logging.WARNING):
-        recovered = db.run_repository.recover_stale_recording_runs()
+    recovered = db.run_repository.recover_stale_recording_runs()
     assert recovered == 1
     run = db.run_repository.get_run("run-old")
     assert run is not None and run.status.value == "error"

--- a/apps/server/tests/adapters/persistence/test_car_variants.py
+++ b/apps/server/tests/adapters/persistence/test_car_variants.py
@@ -36,13 +36,12 @@ def test_resolve_variant_no_variant() -> None:
 
 def test_resolve_variant_inherits_base_gearboxes() -> None:
     """Variant without gearbox override inherits base gearboxes."""
-    # Find a model where first variant has no gearbox override
-    for entry in _library_entries():
-        first_v = entry["variants"][0]
-        if not first_v.get("gearboxes"):
-            resolved = resolve_variant(entry, first_v["name"])
-            assert resolved["gearboxes"] == entry["gearboxes"]
-            break
+    entry = next(entry for entry in _library_entries() if not entry["variants"][0].get("gearboxes"))
+    first_variant = entry["variants"][0]
+
+    resolved = resolve_variant(entry, first_variant["name"])
+
+    assert resolved["gearboxes"] == entry["gearboxes"]
 
 
 def test_resolve_variant_unknown_name_returns_base() -> None:

--- a/apps/server/tests/app/test_config_validation.py
+++ b/apps/server/tests/app/test_config_validation.py
@@ -48,18 +48,23 @@ class TestPositiveIntegerClamping:
     """Zero and negative values for positive-int fields are clamped to 1."""
 
     @pytest.mark.parametrize(
-        "field",
+        ("field", "expected"),
         [
-            "sample_rate_hz",
-            "waveform_seconds",
-            "client_live_ttl_seconds",
-            "client_ttl_seconds",
+            pytest.param("sample_rate_hz", 1, id="sample-rate"),
+            pytest.param("waveform_seconds", 1, id="waveform-seconds"),
+            pytest.param("client_live_ttl_seconds", 1, id="live-ttl"),
+            pytest.param("client_ttl_seconds", 10, id="retention-ttl"),
         ],
     )
     @pytest.mark.parametrize("bad_value", [0, -1, -100])
-    def test_zero_and_negative_clamped_to_minimum(self, field: str, bad_value: int) -> None:
+    def test_zero_and_negative_clamped_to_minimum(
+        self,
+        field: str,
+        expected: int,
+        bad_value: int,
+    ) -> None:
         cfg = _make_processing(**{field: bad_value})
-        assert getattr(cfg, field) >= 1
+        assert getattr(cfg, field) == expected
 
     @pytest.mark.parametrize(
         "field",
@@ -86,7 +91,7 @@ class TestLoadConfigValidation:
         config_path = tmp_path / "config.yaml"
         _write_config(config_path, {"processing": {field: 0}})
         cfg = load_config(config_path)
-        assert getattr(cfg.processing, field) >= 1, f"{field} should be clamped to >= 1"
+        assert getattr(cfg.processing, field) == 1
 
     def test_default_config_passes_validation(self, tmp_path: Path) -> None:
         """Empty override → defaults must all pass validation unchanged."""
@@ -199,23 +204,23 @@ class TestLoggingConfigValidation:
 
     def test_zero_metrics_log_hz_clamped(self) -> None:
         cfg = self._make(metrics_log_hz=0)
-        assert cfg.metrics_log_hz >= 1
+        assert cfg.metrics_log_hz == 1
 
     def test_negative_no_data_timeout_clamped(self) -> None:
         cfg = self._make(no_data_timeout_s=-5.0)
-        assert cfg.no_data_timeout_s >= 0
+        assert cfg.no_data_timeout_s == 15.0
 
     def test_negative_shutdown_timeout_clamped(self) -> None:
         cfg = self._make(shutdown_analysis_timeout_s=-1.0)
-        assert cfg.shutdown_analysis_timeout_s >= 0
+        assert cfg.shutdown_analysis_timeout_s == 30.0
 
     def test_non_positive_run_retention_days_clamped(self) -> None:
         cfg = self._make(run_retention_days=0)
-        assert cfg.run_retention_days >= 1
+        assert cfg.run_retention_days == 7
 
     def test_non_positive_raw_capture_retention_days_clamped(self) -> None:
         cfg = self._make(raw_capture_retention_days=0)
-        assert cfg.raw_capture_retention_days >= 1
+        assert cfg.raw_capture_retention_days == 7
 
 
 class TestTracingConfigValidation:


### PR DESCRIPTION
## Batch
2

## Files processed
100 test files, #101-#200.

## Files changed
3 test files.

## What changed
- Tightened HistoryDB lifecycle assertions around duplicate run creation and stale recording recovery.
- Made car variant inheritance test fail if no matching fixture exists.
- Replaced broad config-clamp assertions with exact final values.

## Why
The tests now prove the intended behavior directly instead of accepting broad outcomes or silently passing when fixture assumptions break.

## Validation
- Focused PDF/report cluster: 64 passed.
- Focused HistoryDB cluster: 106 passed.
- Focused persistence cluster: 107 passed.
- Focused simulator cluster: 32 passed.
- Focused speed/UDP cluster: 112 passed.
- Focused WebSocket cluster: 70 passed.
- Focused app cluster: 140 passed.
- Focused domain cluster: 414 passed.
- Changed-file focused rerun: 162 passed.
- `make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/plan_validation.py --run`

## Kept unchanged
Most processed files already had useful behavior coverage: PDF/report contracts, HistoryDB persistence behavior, simulator/speed/UDP/WebSocket edge cases, app bootstrap/config behavior, and domain value-object invariants.

## Risks and edge cases
Low risk. Test-only changes. No product behavior changes.

## Follow-ups
None.
