### PR TITLE
Improve backend tests batch 4

### DIFF
--- a/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
@@ -83,13 +83,14 @@ async def test_stop_logs_managed_jobs_that_outlive_cancel_timeout(
 
     monkeypatch.setattr(lifecycle_module.asyncio, "wait", _wait_pending)
 
-    with caplog.at_level(logging.WARNING):
-        await lifecycle.stop()
+    try:
+        with caplog.at_level(logging.WARNING):
+            await lifecycle.stop()
 
-    assert "managed shutdown task(s)" in caplog.text
-    assert "system-update" in caplog.text
-    assert "lingering tasks" in caplog.text
-
-    managed.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await managed
+        assert "managed shutdown task(s)" in caplog.text
+        assert "system-update" in caplog.text
+        assert "lingering tasks" in caplog.text
+    finally:
+        managed.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await managed

--- a/apps/server/tests/infra/runtime/test_managed_job_shutdown.py
+++ b/apps/server/tests/infra/runtime/test_managed_job_shutdown.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import logging
 
 import pytest
 
@@ -20,6 +22,15 @@ class _FakeJobSource:
 
 async def _slow_job() -> None:
     await asyncio.sleep(100)
+
+
+async def _stubborn_job() -> None:
+    first_wait = asyncio.Event()
+    second_wait = asyncio.Event()
+    try:
+        await first_wait.wait()
+    except asyncio.CancelledError:
+        await second_wait.wait()
 
 
 async def _instant_job() -> None:
@@ -76,3 +87,38 @@ class TestManagedJobShutdown:
         lingering = await shutdown.cancel(timeout_s=5.0)
         assert lingering == []
         assert active_task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_lingering_tasks_returned_and_logged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Tasks that outlive cancellation are returned and logged by name."""
+        import vibesensor.infra.runtime.managed_job_shutdown as shutdown_module
+
+        task = asyncio.create_task(_stubborn_job(), name="stubborn-job")
+        await asyncio.sleep(0)
+
+        async def _wait_pending(
+            tasks: list[asyncio.Task[None]],
+            timeout: float | None,
+        ) -> tuple[set[asyncio.Task[None]], set[asyncio.Task[None]]]:
+            del timeout
+            await asyncio.sleep(0)
+            return set(), set(tasks)
+
+        monkeypatch.setattr(shutdown_module.asyncio, "wait", _wait_pending)
+        shutdown = ManagedJobShutdown([_FakeJobSource(task)])
+
+        try:
+            with caplog.at_level(logging.WARNING, logger=shutdown_module.LOGGER.name):
+                lingering = await shutdown.cancel(timeout_s=0.01)
+
+            assert lingering == [task]
+            assert "managed shutdown task(s)" in caplog.text
+            assert "stubborn-job" in caplog.text
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -245,7 +245,11 @@ class TestProcessingLoopFailureTracking:
             with pytest.raises(ProcessingLoopFailure, match="Processing loop remained unhealthy"):
                 await loop.run()
 
+        expected_failures = MAX_CONSECUTIVE_FAILURES * MAX_FATAL_BACKOFF_CYCLES
         assert state.processing_state == ProcessingHealth.FATAL
+        assert state.processing_failure_count == expected_failures
+        assert state.last_failure_category == "compute_all"
+        assert state.processing_failure_categories == {"compute_all": expected_failures}
 
     @pytest.mark.asyncio
     async def test_programmer_bug_propagates_from_ingress_state(self) -> None:

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -181,15 +181,14 @@ def test_registry_clear_name_reverts_to_default(tmp_path: Path) -> None:
     # Clear the name
     cleared = registry.clear_name(client_id)
     assert cleared.name == f"client-{client_id[-4:]}"
+    row = snapshot_for_api(registry, now=1.0)[0]
+    assert row["id"] == client_id
+    assert row["name"] == f"client-{client_id[-4:]}"
 
     # Verify persistence: the cleared name should NOT come back after reload
+    assert db.client_name_repository.list_client_names() == {}
     registry2 = ClientRegistry(db=db.client_name_repository)
-    rows = snapshot_for_api(registry2, now=1.0)
-    names = [r["name"] for r in rows if r["id"] == client_id]
-    # After clearing, the client may or may not appear in snapshot (depending on
-    # whether it's currently connected). If it appears, it should have the default name.
-    for name in names:
-        assert name == f"client-{client_id[-4:]}"
+    assert snapshot_for_api(registry2, now=1.0) == []
 
 
 def test_registry_clear_name_preserves_other_clients(tmp_path: Path) -> None:

--- a/apps/server/tests/infra/runtime/test_registry_diagnostics.py
+++ b/apps/server/tests/infra/runtime/test_registry_diagnostics.py
@@ -33,12 +33,13 @@ def test_note_parse_error_normalizes_client_and_invalid_queue_drops_are_ignored(
     diagnostics, clients = _make_diagnostics()
 
     diagnostics.note_parse_error("AABBCCDDEEFF")
+    diagnostics.note_server_queue_drop("AA:BB:CC:DD:EE:FF")
     diagnostics.note_server_queue_drop(None)
     diagnostics.note_server_queue_drop("not-a-client-id")
 
     record = clients["aabbccddeeff"]
     assert record.parse_errors == 1
-    assert record.server_queue_drops == 0
+    assert record.server_queue_drops == 1
     assert list(clients) == ["aabbccddeeff"]
 
 

--- a/apps/server/tests/infra/runtime/test_registry_location_cap.py
+++ b/apps/server/tests/infra/runtime/test_registry_location_cap.py
@@ -48,7 +48,8 @@ def test_set_location_over_64_ascii_bytes_capped(tmp_path: Path) -> None:
     registry = _make_registry(tmp_path)
     record = registry.set_location(_CLIENT_ID, label)
     encoded = record.location_code.encode("utf-8")
-    assert len(encoded) <= 64
+    assert len(encoded) == 64
+    assert record.location_code == "a" * 64
 
 
 def test_set_location_multibyte_truncation_safe(tmp_path: Path) -> None:
@@ -66,6 +67,7 @@ def test_set_location_multibyte_truncation_safe(tmp_path: Path) -> None:
     assert len(encoded) <= 64
     # Must decode cleanly (round-trip)
     assert encoded.decode("utf-8") == record.location_code
+    assert record.location_code == "€" * 21
 
 
 def test_set_location_strips_whitespace_before_cap(tmp_path: Path) -> None:

--- a/apps/server/tests/infra/runtime/test_registry_staleness_diagnostics.py
+++ b/apps/server/tests/infra/runtime/test_registry_staleness_diagnostics.py
@@ -151,4 +151,5 @@ def test_registry_exposes_timing_health_metrics(tmp_path: Path) -> None:
     record = registry.get(client_id.hex())
     assert record is not None
     assert record.last_t0_us == 1_105_000
-    assert isinstance(record.timing_jitter_us_ema, float)
+    assert record.timing_jitter_us_ema == 1_000.0
+    assert record.timing_drift_us_total == 5_000.0

--- a/apps/server/tests/infra/runtime/test_rotational_speeds.py
+++ b/apps/server/tests/infra/runtime/test_rotational_speeds.py
@@ -30,6 +30,11 @@ from vibesensor.infra.runtime.rotational_speeds import rotational_basis_speed_so
             {"gps_enabled": True, "resolution_source": "gps"},
             "manual",
         ),
+        (
+            "OBD2",
+            {"gps_enabled": False, "fallback_active": True},
+            "obd2",
+        ),
     ],
 )
 def test_rotational_basis_speed_source_cases(

--- a/apps/server/tests/infra/runtime/test_rotational_speeds_obd.py
+++ b/apps/server/tests/infra/runtime/test_rotational_speeds_obd.py
@@ -31,3 +31,15 @@ def test_build_rotational_speeds_payload_uses_measured_obd_engine_rpm() -> None:
     assert payload["wheel"]["mode"] == "calculated"
     assert payload["engine"]["mode"] == "measured"
     assert payload["engine"]["rpm"] == pytest.approx(2450.0)
+
+
+def test_build_rotational_speeds_payload_rejects_bool_engine_rpm() -> None:
+    payload = build_rotational_speeds_payload(
+        basis_speed_source="obd2",
+        speed_mps=15.0,
+        measured_engine_rpm=True,
+        analysis_settings=AnalysisSettingsSnapshot(**AnalysisSettingsSnapshot.DEFAULTS),
+    )
+
+    assert payload["engine"]["mode"] == "calculated"
+    assert payload["engine"]["rpm"] is not None

--- a/apps/server/tests/infra/runtime/test_startup_runner.py
+++ b/apps/server/tests/infra/runtime/test_startup_runner.py
@@ -65,14 +65,14 @@ class TestStartupRunnerPhases:
         await runner.run()
 
         assert health_state.startup_state == "ready"
-        assert set(started_names) == {
+        assert started_names == [
             "processing-loop",
             "ws-broadcast",
             "metrics-log",
             "gps-speed",
             "obd-speed",
             "update-startup-recover",
-        }
+        ]
 
     @pytest.mark.asyncio
     async def test_marks_failed_on_exception(self) -> None:

--- a/apps/server/tests/infra/runtime/test_task_supervisor.py
+++ b/apps/server/tests/infra/runtime/test_task_supervisor.py
@@ -46,12 +46,14 @@ async def test_supervisor_restarts_failed_task_and_clears_health() -> None:
                 restartable_exceptions=(RuntimeError,),
             )
         )
-        await asyncio.wait_for(restart_started.wait(), timeout=1.0)
-        assert call_count == 2
-        assert health_state.background_task_failures == {}
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
+        try:
+            await asyncio.wait_for(restart_started.wait(), timeout=1.0)
+            assert call_count == 2
+            assert health_state.background_task_failures == {}
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
+++ b/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
@@ -69,11 +69,17 @@ async def test_shutdown_logs_transport_close_error(caplog: pytest.LogCaptureFixt
     transport = MagicMock()
     transport.close.side_effect = OSError("close boom")
     lifecycle = UdpTransportLifecycle(
-        start_udp_receiver=AsyncMock(),
+        start_udp_receiver=AsyncMock(return_value=(transport, None)),
         start_background_task=MagicMock(),
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
-    lifecycle._data_transport = transport
+    await lifecycle.startup(
+        host="0.0.0.0",
+        port=9000,
+        registry=MagicMock(),
+        processor=MagicMock(),
+        queue_maxsize=64,
+    )
 
     with caplog.at_level(logging.WARNING):
         await lifecycle.shutdown()

--- a/apps/server/tests/infra/test_location_assignment_validator.py
+++ b/apps/server/tests/infra/test_location_assignment_validator.py
@@ -23,6 +23,7 @@ def test_normalize_caps_utf8_bytes_without_splitting_codepoints() -> None:
 
     assert len(normalized.encode("utf-8")) <= 64
     assert normalized.encode("utf-8").decode("utf-8") == normalized
+    assert normalized == "€" * 21
 
 
 def test_validate_assignment_rejects_duplicate_location() -> None:

--- a/apps/server/tests/infra/workers/test_worker_pool.py
+++ b/apps/server/tests/infra/workers/test_worker_pool.py
@@ -83,9 +83,7 @@ class TestWorkerPool:
             return x * 10
 
         result = pool.map_unordered(_maybe_fail, [1, 2, 3])
-        assert 1 in result
-        assert 3 in result
-        assert 2 not in result  # failed item omitted
+        assert result == {1: 10, 3: 30}
 
     def test_stats(self, make_pool) -> None:
         pool = make_pool(max_workers=3)

--- a/apps/server/tests/infra/workers/test_worker_pool_runtime_stats.py
+++ b/apps/server/tests/infra/workers/test_worker_pool_runtime_stats.py
@@ -24,7 +24,11 @@ class TestWorkerPoolRuntimeStats:
             pool.map_unordered(lambda x: time.sleep(0.01) or x, [1, 2])
             stats = pool.stats()
             assert stats["total_run_s"] > 0
+            assert stats["avg_run_s"] > 0
             assert stats["total_tasks"] == 2
+            assert stats["pending_tasks"] == 0
+            assert stats["queued_tasks"] == 0
+            assert stats["running_tasks"] == 0
         finally:
             pool.shutdown()
 

--- a/apps/server/tests/integration/test_contract_persistence_analysis.py
+++ b/apps/server/tests/integration/test_contract_persistence_analysis.py
@@ -140,7 +140,8 @@ def test_key_sample_fields_survive_persistence():
     read_back = db.get_run_samples(run_id)
 
     required_fields = {"t_s", "speed_kmh", "client_name", "vibration_strength_db"}
-    for row in read_back:
+    for expected, row in zip(samples, read_back, strict=True):
         payload = sensor_frame_to_json_object(row)
         for field in required_fields:
             assert field in payload, f"Missing field {field!r} after DB round-trip"
+            assert payload[field] == expected[field]

--- a/apps/server/tests/integration/test_messy_real_world.py
+++ b/apps/server/tests/integration/test_messy_real_world.py
@@ -139,10 +139,12 @@ def test_fault_with_speed_jitter(corner: str, profile: dict[str, Any]) -> None:
     ]
 
     summary = run_analysis(jittered, metadata=profile_metadata(profile))
-    top = extract_top(summary)
-    assert top is not None, f"No finding for fault+jitter {corner}"
-    assert_wheel_source(summary, msg=f"fault+jitter {corner}")
-    assert_confidence_between(summary, 0.10, 1.0, msg=f"fault+jitter {corner}")
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        min_confidence=0.10,
+        msg=f"fault+jitter {corner}",
+    )
 
 
 # F.3 – No-fault diffuse + pothole transients (2 cases)
@@ -422,6 +424,7 @@ def test_fault_with_self_dropout(corner: str, profile: dict[str, Any]) -> None:
     top = extract_top(summary)
     assert top is not None, f"No finding for self-dropout {corner}"
     # Confidence may be lower due to missing data, but fault should be detected
+    assert_wheel_source(summary, msg=f"self-dropout {corner}")
     assert_confidence_between(summary, 0.10, 1.0, msg=f"self-dropout {corner}")
 
 

--- a/apps/server/tests/integration/test_multi_no_transient.py
+++ b/apps/server/tests/integration/test_multi_no_transient.py
@@ -16,12 +16,9 @@ from test_support import (
     SPEED_HIGH,
     SPEED_MID,
     SPEED_VERY_HIGH,
-    assert_confidence_between,
-    assert_confidence_label_valid,
+    assert_diagnosis_contract,
     assert_no_wheel_fault,
     assert_pairwise_monotonic,
-    assert_strongest_location,
-    assert_wheel_source,
     extract_top,
     make_diffuse_samples,
     make_fault_samples,
@@ -59,12 +56,13 @@ pytestmark = pytest.mark.diagnostic_matrix
 
 def _assert_fault_at(summary: dict[str, Any], sensor: str, msg: str) -> None:
     """Common assertion: top finding exists at *sensor* with wheel source."""
-    top = extract_top(summary)
-    assert top is not None, f"{msg}: no finding"
-    assert_wheel_source(summary, msg=msg)
-    assert_strongest_location(summary, sensor, msg=msg)
-    assert_confidence_between(summary, 0.10, 1.0, msg=msg)
-    assert_confidence_label_valid(summary, msg=msg)
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        expected_sensor=sensor,
+        min_confidence=0.10,
+        msg=msg,
+    )
 
 
 # D.3 – 2-sensor pairs with fault localization (4 cases)
@@ -179,10 +177,12 @@ def test_confidence_scales_with_sensor_count(
         fault_vib_db=28.0,
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
-    top = extract_top(summary)
-    assert top is not None, f"No finding for {label}"
-    assert_wheel_source(summary, msg=label)
-    assert_confidence_between(summary, 0.10, 1.0, msg=label)
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        min_confidence=0.10,
+        msg=label,
+    )
 
 
 @pytest.mark.parametrize(

--- a/apps/server/tests/integration/test_multi_system_overlap.py
+++ b/apps/server/tests/integration/test_multi_system_overlap.py
@@ -27,6 +27,7 @@ from test_support import (
     SPEED_LOW,
     SPEED_MID,
     assert_confidence_label_valid,
+    assert_diagnosis_contract,
     assert_no_localized_wheel,
     engine_hz,
     extract_top,
@@ -35,7 +36,6 @@ from test_support import (
     profile_metadata,
     profile_wheel_hz,
     run_analysis,
-    top_confidence,
     wheel_hz,
 )
 
@@ -203,10 +203,13 @@ def test_engine_plus_wheel_detects_wheel(
         engine_amp=0.02,
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
-    conf = top_confidence(summary)
-    assert conf > 0.0, f"No finding when engine+wheel at {corner}/{speed}/{profile['name']}"
-    top = extract_top(summary)
-    assert top is not None
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        expected_sensor=sensor,
+        min_confidence=0.01,
+        msg=f"engine+wheel at {corner}/{speed}/{profile['name']}",
+    )
 
 
 # ===================================================================
@@ -237,8 +240,12 @@ def test_engine_alias_suppression(eng_name: str, engine_amp: float) -> None:
         engine_amp=engine_amp,
     )
     summary = run_analysis(samples)
-    # Pipeline should not crash even with strong engine presence
-    assert "top_causes" in summary
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        min_confidence=0.01,
+        msg=f"engine alias suppression {eng_name}",
+    )
 
 
 # ===================================================================
@@ -266,8 +273,13 @@ def test_driveshaft_plus_wheel_overlap(
         profile=profile,
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
-    conf = top_confidence(summary)
-    assert conf > 0.0, f"No finding for driveshaft+wheel at {corner}/{speed}/{profile['name']}"
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        expected_sensor=sensor,
+        min_confidence=0.01,
+        msg=f"driveshaft+wheel at {corner}/{speed}/{profile['name']}",
+    )
 
 
 # ===================================================================
@@ -306,10 +318,13 @@ def test_three_systems_simultaneous(corner: str, speed: float) -> None:
     )
 
     summary = run_analysis(samples)
-    assert "top_causes" in summary
-    # Should produce at least one finding
-    conf = top_confidence(summary)
-    assert conf > 0.0, f"Three-system scenario at {corner}/{speed} produced no findings"
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        expected_sensor=sensor,
+        min_confidence=0.01,
+        msg=f"three-system scenario at {corner}/{speed}",
+    )
 
 
 # ===================================================================
@@ -370,7 +385,7 @@ def test_engine_plus_single_sensor_wheel(
     wheel_amp: float,
     engine_amp: float,
 ) -> None:
-    """Engine + localized wheel: pipeline should find the localized wheel signal."""
+    """Single-sensor overlap should produce a diagnosis without crashing."""
     corner = "FL"
     sensor = CORNER_SENSORS[corner]
     samples = _make_engine_plus_wheel_samples(
@@ -381,9 +396,12 @@ def test_engine_plus_single_sensor_wheel(
         engine_amp=engine_amp,
     )
     summary = run_analysis(samples)
-    conf = top_confidence(summary)
-    assert conf > 0.0, (
-        f"Single-sensor wheel+engine at {corner} ({strength_name}) should produce a finding"
+    assert_diagnosis_contract(
+        summary,
+        min_confidence=0.01,
+        msg=(
+            f"single-sensor wheel+engine at {corner} ({strength_name}) should produce a diagnosis"
+        ),
     )
 
 
@@ -413,9 +431,13 @@ def test_profile_engine_plus_wheel(profile: dict[str, Any]) -> None:
 
     meta = profile_metadata(profile)
     summary = run_analysis(samples, metadata=meta)
-    assert "top_causes" in summary
-    conf = top_confidence(summary)
-    assert conf > 0.0, f"Profile {profile['name']} engine+wheel at {corner} produced no findings"
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        expected_sensor=sensor,
+        min_confidence=0.01,
+        msg=f"profile {profile['name']} engine+wheel at {corner}",
+    )
     # Validate confidence label if above floor
     top = extract_top(summary)
     if top and float(top.get("confidence", 0)) > 0.25:

--- a/apps/server/tests/integration/test_multi_transient.py
+++ b/apps/server/tests/integration/test_multi_transient.py
@@ -18,11 +18,8 @@ from test_support import (
     SPEED_HIGH,
     SPEED_MID,
     SPEED_VERY_HIGH,
-    assert_confidence_label_valid,
-    assert_strongest_location,
+    assert_diagnosis_contract,
     assert_tolerant_no_fault,
-    assert_wheel_source,
-    extract_top,
     make_diffuse_samples,
     make_profile_fault_samples,
     make_profile_speed_sweep_fault_samples,
@@ -68,11 +65,13 @@ pytestmark = pytest.mark.diagnostic_matrix
 
 def _assert_fault_at(summary: dict[str, Any], sensor: str, msg: str) -> None:
     """Common assertion: top finding exists at *sensor* with wheel source."""
-    top = extract_top(summary)
-    assert top is not None, f"{msg}: no finding"
-    assert_wheel_source(summary, msg=msg)
-    assert_strongest_location(summary, sensor, msg=msg)
-    assert_confidence_label_valid(summary, msg=msg)
+    assert_diagnosis_contract(
+        summary,
+        expected_source="wheel",
+        expected_sensor=sensor,
+        min_confidence=0.01,
+        msg=msg,
+    )
 
 
 # E.2 – 4-sensor transient on non-fault sensor (4 cases)
@@ -148,7 +147,6 @@ def test_8sensor_fault_with_transient(corner: str, profile: dict[str, Any]) -> N
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"8s+t {corner}")
-    assert_confidence_label_valid(summary, msg=f"8s+t {corner}")
 
 
 # E.5 – 12-sensor fault + transient (4 corners = 4 cases)

--- a/apps/server/tests/integration/test_real_world_scenarios.py
+++ b/apps/server/tests/integration/test_real_world_scenarios.py
@@ -16,7 +16,11 @@ from collections.abc import Callable
 from typing import Any
 
 from test_support import make_sample
-from test_support.assertions import assert_forbidden_systems, assert_source_is
+from test_support.assertions import (
+    assert_diagnosis_contract,
+    assert_forbidden_systems,
+    assert_source_is,
+)
 from test_support.core import (
     FINAL_DRIVE,
     GEAR_RATIO,
@@ -219,10 +223,14 @@ class TestVeryShortRecording:
         )
 
         summary = summarize_run_data(meta, samples, lang="en", file_name="short_5s")
-        assert "findings" in summary
-        # Run suitability should exist
+        assert_summary_sections(summary)
         suitability = summary.get("run_suitability", [])
         assert isinstance(suitability, list)
+        assert {str(check.get("state")) for check in suitability if isinstance(check, dict)} <= {
+            "pass",
+            "warn",
+            "fail",
+        }
         # The summary must complete without crashing; any findings must be valid
         for f in summary.get("findings", []):
             if isinstance(f, dict):
@@ -240,7 +248,7 @@ class TestVeryShortRecording:
         )
 
         summary = summarize_run_data(meta, samples, lang="en", file_name="short_3s")
-        assert "findings" in summary
+        assert_summary_sections(summary)
 
 
 # ===========================================================================
@@ -266,17 +274,14 @@ class TestGradualFaultOnset:
         )
 
         summary = summarize_run_data(meta, samples, lang="en", file_name="gradual_onset")
-        assert_summary_sections(summary, min_findings=0)
-
-        # Should still detect the fault (even if lower confidence due to averaging)
-        non_ref = [
-            f
-            for f in summary.get("findings", [])
-            if isinstance(f, dict)
-            and not str(f.get("finding_id", "")).startswith("REF_")
-            and float(f.get("confidence") or 0) > 0.10
-        ]
-        assert len(non_ref) >= 1, "Gradual onset fault should be detected"
+        assert_summary_sections(summary, min_findings=1, min_top_causes=1)
+        assert_diagnosis_contract(
+            summary,
+            expected_source="wheel",
+            expected_sensor="front-left",
+            min_confidence=0.10,
+            msg="Gradual onset fault should be detected at front-left",
+        )
 
 
 # ===========================================================================

--- a/apps/server/tests/integration/test_report_pipeline.py
+++ b/apps/server/tests/integration/test_report_pipeline.py
@@ -514,7 +514,7 @@ class TestPdfLanguageParity:
             f"Confidence mismatch: EN={en_conf:.4f}, NL={nl_conf:.4f}"
         )
 
-    @pytest.mark.parametrize("field", ["source", "strongest_location"])
+    @pytest.mark.parametrize("field", ["suspected_source", "strongest_location"])
     def test_same_top_field(self, field: str) -> None:
         """EN and NL summaries should have the same top-cause field value."""
         en_top = extract_top(self.summary_en)

--- a/apps/server/tests/integration/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_core_regressions.py
@@ -170,19 +170,45 @@ class TestModuleAllExports:
     """Verify key public modules keep non-empty __all__ exports for import guardrails."""
 
     @pytest.mark.parametrize(
-        "module_path",
+        ("module_path", "expected_exports"),
         [
-            "vibesensor.shared.types.car_config",
-            "vibesensor.shared.types.run_schema",
-            "vibesensor.shared.types.speed_source_config",
-            "vibesensor.adapters.udp.protocol",
-            "vibesensor.infra.workers.worker_pool",
-            "vibesensor.adapters.persistence.car_library",
-            "vibesensor.adapters.gps.gps_speed",
-            "vibesensor.infra.runtime.registry",
+            (
+                "vibesensor.shared.types.car_config",
+                {"CarConfigPayload", "car_to_persistence_dict", "new_car_id"},
+            ),
+            (
+                "vibesensor.shared.types.run_schema",
+                {"RUN_SCHEMA_VERSION", "RunMetadata", "RunFinalizationStageResult"},
+            ),
+            (
+                "vibesensor.shared.types.speed_source_config",
+                {"SpeedSourceConfig", "SpeedSourcePayload", "ResolvedSpeedSource"},
+            ),
+            (
+                "vibesensor.adapters.udp.protocol",
+                {"DataMessage", "pack_data", "parse_data", "parse_hello"},
+            ),
+            ("vibesensor.infra.workers.worker_pool", {"WorkerPool"}),
+            (
+                "vibesensor.adapters.persistence.car_library",
+                {"load_car_library", "resolve_variant", "CarLibraryEntry"},
+            ),
+            ("vibesensor.adapters.gps.gps_speed", {"GPSSpeedMonitor", "SpeedResolution"}),
+            (
+                "vibesensor.infra.runtime.registry",
+                {"ClientRecord", "ClientRegistry", "DataUpdateResult"},
+            ),
         ],
     )
-    def test_module_has_all(self, module_path: str) -> None:
+    def test_module_has_expected_all_exports(
+        self,
+        module_path: str,
+        expected_exports: set[str],
+    ) -> None:
         mod = importlib.import_module(module_path)
         assert hasattr(mod, "__all__"), f"{module_path} is missing __all__"
-        assert len(mod.__all__) > 0, f"{module_path}.__all__ is empty"
+        exports = set(mod.__all__)
+        assert exports, f"{module_path}.__all__ is empty"
+        assert expected_exports <= exports, (
+            f"{module_path}.__all__ missing expected exports: {sorted(expected_exports - exports)}"
+        )

--- a/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
+++ b/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import json
 import math
+from pathlib import Path
 
-import pytest
 from _paths import SERVER_ROOT
 from test_support.persisted_analysis import make_persisted_analysis
 
@@ -91,24 +91,30 @@ class TestStrengthFloorFallback:
 class TestStoreAnalysisErrorGuard:
     """Regression: store_analysis_error must not overwrite a completed run."""
 
-    def test_error_does_not_overwrite_complete(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_error_does_not_overwrite_complete(self, tmp_path: Path) -> None:
         db = create_history_persistence_adapters(tmp_path / "test.db")
-        run_id = "test-run-001"
-        db.run_repository.create_run(run_id, "2024-01-01T00:00:00", _metadata(run_id, test=True))
+        try:
+            run_id = "test-run-001"
+            db.run_repository.create_run(
+                run_id,
+                "2024-01-01T00:00:00",
+                _metadata(run_id, test=True),
+            )
 
-        # Complete the analysis
-        db.run_repository.store_analysis(run_id, make_persisted_analysis({"result": "ok"}))
-        run_before = db.run_repository.get_run(run_id)
-        assert run_before is not None
-        assert run_before.status.value == "complete"
+            db.run_repository.store_analysis(run_id, make_persisted_analysis({"result": "ok"}))
+            run_before = db.run_repository.get_run(run_id)
+            assert run_before is not None
+            assert run_before.status.value == "complete"
 
-        # Try to overwrite with an error
-        db.run_repository.store_analysis_error(run_id, "spurious error")
-        run_after = db.run_repository.get_run(run_id)
-        assert run_after is not None
-        assert run_after.status.value == "complete", (
-            "store_analysis_error must not overwrite a completed run"
-        )
+            db.run_repository.store_analysis_error(run_id, "spurious error")
+            run_after = db.run_repository.get_run(run_id)
+            assert run_after is not None
+            assert run_after.status.value == "complete", (
+                "store_analysis_error must not overwrite a completed run"
+            )
+            assert run_after.analysis == run_before.analysis
+        finally:
+            db.lifecycle.close()
 
 
 class TestEvidencePeakPresentFormat:

--- a/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
@@ -175,22 +175,25 @@ class TestBoundedSample:
 
 def test_speed_unit_persists_and_round_trips(tmp_path: Path) -> None:
     db = _make_history_db(tmp_path, "settings.db")
-    services = build_settings_services(db=db.settings_snapshot_repository)
+    try:
+        services = build_settings_services(db=db.settings_snapshot_repository)
 
-    # Default
-    assert services.ui_preferences.speed_unit == "kmh"
+        # Default
+        assert services.ui_preferences.speed_unit == "kmh"
 
-    # Change to mps
-    services.ui_preferences.set_speed_unit("mps")
-    assert services.ui_preferences.speed_unit == "mps"
+        # Change to mps
+        services.ui_preferences.set_speed_unit("mps")
+        assert services.ui_preferences.speed_unit == "mps"
 
-    # Reload from DB
-    services2 = build_settings_services(db=db.settings_snapshot_repository)
-    assert services2.ui_preferences.speed_unit == "mps"
+        # Reload from DB
+        services2 = build_settings_services(db=db.settings_snapshot_repository)
+        assert services2.ui_preferences.speed_unit == "mps"
 
-    # Invalid falls back
-    with pytest.raises(ValueError, match="speed_unit must be one of"):
-        services.ui_preferences.set_speed_unit("mph")  # not a valid choice
+        # Invalid falls back
+        with pytest.raises(ValueError, match="speed_unit must be one of"):
+            services.ui_preferences.set_speed_unit("mph")  # not a valid choice
+    finally:
+        db.lifecycle.close()
 
 
 # ---------------------------------------------------------------------------
@@ -201,22 +204,26 @@ def test_speed_unit_persists_and_round_trips(tmp_path: Path) -> None:
 def test_iter_run_samples_returns_all_rows(tmp_path: Path) -> None:
     total = 37
     db = _seeded_history_db(tmp_path, "r1", total)
-
-    all_rows: list[SensorFrame] = []
-    for batch in db.run_repository.iter_run_samples("r1", batch_size=10):
-        all_rows.extend(batch)
-    assert len(all_rows) == total
-    assert [r.t_s for r in all_rows] == [float(i) for i in range(total)]
+    try:
+        all_rows: list[SensorFrame] = []
+        for batch in db.run_repository.iter_run_samples("r1", batch_size=10):
+            all_rows.extend(batch)
+        assert len(all_rows) == total
+        assert [r.t_s for r in all_rows] == [float(i) for i in range(total)]
+    finally:
+        db.lifecycle.close()
 
 
 def test_iter_run_samples_offset(tmp_path: Path) -> None:
     db = _seeded_history_db(tmp_path, "r2", 20)
-
-    all_rows: list[SensorFrame] = []
-    for batch in db.run_repository.iter_run_samples("r2", batch_size=5, offset=10):
-        all_rows.extend(batch)
-    assert len(all_rows) == 10
-    assert all_rows[0].t_s == 10.0
+    try:
+        all_rows: list[SensorFrame] = []
+        for batch in db.run_repository.iter_run_samples("r2", batch_size=5, offset=10):
+            all_rows.extend(batch)
+        assert len(all_rows) == 10
+        assert [r.t_s for r in all_rows] == [float(i) for i in range(10, 20)]
+    finally:
+        db.lifecycle.close()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
@@ -44,6 +44,13 @@ class TestFlushBumpsGeneration:
         with proc._store.lock:
             buf = proc._store._registry._get_or_create_unlocked("sensor-1")
         buf.ingest_generation = 5
+        buf.reset_generation = 2
+        buf.write_idx = 7
         buf.count = 10  # pretend some data
+        buf.latest_metrics = {"stale": True}
         proc.flush_client_buffer("sensor-1")
         assert buf.ingest_generation == 6
+        assert buf.reset_generation == 3
+        assert buf.count == 0
+        assert buf.write_idx == 0
+        assert buf.latest_metrics == {}

--- a/apps/server/tests/integration/test_saved_fuzz_corpus_replay.py
+++ b/apps/server/tests/integration/test_saved_fuzz_corpus_replay.py
@@ -265,9 +265,12 @@ def _assert_expected_outcome(artifact: SavedFuzzArtifact) -> None:
         return
     if target == "processor":
         result, target_expect = _replay_processor_artifact(artifact)
-        assert set(cast(dict[str, object], result["compute_all_result"])) == set(
-            cast(list[str], target_expect["clients"])
-        )
+        expected_clients = set(cast(list[str], target_expect["clients"]))
+        assert set(cast(dict[str, object], result["metrics_by_client"])) == expected_clients
+        assert set(cast(dict[str, object], result["spectrum_by_client"])) == expected_clients
+        assert set(cast(dict[str, object], result["latest_xyz"])) == expected_clients
+        assert set(cast(dict[str, object], result["compute_all_result"])) == expected_clients
+        assert set(cast(list[str], result["fresh_clients"])) == expected_clients
         return
     if target == "analysis":
         summary, target_expect = _replay_analysis_artifact(artifact)

--- a/apps/server/tests/integration/test_scenario_ground_truth_contract.py
+++ b/apps/server/tests/integration/test_scenario_ground_truth_contract.py
@@ -429,6 +429,11 @@ GROUND_TRUTH_SCENARIOS = [
 ]
 
 
+def test_ground_truth_scenario_ids_are_unique() -> None:
+    case_ids = [scenario.case_id for scenario in GROUND_TRUTH_SCENARIOS]
+    assert len(case_ids) == len(set(case_ids))
+
+
 @pytest.fixture(params=GROUND_TRUTH_SCENARIOS, ids=lambda spec: spec.case_id)
 def scenario(request: pytest.FixtureRequest) -> ScenarioSpec:
     return request.param

--- a/apps/server/tests/integration/test_scenario_ground_truth_invariants.py
+++ b/apps/server/tests/integration/test_scenario_ground_truth_invariants.py
@@ -128,7 +128,7 @@ class TestSimulatorDeterminism:
 
 
 class TestLanguageSelectionPrecedence:
-    """Verify report-language selection prefers explicit inputs over fallback metadata."""
+    """Verify report-language selection is driven by explicit inputs."""
 
     def test_explicit_lang_overrides_metadata(self) -> None:
         summary = summarize_run_data(
@@ -145,7 +145,7 @@ class TestLanguageSelectionPrecedence:
         )
         assert summary.get("lang") == "en"
 
-    def test_metadata_language_used_when_no_explicit_lang(self) -> None:
+    def test_metadata_language_does_not_override_default_without_explicit_lang(self) -> None:
         summary = summarize_run_data(
             standard_metadata(language="nl"),
             fault_phase(
@@ -155,10 +155,10 @@ class TestLanguageSelectionPrecedence:
                 sensors=ALL_SENSORS,
                 start_t_s=0.0,
             ),
-            lang="nl",
+            lang=None,
             file_name="test",
         )
-        assert summary.get("lang") == "nl"
+        assert summary.get("lang") == "en"
 
     def test_en_default_when_no_lang_anywhere(self) -> None:
         metadata = standard_metadata()
@@ -172,7 +172,7 @@ class TestLanguageSelectionPrecedence:
                 sensors=ALL_SENSORS,
                 start_t_s=0.0,
             ),
-            lang="en",
+            lang=None,
             file_name="test",
         )
         assert summary.get("lang") == "en"

--- a/apps/server/tests/integration/test_sensor_failure_e2e_pipeline.py
+++ b/apps/server/tests/integration/test_sensor_failure_e2e_pipeline.py
@@ -288,7 +288,9 @@ def test_sample_rate_mismatch_warns_in_health_but_pipeline_completes(
 
     top_causes = artifacts.analysis.get("top_causes") or []
     assert top_causes
-    assert str(top_causes[0].get("strongest_location")) == "front-left"
+    top_cause = top_causes[0]
+    assert "wheel" in str(top_cause.get("suspected_source", "")).lower()
+    assert str(top_cause.get("strongest_location")) == "front-left"
     assert artifacts.health["status"] == "warn"
     assert artifacts.health["sample_rate_mismatch_count"] == 1
     assert "sample_rate_mismatch" in artifacts.health["degradation_reasons"]

--- a/apps/server/tests/integration/test_single_no_transient.py
+++ b/apps/server/tests/integration/test_single_no_transient.py
@@ -199,24 +199,22 @@ def test_single_sensor_ramp_only_no_fault(profile: dict[str, Any]) -> None:
     assert_strict_no_fault(summary, msg="ramp-only")
 
 
-# B.9 – Fault with 2x and 3x harmonics (4 corners = 4 cases)
+# B.9 – Fault with 1x and 2x harmonics (4 corners = 4 cases)
 
 
 @pytest.mark.parametrize("profile", _OPTIMIZED_CAR_PROFILES, ids=_OPTIMIZED_CAR_PROFILE_IDS)
 @pytest.mark.parametrize("corner", _CORNERS)
-def test_single_sensor_harmonics_1x_2x_3x(corner: str, profile: dict[str, Any]) -> None:
-    """Strong fault with all three wheel harmonics."""
-    # Note: add_wheel_3x is not supported by make_profile_fault_samples;
-    # profile-aware builder covers 1x + 2x harmonics.
+def test_single_sensor_harmonics_1x_2x(corner: str, profile: dict[str, Any]) -> None:
+    """Strong fault with primary and second wheel harmonics."""
     summary, top = _run_single_fault(
         profile,
         corner,
         fault_amp=0.08,
         add_wheel_2x=True,
     )
-    assert top is not None, f"No finding for {corner} with 1x+2x+3x"
-    assert_confidence_between(summary, 0.15, 1.0, msg=f"{corner} 1x+2x+3x")
-    assert_confidence_label_valid(summary, msg=f"{corner} 1x+2x+3x")
+    assert top is not None, f"No finding for {corner} with 1x+2x"
+    assert_confidence_between(summary, 0.15, 1.0, msg=f"{corner} 1x+2x")
+    assert_confidence_label_valid(summary, msg=f"{corner} 1x+2x")
 
 
 # B.10 – Long duration steady fault (2 corners × 2 durations = 4 cases)

--- a/apps/server/tests/integration/test_udp_ingest_drop_report_honesty.py
+++ b/apps/server/tests/integration/test_udp_ingest_drop_report_honesty.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -81,7 +82,7 @@ def _samples() -> np.ndarray:
 
 
 def test_udp_ingest_queue_drop_reaches_persisted_report_honesty(
-    tmp_path,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     history_db = build_history_db(tmp_path)
@@ -225,6 +226,10 @@ def test_udp_ingest_queue_drop_reaches_persisted_report_honesty(
         prepared = prepare_persisted_report_input(summary)
         document = build_report_document(prepared)
 
-        assert any("UDP ingest queue drops" in (row.detail or "") for row in document.data_trust)
+        ingest_drop_rows = [
+            row for row in document.data_trust if "UDP ingest queue drops" in (row.detail or "")
+        ]
+        assert ingest_drop_rows
+        assert ingest_drop_rows[0].state == "warn"
     finally:
         history_db.lifecycle.close()

--- a/apps/server/tests/integration/test_udp_late_packet_report_honesty.py
+++ b/apps/server/tests/integration/test_udp_late_packet_report_honesty.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 from test_support.findings import make_finding_payload
 from test_support.history_db_lifecycle import build_history_db
 from test_support.report_helpers import minimal_summary
@@ -79,7 +81,10 @@ def _samples(freq_hz: float) -> np.ndarray:
     return np.column_stack([wave, zeros, zeros])
 
 
-def test_late_udp_packet_reaches_persisted_report_honesty(tmp_path, monkeypatch) -> None:
+def test_late_udp_packet_reaches_persisted_report_honesty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     history_db = build_history_db(tmp_path)
     try:
         registry = ClientRegistry(db=history_db.client_name_repository)
@@ -218,9 +223,12 @@ def test_late_udp_packet_reaches_persisted_report_honesty(tmp_path, monkeypatch)
         prepared = prepare_persisted_report_input(summary)
         document = build_report_document(prepared)
 
-        assert any(
-            "late or out-of-order packets quarantined from live processing" in (row.detail or "")
+        late_packet_rows = [
+            row
             for row in document.data_trust
-        )
+            if "late or out-of-order packets quarantined from live processing" in (row.detail or "")
+        ]
+        assert late_packet_rows
+        assert late_packet_rows[0].state == "warn"
     finally:
         history_db.lifecycle.close()

--- a/apps/server/tests/integration/test_weird_sensor_mix.py
+++ b/apps/server/tests/integration/test_weird_sensor_mix.py
@@ -196,6 +196,7 @@ def test_one_wheel_plus_cabin_correct_localization(
     assert_confidence_between(summary, 0.15, 1.0, msg=tag)
     top = extract_top(summary)
     assert top is not None, f"Expected a top cause for {tag}"
+    assert str(top.get("strongest_location") or "").lower() == wheel_sensor.lower()
 
 
 # ===================================================================

--- a/apps/server/tests/scripts/test_vibesensor_obd_admin.py
+++ b/apps/server/tests/scripts/test_vibesensor_obd_admin.py
@@ -86,3 +86,22 @@ def test_find_repo_venv_python_falls_back_to_python3(
 
     assert module._find_repo_venv_python() == target_python
     assert target_python.name == "python3"
+
+
+def test_ensure_repo_venv_python_reports_checked_candidates_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module()
+    venv_root = tmp_path / ".venv"
+
+    monkeypatch.setattr(module, "VENV_ROOT_CANDIDATES", (venv_root,))
+    monkeypatch.setattr(module, "VENV_PYTHON_BASENAMES", ("python", "python3"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        module._ensure_repo_venv_python()
+
+    message = str(exc_info.value)
+    assert "Missing expected virtualenv interpreter" in message
+    assert str(venv_root / "bin" / "python") in message
+    assert str(venv_root / "bin" / "python3") in message

--- a/apps/server/tests/shared/boundaries/test_finding_roundtrip.py
+++ b/apps/server/tests/shared/boundaries/test_finding_roundtrip.py
@@ -123,7 +123,10 @@ class TestFindingRoundtrip:
         assert restored.location is not None
         assert restored.location.strongest_location == "front-left"
         assert restored.location.dominance_ratio == pytest.approx(2.5)
+        assert restored.location.localization_confidence == pytest.approx(0.9)
+        assert restored.location.ambiguous is True
         assert restored.location.alternative_locations == ("front-right",)
+        assert restored.location.location_count == 2
 
     def test_signatures_preserved(self) -> None:
         sigs = (

--- a/apps/server/tests/shared/boundaries/test_run_log.py
+++ b/apps/server/tests/shared/boundaries/test_run_log.py
@@ -172,6 +172,8 @@ def test_as_float_or_none(value: object, expected: float | None) -> None:
         (None, None),
         ("abc", None),
         (float("nan"), None),
+        (True, None),
+        (False, None),
     ],
 )
 def test_as_int_or_none(value: object, expected: int | None) -> None:
@@ -335,6 +337,28 @@ def test_read_jsonl_run_logs_warning_for_corrupt_lines(
         run_data = read_jsonl_run(path)
     assert len(run_data.samples) == 1
     assert "Skipping corrupt JSONL line 2" in caplog.text
+
+
+def test_read_jsonl_run_skips_malformed_sample_line(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    path = tmp_path / "malformed_sample.jsonl"
+    metadata = _make_run_metadata(run_id="r5")
+    lines = [
+        json.dumps(metadata),
+        json.dumps({"record_type": "sample", "t_s": 1.0, "sample_rate_hz": "fast"}),
+        json.dumps({"record_type": "sample", "t_s": 2.0}),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="vibesensor.shared.boundaries.runs.log"):
+        run_data = read_jsonl_run(path)
+
+    assert [sample.t_s for sample in run_data.samples] == [2.0]
+    assert "Skipping malformed sample at line 2" in caplog.text
+    assert "sample_rate_hz" in caplog.text
 
 
 # -- create_run_metadata -------------------------------------------------------

--- a/apps/server/tests/shared/boundaries/test_settings_http_payloads.py
+++ b/apps/server/tests/shared/boundaries/test_settings_http_payloads.py
@@ -105,7 +105,12 @@ def test_preference_response_payloads_project_scalars() -> None:
 
 def test_analysis_settings_update_payload_from_mapping_omits_none_fields() -> None:
     payload = analysis_settings_update_payload_from_mapping(
-        {"tire_width_mm": 255.0, "gear_uncertainty_pct": 1.5}
+        {
+            "tire_width_mm": 255.0,
+            "gear_uncertainty_pct": 1.5,
+            "final_drive_ratio": None,
+            "tire_aspect_pct": True,
+        }
     )
 
     assert payload == {

--- a/apps/server/tests/shared/test_raw_capture_quality.py
+++ b/apps/server/tests/shared/test_raw_capture_quality.py
@@ -42,6 +42,15 @@ def test_raw_capture_loss_policy_warns_for_first_queue_overflow() -> None:
     assert assessment.gate_whole_run is False
 
 
+def test_raw_capture_loss_policy_reports_ok_when_no_manifest_is_available() -> None:
+    assessment = assess_raw_capture_loss_policy(None)
+
+    assert assessment.severity == "ok"
+    assert assessment.reason == "raw_capture_not_available"
+    assert assessment.gate_whole_run is False
+    assert assessment.total_loss_event_count == 0
+
+
 def test_raw_capture_loss_policy_gates_whole_run_for_fatal_queue_overflow() -> None:
     assessment = assess_raw_capture_loss_policy(_manifest(queue_overflow=120))
 

--- a/apps/server/tests/shared/types/test_domain_models.py
+++ b/apps/server/tests/shared/types/test_domain_models.py
@@ -40,6 +40,8 @@ class TestAsFloatOrNone:
             (float("inf"), None),
             (float("-inf"), None),
             ("abc", None),
+            (True, None),
+            (False, None),
         ],
     )
     def test_as_float_or_none(self, value: Any, expected: float | None) -> None:
@@ -54,6 +56,8 @@ class TestAsIntOrNone:
             (3.7, 4),
             (float("nan"), None),
             (None, None),
+            (True, None),
+            (False, None),
         ],
     )
     def test_as_int_or_none(self, value: Any, expected: int | None) -> None:

--- a/apps/server/tests/shared/utils/test_constants_and_helpers.py
+++ b/apps/server/tests/shared/utils/test_constants_and_helpers.py
@@ -103,3 +103,4 @@ def test_engine_rpm_basic() -> None:
     assert wh is not None
     rpm = spec.engine_rpm_from_wheel_hz(wh)
     assert rpm is not None
+    assert rpm == pytest.approx(wh * spec.final_drive_ratio * spec.current_gear_ratio * 60.0)


### PR DESCRIPTION
Batch 4: test files 301-400.

Processed: 100 files.
Changed: 41 files.
Size: large.

What changed:
- Tightened runtime, registry, worker, integration, boundary, shared utility, and type-helper tests.
- Added missing failure-path assertions for virtualenv discovery, malformed JSONL samples, raw-capture unavailable state, bool numeric coercion, and engine RPM math.
- Strengthened persistence/report/diagnosis assertions around payload contracts, warning rows, pagination order, cached metrics reset, and scenario IDs.
- Improved async/resource cleanup in runtime tests.
- Marked test-support helper modules as out of scope in the local tracker; no product behavior changed.

Why:
- Tests now prove behavior instead of only checking loose state or mocks.
- Several cases now assert exact persisted/report-facing contracts and important edge cases.
- Helper-only files should not be treated as executable test files.

Validation:
- `make plan-validation`
- `./.venv/bin/python -m pytest -q $(git --no-pager diff --name-only -- 'apps/server/tests/**/*.py')` -> 952 passed
- `make lint`
- `make typecheck-backend`
- `./.venv/bin/python tools/tests/plan_validation.py --run` attempted; local runner failed on system-Python environment gaps (`ruff`, `mypy`, `pytest`, `vibesensor`, `yaml` missing). Backend test shards 1/2/3/5 and e2e passed there; shard 4 had one raw-capture writer failure that passed when isolated with the repo venv.

Risks and edge cases:
- Mostly assertion-only changes, but broad surface area.
- Some integration expectations are stricter around current payload names and localization/source behavior.
- Formatting touched two changed integration files after lint.

Kept unchanged:
- Strong existing coverage for unchanged files was left as-is: registry sequence/thread safety, WebSocket payloads, multi-sensor pipeline, synthetic scenario matrix, summary/report codecs, warning localization, tracing/logging, window quality layers, and whole-run type contracts.

Follow-ups:
- Continue batch 5 after merge.
