### PR TITLE
Strengthen diagnostics tests batch 5

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_accel_statistics.py
+++ b/apps/server/tests/use_cases/diagnostics/test_accel_statistics.py
@@ -34,16 +34,19 @@ class TestComputeAccelStatistics:
         result = _compute_accel_statistics(sensor_frames_from_mappings(samples), "ADXL345")
         assert len(result["accel_x_vals"]) == 1
         assert result["accel_x_vals"][0] == pytest.approx(0.1)
+        assert result["x_mean"] == pytest.approx(0.1)
         assert len(result["accel_mag_vals"]) == 1
         expected_mag = math.sqrt(0.1**2 + 0.2**2 + 1.0**2)
         assert result["accel_mag_vals"][0] == pytest.approx(expected_mag, rel=1e-3)
+        assert result["amp_metric_values"] == pytest.approx([12.0])
 
     def test_saturation_detected_near_limit(self) -> None:
         samples: list[dict[str, Any]] = [
             {"accel_x_g": 15.7, "accel_y_g": 0.0, "accel_z_g": 0.0},
         ]
         result = _compute_accel_statistics(sensor_frames_from_mappings(samples), "ADXL345")
-        assert result["sat_count"] >= 1, "Near-limit value should count as saturation"
+        assert result["sensor_limit"] == pytest.approx(16.0)
+        assert result["sat_count"] == 1
 
     def test_missing_axes_handled(self) -> None:
         samples: list[dict[str, Any]] = [{"accel_x_g": 0.5}]
@@ -60,5 +63,5 @@ class TestComputeAccelStatistics:
             sensor_frames_from_mappings(samples),
             "totally_unknown_sensor",
         )
-        if result["sensor_limit"] is None:
-            assert result["sat_count"] == 0
+        assert result["sensor_limit"] is None
+        assert result["sat_count"] == 0

--- a/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_faults.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_faults.py
@@ -231,11 +231,11 @@ class TestDuplicateReplayedSamples:
             lang="en",
             file_name="dup_test",
         )
-        assert_summary_sections(duped, min_findings=0)
+        assert_summary_sections(baseline, min_findings=1, min_top_causes=1)
+        assert_summary_sections(duped, min_findings=1, min_top_causes=1)
         baseline_top = baseline.get("top_causes", [])
         duped_top = duped.get("top_causes", [])
-        if baseline_top and duped_top:
-            assert (
-                float(duped_top[0].get("confidence", 0))
-                <= float(baseline_top[0].get("confidence", 0)) + 0.15
-            )
+        assert (
+            float(duped_top[0].get("confidence", 0))
+            <= float(baseline_top[0].get("confidence", 0)) + 0.15
+        )

--- a/apps/server/tests/use_cases/diagnostics/test_engine_alias_suppression.py
+++ b/apps/server/tests/use_cases/diagnostics/test_engine_alias_suppression.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from test_support.findings import make_finding
 
 from vibesensor.use_cases.diagnostics.orders.heuristics import (
@@ -29,8 +30,8 @@ class TestSuppressEngineAliases:
         ]
         result = _suppress_engine_aliases(findings)
         engine_findings = [f for f in result if str(f.suspected_source) == "engine"]
-        if engine_findings:
-            assert engine_findings[0].effective_confidence < 0.65
+        assert len(engine_findings) == 1
+        assert engine_findings[0].effective_confidence == pytest.approx(0.39)
 
     def test_strong_engine_not_suppressed(self) -> None:
         findings = [

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -242,5 +242,5 @@ class TestSuppressEngineAliases:
         ]
         result = _suppress_engine_aliases(input_findings)
         engine_results = [f for f in result if str(f.suspected_source).strip().lower() == "engine"]
-        if engine_results:
-            assert engine_results[0].effective_confidence < 0.50
+        assert len(engine_results) == 1
+        assert engine_results[0].effective_confidence == pytest.approx(0.30)

