### PR TITLE
Improve batch 6 test assertions

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_ranking_utils.py
+++ b/apps/server/tests/use_cases/diagnostics/test_ranking_utils.py
@@ -9,6 +9,7 @@ from vibesensor.use_cases.diagnostics._ranking_utils import (
 
 
 def test_dominant_weighted_value_keeps_count_weight_and_value_tiebreaks() -> None:
+    assert dominant_weighted_value(values=()) is None
     assert (
         dominant_weighted_value(
             values=(
@@ -18,6 +19,15 @@ def test_dominant_weighted_value_keeps_count_weight_and_value_tiebreaks() -> Non
             )
         )
         == "front-left"
+    )
+    assert (
+        dominant_weighted_value(
+            values=(
+                ("alpha", 1.0),
+                ("bravo", 2.0),
+            )
+        )
+        == "bravo"
     )
     assert (
         dominant_weighted_value(

--- a/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
@@ -115,12 +115,12 @@ def test_wait_returns_false_on_timeout(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(logger._post_analysis, "_run_post_analysis", _very_slow_analysis)
     logger.schedule_post_analysis("run-slow")
 
-    # Wait until the analysis thread has actually started
-    started.wait(timeout=2.0)
-
-    result = logger.wait_for_post_analysis(timeout_s=0.3)
-    assert result is False
-    finish.set()
+    assert started.wait(timeout=2.0)
+    try:
+        result = logger.wait_for_post_analysis(timeout_s=0.3)
+        assert result is False
+    finally:
+        finish.set()
     assert logger.wait_for_post_analysis(timeout_s=2.0) is True
 
 

--- a/apps/server/tests/use_cases/diagnostics/test_strength_and_reason_selection_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_and_reason_selection_regressions.py
@@ -34,8 +34,7 @@ class TestStrengthLabelNanGuard:
     def test_invalid_returns_unknown(self, db_value: object) -> None:
         key, label = strength_label(db_value)
         assert key == "unknown"
-        if db_value is not None or isinstance(db_value, float):
-            assert "nknown" in label  # "Unknown" or "Onbekend"
+        assert label == "Unknown"
 
     def test_valid_db_returns_band(self) -> None:
         key, _label = strength_label(15.0)

--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -73,8 +73,8 @@ def test_floor_rms_peak_index_out_of_range_ignored() -> None:
         min_hz=0,
         max_hz=100,
     )
-    # Bad index ignored → median of [0.5, 0.6]
-    assert result > 0
+    # Bad index ignored -> median of [0.5, 0.6].
+    assert result == pytest.approx(0.55)
 
 
 def test_floor_rms_skips_broadcast_peak_exclusion_on_sorted_freq(

--- a/apps/server/tests/use_cases/history/test_report_loader.py
+++ b/apps/server/tests/use_cases/history/test_report_loader.py
@@ -35,6 +35,8 @@ def test_report_loader_enriches_analysis_with_finalization_stage_metadata() -> N
 
     enriched_metadata = enriched.to_json_object()["metadata"]
     assert isinstance(enriched_metadata, dict)
+    assert enriched_metadata["run_id"] == "run-1"
+    assert enriched_metadata["sensor_model"] == "ADXL345"
     assert enriched_metadata["finalization_stages"] == [
         {
             "stage_name": "FinalizeRawCaptureStage",

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -145,9 +145,7 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
     assert primary.tier in {"B", "C"}
 
 
-def test_prepare_persisted_report_input_does_not_roundtrip_through_summary(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_prepare_persisted_report_input_does_not_roundtrip_through_summary() -> None:
     analysis = PersistedAnalysis.from_json_object(
         {
             "run_id": "persisted-run",

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -48,7 +48,7 @@ def test_build_sample_records_uses_only_active_clients(make_logger) -> None:
     assert rows[0].strength_floor_amp_g == 0.003
 
 
-def test_build_sample_records_caps_combined_and_axis_peak_lists(make_logger, fake_registry) -> None:
+def test_build_sample_records_caps_combined_top_peak_list(make_logger, fake_registry) -> None:
     active = fake_registry.get("active")
     assert active is not None
     active.latest_metrics["combined"]["strength_metrics"]["top_peaks"] = [

--- a/apps/server/tests/use_cases/run/test_pipeline_resilience.py
+++ b/apps/server/tests/use_cases/run/test_pipeline_resilience.py
@@ -313,15 +313,16 @@ class TestPostAnalysisOutcomeTracking:
         assert snapshot.last_completed_run_id is None
         assert snapshot.last_completed_error is None
 
-    def test_success_tracked(self, make_worker) -> None:
-        """Successful analysis records run_id with no error."""
-        worker = make_worker(run_fn=lambda _rid: None)
+    def test_worker_runs_injected_post_analysis_function(self, make_worker) -> None:
+        run_calls: list[str] = []
+        worker = make_worker(run_fn=run_calls.append)
         worker.schedule("run-ok")
         assert worker.wait(timeout_s=2.0)
 
-        # Note: _run_post_analysis was mocked so the worker loop tracks it
-        # but the actual _run_post_analysis doesn't set the outcome.
-        # Let's test with a real-ish DB instead.
+        snapshot = worker.snapshot()
+        assert run_calls == ["run-ok"]
+        assert snapshot.queue_depth == 0
+        assert snapshot.active_run_id is None
 
     def test_outcome_after_real_analysis_success(self) -> None:
         """Last completed outcome is set after successful analysis."""

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary_raw_capture_finalize.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary_raw_capture_finalize.py
@@ -76,4 +76,4 @@ def test_build_post_analysis_summary_persists_raw_capture_finalize_state_and_war
         == "raw capture finalize timed out"
     )
     warnings = summary["warnings"]
-    assert warnings[0]["code"] == WARNING_CODE_RAW_CAPTURE_FINALIZE_DEGRADED
+    assert [warning["code"] for warning in warnings] == [WARNING_CODE_RAW_CAPTURE_FINALIZE_DEGRADED]

--- a/apps/server/tests/use_cases/run/test_sample_strength_metrics.py
+++ b/apps/server/tests/use_cases/run/test_sample_strength_metrics.py
@@ -41,9 +41,14 @@ class TestExtractStrengthData:
         result = extract_strength_data(metrics)
         assert result.vibration_strength_db == pytest.approx(18.5)
         assert result.strength_bucket == "l3"
-        payloads = strength_peak_payloads(result.top_peaks, max_items=8)
-        assert len(payloads) == 1
-        assert payloads[0]["hz"] == pytest.approx(45.0)
+        assert strength_peak_payloads(result.top_peaks, max_items=8) == [
+            {
+                "hz": 45.0,
+                "amp": 0.015,
+                "vibration_strength_db": 18.5,
+                "strength_bucket": "l3",
+            }
+        ]
 
 
 class TestDominantHzFromStrength:


### PR DESCRIPTION
Batch 6.\n\nFiles processed: 100 (501-600).\nFiles changed: 10.\nPR size: small.\n\nWhat changed:\n- Added sharper edge assertions for diagnostics ranking, shutdown timeout cleanup, strength labels, and strength floor scoring.\n- Preserved metadata checks in history report loading and removed unused fixture setup in persisted report preparation tests.\n- Tightened run/post-analysis tests for worker execution, warning exactness, and strength peak payload round-trips.\n- Renamed one sample-record peak cap test so the name matches actual asserted behavior.\n\nWhy:\n- These were small safe improvements found while manually reviewing batch 6 test files.\n- Good tests in the batch were kept unchanged; they already covered behavior, edge cases, and failure paths clearly.\n\nValidation run:\n- make plan-validation\n- ./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_ranking_utils.py apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py apps/server/tests/use_cases/diagnostics/test_strength_and_reason_selection_regressions.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/history/test_report_loader.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_pipeline_resilience.py apps/server/tests/use_cases/run/test_post_analysis_summary_raw_capture_finalize.py apps/server/tests/use_cases/run/test_sample_strength_metrics.py\n- make lint\n- make typecheck-backend\n\nRisks and edge cases:\n- Test-only changes.\n- Assertions are stricter but match current intended behavior.\n- No product behavior changed.\n\nKept unchanged summary:\n- Most batch 6 diagnostics, history, post-analysis, raw-capture, recorder, run-context, and sample-record tests already had useful behavioral coverage.\n- Helper-only conftest was marked out of scope in the local tracker, not changed.\n\nFollow-ups:\n- Continue with batch 7 after this PR is green and merged.