### PR TITLE
Improve batch 7 backend tests

### DIFF
--- a/apps/server/tests/use_cases/run/test_speed_context.py
+++ b/apps/server/tests/use_cases/run/test_speed_context.py
@@ -106,6 +106,32 @@ class TestResolveSpeedContext:
         assert rpm is not None and rpm > 0
         assert rpm_source == "estimated_from_speed_and_ratios"
 
+    def test_measured_engine_rpm_takes_precedence_over_estimate(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _FakeSpec:
+            def engine_rpm_from_speed_kmh(self, speed_kmh: float) -> float | None:
+                return 999.0 if speed_kmh > 0 else None
+
+        monkeypatch.setattr(
+            "vibesensor.use_cases.run.sample_speed_context.order_reference_spec_from_snapshot",
+            lambda snapshot: _FakeSpec(),
+        )
+
+        context = resolve_speed_context(
+            gps_speed_mps=12.0,
+            resolved_speed_mps=12.0,
+            resolved_speed_source="obd2",
+            analysis_settings_snapshot=_analysis_settings_snapshot(),
+            measured_engine_rpm=3210.0,
+            measured_engine_rpm_source="obd2_pid",
+        )
+
+        assert context.speed_kmh == pytest.approx(43.2)
+        assert context.engine_rpm == 3210.0
+        assert context.engine_rpm_source == "obd2_pid"
+
     def test_manual_override(self) -> None:
         logger, gps_mock = _make_run_recorder()
         gps_mock.override_speed_mps = 20.0

--- a/apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py
@@ -89,6 +89,11 @@ def test_validate_bundle_succeeds(tmp_path: Path) -> None:
 
     assert len(manifest.environments) == 1
     assert manifest.environments[0].name == "m5stack_atom"
+    assert [(segment.file, segment.offset) for segment in manifest.environments[0].segments] == [
+        ("m5stack_atom/firmware.bin", "0x10000"),
+        ("m5stack_atom/bootloader.bin", "0x1000"),
+        ("m5stack_atom/partitions.bin", "0x8000"),
+    ]
 
 
 def test_validate_bundle_fails_missing_manifest(tmp_path: Path) -> None:

--- a/apps/server/tests/use_cases/updates/test_restart_scheduler.py
+++ b/apps/server/tests/use_cases/updates/test_restart_scheduler.py
@@ -25,6 +25,15 @@ async def test_schedule_uses_systemd_run_when_available(tmp_path) -> None:
 
     assert await scheduler.schedule() is True
     commands.run.assert_awaited_once()
+    assert commands.run.await_args.args[0] == [
+        "systemd-run",
+        "--unit",
+        "vibesensor-post-update-restart",
+        "--on-active=2s",
+        "systemctl",
+        "restart",
+        "vibesensor.service",
+    ]
 
 
 @pytest.mark.asyncio
@@ -46,3 +55,15 @@ async def test_schedule_falls_back_to_direct_systemctl_restart(tmp_path) -> None
 
     assert await scheduler.schedule() is True
     assert commands.run.await_count == 2
+    assert [call.args[0] for call in commands.run.await_args_list] == [
+        [
+            "systemd-run",
+            "--unit",
+            "vibesensor-post-update-restart",
+            "--on-active=2s",
+            "systemctl",
+            "restart",
+            "vibesensor.service",
+        ],
+        ["systemctl", "restart", "vibesensor.service"],
+    ]

--- a/apps/server/tests/use_cases/updates/test_update_manager_models.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_models.py
@@ -53,11 +53,15 @@ class TestUpdateJobStatus:
         data = update_status_to_builtins(status)
         assert data["state"] == "failed"
         assert data["ssid"] == "TestNet"
-        assert len(data["issues"]) == 1
+        assert data["issues"] == [
+            {"phase": "installing", "message": "Install failed", "detail": "rc=1"},
+        ]
 
     def test_log_tail_truncated(self) -> None:
         status = UpdateJobStatus(log_tail=[f"line {i}" for i in range(100)])
-        assert len(update_status_to_builtins(status)["log_tail"]) == 50
+        assert update_status_to_builtins(status)["log_tail"] == [
+            f"line {i}" for i in range(50, 100)
+        ]
 
 
 class TestUpdaterInterpreterSelection:

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_diagnostics.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_diagnostics.py
@@ -19,7 +19,9 @@ class TestParseWifiDiagnostics:
         log_dir = _wifi_log_dir(tmp_path)
         (log_dir / "summary.txt").write_text("status=FAILED\nrc=22\n")
         issues = parse_wifi_diagnostics(str(log_dir))
-        assert any("failure" in issue.message.lower() for issue in issues)
+        assert [(issue.phase, issue.message, issue.detail) for issue in issues] == [
+            ("diagnostics", "Hotspot summary reports failure", "status=FAILED"),
+        ]
 
     def test_summary_timeout_case_insensitive(self, tmp_path) -> None:
         log_dir = _wifi_log_dir(tmp_path)
@@ -40,9 +42,9 @@ class TestParseWifiDiagnostics:
             "2024-01-01 INFO normaline\n2024-01-01 ERROR something failed\n2024-01-01 INFO ok\n",
         )
         issues = parse_wifi_diagnostics(str(log_dir))
-        assert any(
-            "error" in issue.detail.lower() or "failed" in issue.detail.lower() for issue in issues
-        )
+        assert [(issue.phase, issue.message, issue.detail) for issue in issues] == [
+            ("diagnostics", "Hotspot log issue", "2024-01-01 ERROR something failed"),
+        ]
 
     def test_password_not_leaked_in_diagnostics(self, tmp_path) -> None:
         log_dir = tmp_path / "wifi"


### PR DESCRIPTION
Batch 7.

Processed 100 files: #601-#700.
Changed 5 files.
PR size: small.

What changed:
- Added measured engine RPM precedence coverage in speed context tests.
- Asserted exact firmware bundle segment files and offsets.
- Asserted exact restart scheduler command sequences.
- Asserted exact update issue serialization and retained log tail.
- Asserted exact Wi-Fi diagnostics issue tuples.

Why:
- Existing tests were good overall. These five had weak count, broad any, or partial assertions that could miss regressions.

Validation run:
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/run/test_speed_context.py apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py apps/server/tests/use_cases/updates/test_restart_scheduler.py apps/server/tests/use_cases/updates/test_update_manager_models.py apps/server/tests/use_cases/updates/wifi/test_wifi_diagnostics.py` -> 37 passed.
- `make plan-validation`
- `make lint`
- `make typecheck-backend`

Files kept unchanged:
- Backend run/update tests with already specific behavior and failure-path coverage.
- Docker E2E tests kept as full-stack coverage.
- UI Vitest specs kept because assertions already targeted behavior.
- Helper/support modules and product modules discovered by naming convention marked out of scope locally.

Risks and edge cases:
- Test-only change.
- No product behavior changed.
- Assertions are stricter but match current intended contracts.

Follow-ups:
- Continue with batch 8 after this PR merges.