--- a/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py
+++ b/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py
@@ -7,6 +7,7 @@ from test_support import (
     build_speed_sweep_fault_samples,
     extract_top_finding,
     make_sample,
+    parse_speed_band,
     standard_metadata,
     wheel_hz,
 )
@@ -48,17 +49,16 @@ class TestSpeedBandAttribution:
             fault_vib_db=6.0,
             noise_vib_db=6.0,
         )
-        speed_band = str(
+        band_low, band_high = parse_speed_band(
             extract_top_finding(
                 summarize_run_data(
                     standard_metadata(),
                     baseline + fault + cool,
                     include_samples=False,
                 ),
-            ).get("strongest_speed_band")
-            or "",
+            ),
         )
-        assert "120" in speed_band or "110" in speed_band
+        assert band_low <= 120.0 <= band_high
 
 
 class TestWheelVsEngineDrivelineGating:

--- a/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_progression.py
+++ b/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_progression.py
@@ -197,24 +197,17 @@ class TestScenario2StopGoIntermittent:
             fault_amp=0.055,
             fault_vib_db=23.0,
         )
-        speed_band = str(
+        band_low, band_high = parse_speed_band(
             extract_top_finding(
                 summarize_run_data(
                     standard_metadata(),
                     samples_50 + samples_60,
                     include_samples=False,
                 ),
-            ).get("strongest_speed_band")
-            or "",
+            ),
         )
-        band_low = 0
-        for part in speed_band.replace("km/h", "").split("-"):
-            try:
-                band_low = int(part.strip())
-                break
-            except ValueError:
-                continue
-        assert band_low >= 40
+        assert band_low >= 40.0
+        assert band_low <= 60.0 <= band_high
 
 
 class TestScenario3HighwayRearRight:
@@ -335,17 +328,16 @@ class TestScenario4CoastDownMidRange:
         )
 
     def test_speed_band_emphasizes_midrange(self) -> None:
-        speed_band = str(
+        band_low, band_high = parse_speed_band(
             extract_top_finding(
                 summarize_run_data(
                     standard_metadata(),
                     self.build_coast_down_samples(add_harmonic=False),
                     include_samples=False,
                 ),
-            ).get("strongest_speed_band")
-            or "",
+            ),
         )
-        assert any(str(speed) in speed_band for speed in [70, 80, 90])
+        assert band_low <= 80.0 <= band_high
 
 
 class TestScenario5MixedNoiseThenFault:


### PR DESCRIPTION
Batch 5.\n\nFiles processed: 100 (#401-#500).\nFiles changed: 6.\nSize: small.\n\nWhat changed:\n- Tightened diagnostics statistics assertions around axis means, dB metrics, saturation counts, and unknown-sensor no-saturation behavior.\n- Required duplicate-replay robustness tests to prove both baseline and duplicated runs produce findings before comparing confidence.\n- Locked engine alias suppression confidence and surviving suppressed finding counts.\n- Replaced string/manual speed-band checks with parsed numeric assertions for phased diagnosis scenarios.\n\nWhy:\n- Existing tests had useful coverage but a few assertions could pass with weaker or malformed behavior.\n- Changes keep current product behavior and make expected diagnostics contracts more explicit.\n\nValidation:\n- make plan-validation\n- ./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_accel_statistics.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_faults.py apps/server/tests/use_cases/diagnostics/test_engine_alias_suppression.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_progression.py\n- make lint\n- make typecheck-backend\n\nRisks and edge cases:\n- Low risk. Test-only assertion strengthening.\n- Speed-band assertions now verify parsed numeric ranges, not display substrings.\n- Saturation and suppression tests now check exact expected values where the fixture data is deterministic.\n\nKept unchanged:\n- Test support helper modules #401-#438 were helper/facade files, marked out of scope.\n- Benchmark and diagnostics files with already strong behavior coverage were kept unchanged.\n- Post-run raw window, STFT, order-band, vehicle-reference, dense-finding, episode, feature, and ranking helper tests already covered important happy paths and edge cases.\n\nFollow-ups:\n- Continue with batch 6 after this PR is green and merged.