### PR TITLE
Improve batch 3 test assertions

### DIFF
--- a/apps/server/tests/hygiene/test_operational_errors.py
+++ b/apps/server/tests/hygiene/test_operational_errors.py
@@ -24,12 +24,10 @@ def test_operational_base_exception_is_exception() -> None:
 
 @pytest.mark.parametrize("exc_cls", _ALL_OPERATIONAL_EXCEPTIONS, ids=lambda cls: cls.__name__)
 def test_operational_errors_catchable_by_base(exc_cls: type[OperationalError]) -> None:
-    try:
+    with pytest.raises(OperationalError) as exc_info:
         raise exc_cls("test")
-    except OperationalError as exc:
-        assert str(exc) == "test"
-    else:
-        raise AssertionError(f"{exc_cls.__name__} not catchable as OperationalError")
+
+    assert str(exc_info.value) == "test"
 
 
 def test_operational_error_base_is_direct_exception_subclass() -> None:

--- a/apps/server/tests/hygiene/test_publish_github_release.py
+++ b/apps/server/tests/hygiene/test_publish_github_release.py
@@ -160,17 +160,14 @@ def test_run_reports_timeout_with_command_context(monkeypatch) -> None:
 
     monkeypatch.setattr(module.subprocess, "run", _timeout)
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         module._run(
             ["gh", "api", "repos/owner/repo/releases"],
             capture_output=True,
             context="Create release 'server-v1' in owner/repo",
             timeout_s=5,
         )
-    except SystemExit as exc:
-        message = str(exc)
-    else:
-        raise AssertionError("Expected SystemExit")
+    message = str(exc_info.value)
 
     assert "Create release 'server-v1' in owner/repo timed out after 5s" in message
     assert "command: gh api repos/owner/repo/releases" in message
@@ -191,17 +188,14 @@ def test_run_reports_nonzero_exit_with_output_excerpt(monkeypatch) -> None:
 
     monkeypatch.setattr(module.subprocess, "run", _failed)
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         module._run(
             ["gh", "release", "upload"],
             capture_output=True,
             context="Upload 1 asset(s) to release 'server-v1' in owner/repo",
             timeout_s=30,
         )
-    except SystemExit as exc:
-        message = str(exc)
-    else:
-        raise AssertionError("Expected SystemExit")
+    message = str(exc_info.value)
 
     assert "failed with exit code 2" in message
     assert "command: gh release upload" in message
@@ -224,12 +218,9 @@ def test_existing_release_id_reports_malformed_json(monkeypatch) -> None:
 
     monkeypatch.setattr(module, "_run", _fake_run)
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         module._existing_release_id("owner/repo", "server-v2026.3.28", timeout_s=10)
-    except SystemExit as exc:
-        message = str(exc)
-    else:
-        raise AssertionError("Expected SystemExit")
+    message = str(exc_info.value)
 
     assert "Malformed GitHub release lookup JSON" in message
     assert "server-v2026.3.28" in message

--- a/apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py
+++ b/apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from test_support.settings_services import PersistedSettingsServices, build_settings_services
 
+from vibesensor.domain import normalize_sensor_id
 from vibesensor.infra.processing import ClientBuffer, SignalProcessor
 from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.use_cases.diagnostics._counters import counter_delta
@@ -179,7 +180,7 @@ class TestSettingsStoreRollbackDbFailure:
 
         # Sensor should not exist after rollback
         sensors = store.sensor_settings.get_sensors()
-        normalized = mac.upper().replace(":", "")
+        normalized = normalize_sensor_id(mac)
         assert normalized not in sensors
 
     def test_assign_sensor_location_rollback_existing_sensor(
@@ -196,6 +197,6 @@ class TestSettingsStoreRollbackDbFailure:
 
         # Should have original values
         sensors = store.sensor_settings.get_sensors()
-        normalized = mac.upper().replace(":", "")
+        normalized = normalize_sensor_id(mac)
         assert sensors[normalized]["name"] == "Rear Left Wheel"
         assert sensors[normalized]["location_code"] == "rear_left_wheel"

--- a/apps/server/tests/infra/runtime/test_lifecycle_manager_public_state.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle_manager_public_state.py
@@ -65,19 +65,20 @@ async def test_start_marks_runtime_ready_and_tracks_running_tasks() -> None:
     )
 
     await lifecycle.start()
-    await _wait_until(lambda: "processing-loop" in lifecycle.tasks)
+    try:
+        await _wait_until(lambda: "processing-loop" in lifecycle.tasks)
 
-    assert {
-        "processing-loop",
-        "ws-broadcast",
-        "metrics-log",
-        "gps-speed",
-        "obd-speed",
-    }.issubset(set(lifecycle.tasks))
-    assert runtime_state.health_state.startup_state == "ready"
-    assert runtime_state.health_state.startup_phase == "ready"
-
-    await lifecycle.stop()
+        assert {
+            "processing-loop",
+            "ws-broadcast",
+            "metrics-log",
+            "gps-speed",
+            "obd-speed",
+        }.issubset(set(lifecycle.tasks))
+        assert runtime_state.health_state.startup_state == "ready"
+        assert runtime_state.health_state.startup_phase == "ready"
+    finally:
+        await lifecycle.stop()
 
 
 @pytest.mark.asyncio
@@ -114,11 +115,14 @@ async def test_start_records_background_task_failure_in_health_state() -> None:
     )
 
     await lifecycle.start()
-    await _wait_until(lambda: "ws-broadcast" in runtime_state.health_state.background_task_failures)
+    try:
+        await _wait_until(
+            lambda: "ws-broadcast" in runtime_state.health_state.background_task_failures
+        )
 
-    assert runtime_state.health_state.background_task_failures["ws-broadcast"] == "ws boom"
-
-    await lifecycle.stop()
+        assert runtime_state.health_state.background_task_failures["ws-broadcast"] == "ws boom"
+    finally:
+        await lifecycle.stop()
 
 
 @pytest.mark.asyncio
@@ -171,12 +175,13 @@ async def test_start_clears_restartable_failure_after_successful_retry(
     monkeypatch.setattr("vibesensor.infra.runtime.task_supervisor.anyio.sleep", _fast_sleep)
 
     await lifecycle.start()
-    await asyncio.wait_for(restart_started.wait(), timeout=1.0)
+    try:
+        await asyncio.wait_for(restart_started.wait(), timeout=1.0)
 
-    assert ws_run_calls["count"] == 2
-    assert runtime_state.health_state.background_task_failures == {}
-
-    await lifecycle.stop()
+        assert ws_run_calls["count"] == 2
+        assert runtime_state.health_state.background_task_failures == {}
+    finally:
+        await lifecycle.stop()
 
 
 @pytest.mark.asyncio
@@ -229,9 +234,10 @@ async def test_stop_cleans_owned_resources_once_and_clears_public_tasks() -> Non
     )
 
     await lifecycle.start()
-    await _wait_until(lambda: bool(lifecycle.tasks))
-
-    await lifecycle.stop()
+    try:
+        await _wait_until(lambda: bool(lifecycle.tasks))
+    finally:
+        await lifecycle.stop()
 
     assert lifecycle.tasks == []
     run_recorder.shutdown_report.assert_called_once_with(5.0)


### PR DESCRIPTION
Batch 3 test pass.

Processed: 100 files (#201-#300)
Changed: 4 test files
Size: small

What changed:
- Replaced manual expected-exception try/except blocks with `pytest.raises` in operational-error and GitHub release helper tests.
- Reused production `normalize_sensor_id()` in settings rollback regression assertions so the test checks the real persisted key.
- Wrapped lifecycle-manager async assertions in `finally` cleanup so started runtime tasks are stopped on assertion failure.

Why:
- The exception tests now fail through pytest's native assertion path.
- The rollback test no longer risks passing because of hand-written MAC normalization drift.
- Lifecycle tests preserve cleanup when assertions fail.

Validation:
- `./.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_history_db_mixins.py ... apps/server/tests/hygiene/test_watch_pr_checks.py` — 146 passed.
- `./.venv/bin/python -m pytest -q apps/server/tests/infra/config/test_car_settings.py ... apps/server/tests/infra/runtime/test_lifecycle_manager_public_state.py` — 434 passed, 3 existing aiosqlite event-loop deprecation warnings.
- `make plan-validation`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/plan_validation.py --run`

Risks and edge cases:
- Test-only changes.
- No product behavior changed.
- Lifecycle cleanup changes only affect failure-path test teardown.

Kept unchanged:
- Most batch files already had focused behavior assertions for hygiene guardrails, settings persistence, processing math/cache/FFT behavior, and runtime projection/liveness contracts.
- Benchmark file was kept as an opt-in hand-maintained benchmark with an equivalence sanity check.

Follow-ups:
- None.
